### PR TITLE
Allow custom RPC configuration in localhost client

### DIFF
--- a/packages/kit-plugin-rpc/src/index.ts
+++ b/packages/kit-plugin-rpc/src/index.ts
@@ -65,6 +65,6 @@ export function rpc<TClusterUrl extends ClusterUrl>(
  *
  * @see {@link rpc}
  */
-export function localhostRpc() {
-    return rpc('http://127.0.0.1:8899', { url: 'ws://127.0.0.1:8900' });
+export function localhostRpc(url?: string, rpcSubscriptionsConfig?: { url: string }) {
+    return rpc(url ?? 'http://127.0.0.1:8899', rpcSubscriptionsConfig ?? { url: 'ws://127.0.0.1:8900' });
 }

--- a/packages/kit-plugins/src/defaults.ts
+++ b/packages/kit-plugins/src/defaults.ts
@@ -84,9 +84,11 @@ export function createDefaultRpcClient<TClusterUrl extends ClusterUrl>(config: {
  * const client = await createDefaultLocalhostRpcClient({ payer: customPayer });
  * ```
  */
-export function createDefaultLocalhostRpcClient(config: { payer?: TransactionSigner } = {}) {
+export function createDefaultLocalhostRpcClient(
+    config: { payer?: TransactionSigner; rpcSubscriptionsConfig?: { url: string }; url?: string } = {},
+) {
     return createEmptyClient()
-        .use(localhostRpc())
+        .use(localhostRpc(config.url, config.rpcSubscriptionsConfig))
         .use(airdrop())
         .use(payerOrGeneratedPayer(config.payer))
         .use(defaultTransactionPlannerAndExecutorFromRpc())

--- a/packages/kit-plugins/test/defaults.test.ts
+++ b/packages/kit-plugins/test/defaults.test.ts
@@ -156,6 +156,17 @@ describe('createDefaultLocalhostRpcClient', () => {
         expect(client.sendTransactions).toBeTypeOf('function');
         expect(client.sendTransaction).toBeTypeOf('function');
     });
+
+    it('it uses a custom url and subscriptions url', async () => {
+        const airdropFn = vi.fn().mockResolvedValue('MockSignature');
+        (airdropFactory as Mock).mockReturnValueOnce(airdropFn);
+
+        const client = await createDefaultLocalhostRpcClient({
+            rpcSubscriptionsConfig: { url: 'ws://host.docker.internal:8900' },
+            url: 'http://host.docker.internal:8899',
+        });
+        expect(client.airdrop).toBeTypeOf('function');
+    });
 });
 
 describe('createDefaultLiteSVMClient', () => {


### PR DESCRIPTION
This PR enables connecting the default localhost rpc client to a custom rpc and websocket url by exposing a new optional property `rpc`.

This is useful for connecting the client to a test validator running in a container [like this](https://github.com/beeman/testcontainers).

