### PR TITLE
Add a plugin to the instruction-plan package to send as a single transaction

### DIFF
--- a/examples/transfer-lamports/src/index.ts
+++ b/examples/transfer-lamports/src/index.ts
@@ -18,7 +18,7 @@ const client = await createDefaultLocalhostRpcClient();
 const destinationAccountAddress = (await generateKeyPairSigner()).address;
 
 try {
-    const result = await client.send(
+    const result = await client.sendTransaction(
         getTransferSolInstruction({
             amount: lamports(10_000_000n),
             // 0.01 SOL
@@ -28,19 +28,17 @@ try {
         }),
     );
 
-    const summary = summarizeTransactionPlanResult(result);
-    if (summary.successful) {
-        const [transaction] = summary.successfulTransactions;
-        const { signature } = transaction.status;
+    if (result.kind === 'successful') {
+        const { signature } = result;
         console.log(
             `Transaction successful! https://explorer.solana.com/tx/${signature}?cluster=custom&customUrl=http%3A%2F%2F127.0.0.1%3A8899}`,
         );
     } else {
-        if (summary.canceledTransactions.length > 0) {
+        if (result.kind === 'canceled') {
             console.log('Transaction was cancelled');
         } else {
             console.log('Transaction failed');
-            throw summary.failedTransactions[0].status.error;
+            throw result.error;
         }
     }
 } catch (e) {

--- a/packages/kit-plugins/src/defaults.ts
+++ b/packages/kit-plugins/src/defaults.ts
@@ -10,6 +10,7 @@ import {
     defaultTransactionPlannerAndExecutorFromLitesvm,
     defaultTransactionPlannerAndExecutorFromRpc,
     sendInstructionPlans,
+    sendTransaction,
 } from '@solana/kit-plugin-instruction-plan';
 import { litesvm } from '@solana/kit-plugin-litesvm';
 import { generatedPayerWithSol, payer } from '@solana/kit-plugin-payer';
@@ -49,7 +50,8 @@ export function createDefaultRpcClient<TClusterUrl extends ClusterUrl>(config: {
         .use(rpc<TClusterUrl>(config.url, config.rpcSubscriptionsConfig))
         .use(payer(config.payer))
         .use(defaultTransactionPlannerAndExecutorFromRpc())
-        .use(sendInstructionPlans());
+        .use(sendInstructionPlans())
+        .use(sendTransaction());
 }
 
 /**
@@ -90,7 +92,8 @@ export function createDefaultLocalhostRpcClient(config: { payer?: TransactionSig
         .use(airdrop())
         .use(payerOrGeneratedPayer(config.payer))
         .use(defaultTransactionPlannerAndExecutorFromRpc())
-        .use(sendInstructionPlans());
+        .use(sendInstructionPlans())
+        .use(sendTransaction());
 }
 
 /**
@@ -135,7 +138,8 @@ export function createDefaultLiteSVMClient(config: { payer?: TransactionSigner }
         .use(airdrop())
         .use(payerOrGeneratedPayer(config.payer))
         .use(defaultTransactionPlannerAndExecutorFromLitesvm())
-        .use(sendInstructionPlans());
+        .use(sendInstructionPlans())
+        .use(sendTransaction());
 }
 
 /**


### PR DESCRIPTION
This PR adds a new `sendTransaction` plugin to the instruction-plans package. This uses the same internals as `send`, but errors if the planned `TransactionPlan` is not a single transaction message. It then unpacks the single transaction plan result and returns just a `TransactionPlanResultStatus`.

This makes the result much easier for consumers to handle, as they don't need to consider results of multiple transactions.

I've updated the example from this PR stack to demonstrate this simplification

Draft, TODOs:

- Need to figure out what errors from kit-plugins should look like. Should we just reserve some space in the kit package, since that uses `@solana/errors`? It could be confusing to have errors across multiple packages, though that's also inevitable with other packages. It's also quite complex to replicate `@solana/errors`
    - Also note that `SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT` is in Kit, but only thrown by compute-budget
- If we have asserted that a `TransactionPlan` has `kind === "single"`, then can we update the types in Kit to return a `TransactionPlanResult` with the kind known to be `single`? If so this can be simplified a bit. Related Kit issue: https://github.com/anza-xyz/kit/issues/1209