### PR TITLE
feat(litesvm): add transaction result assertions and type guards

### DIFF
--- a/packages/kit-plugin-litesvm/src/assertions.ts
+++ b/packages/kit-plugin-litesvm/src/assertions.ts
@@ -1,0 +1,125 @@
+import type { FailedTransactionMetadata, TransactionMetadata } from '@loris-sandbox/litesvm-kit';
+import { SimulatedTransactionInfo } from '@loris-sandbox/litesvm-kit';
+
+export type { FailedTransactionMetadata, TransactionMetadata } from '@loris-sandbox/litesvm-kit';
+export { SimulatedTransactionInfo } from '@loris-sandbox/litesvm-kit';
+
+/** Result from `sendTransaction`. */
+export type SendTransactionResult = FailedTransactionMetadata | TransactionMetadata;
+
+/** Result from `airdrop` or `getTransaction` (can be `null`). */
+export type TransactionResult = FailedTransactionMetadata | TransactionMetadata | null;
+
+/** Result from `simulateTransaction`. */
+export type SimulationResult = FailedTransactionMetadata | SimulatedTransactionInfo;
+
+/**
+ * Checks if a transaction result is successful (`TransactionMetadata`).
+ *
+ * @example
+ * ```ts
+ * const result = client.svm.sendTransaction(tx);
+ * if (isSuccessfulTransaction(result)) {
+ *     console.log(result.computeUnitsConsumed());
+ * }
+ * ```
+ */
+export function isSuccessfulTransaction(
+    result: SendTransactionResult | TransactionResult,
+): result is TransactionMetadata {
+    return result !== null && !('err' in result);
+}
+
+/**
+ * Checks if a transaction result is a failure (`FailedTransactionMetadata`).
+ *
+ * @example
+ * ```ts
+ * const result = client.svm.sendTransaction(tx);
+ * if (isFailedTransaction(result)) {
+ *     console.error(result.err());
+ * }
+ * ```
+ */
+export function isFailedTransaction(
+    result: SendTransactionResult | SimulationResult | TransactionResult,
+): result is FailedTransactionMetadata {
+    return result !== null && 'err' in result;
+}
+
+/**
+ * Asserts that a transaction result is successful (`TransactionMetadata`).
+ * Throws if the result is `null` or a `FailedTransactionMetadata`.
+ *
+ * @example
+ * ```ts
+ * const result = client.svm.airdrop(address, lamports);
+ * assertIsSuccessfulTransaction(result);
+ * console.log(result.computeUnitsConsumed()); // result is TransactionMetadata
+ * ```
+ */
+export function assertIsSuccessfulTransaction(
+    result: SendTransactionResult | TransactionResult,
+): asserts result is TransactionMetadata {
+    if (result === null) {
+        throw new Error('Expected successful transaction but got null');
+    }
+    if ('err' in result) {
+        throw new Error(`Transaction failed: ${String(result.err())}`);
+    }
+}
+
+/**
+ * Asserts that a transaction result is a failure (`FailedTransactionMetadata`).
+ * Throws if the result is `null` or successful. Useful for testing expected failures.
+ *
+ * @example
+ * ```ts
+ * const result = client.svm.sendTransaction(badTx);
+ * assertIsFailedTransaction(result);
+ * expect(result.err().toString()).toContain('InsufficientFunds');
+ * ```
+ */
+export function assertIsFailedTransaction(
+    result: SendTransactionResult | SimulationResult | TransactionResult,
+): asserts result is FailedTransactionMetadata {
+    if (result === null) {
+        throw new Error('Expected failed transaction but got null');
+    }
+    if (!('err' in result)) {
+        throw new Error('Expected failed transaction but got successful result');
+    }
+}
+
+/**
+ * Checks if a simulation result is successful (`SimulatedTransactionInfo`).
+ *
+ * @example
+ * ```ts
+ * const result = client.svm.simulateTransaction(tx);
+ * if (isSuccessfulSimulation(result)) {
+ *     console.log(result.meta().computeUnitsConsumed());
+ *     console.log(result.postAccounts());
+ * }
+ * ```
+ */
+export function isSuccessfulSimulation(result: SimulationResult): result is SimulatedTransactionInfo {
+    return !('err' in result);
+}
+
+/**
+ * Asserts that a simulation result is successful (`SimulatedTransactionInfo`).
+ * Throws if the result is a `FailedTransactionMetadata`.
+ *
+ * @example
+ * ```ts
+ * const result = client.svm.simulateTransaction(tx);
+ * assertIsSuccessfulSimulation(result);
+ * console.log(result.meta().computeUnitsConsumed()); // result is SimulatedTransactionInfo
+ * ```
+ */
+export function assertIsSuccessfulSimulation(result: SimulationResult): asserts result is SimulatedTransactionInfo {
+    if ('err' in result) {
+        throw new Error(`Simulation failed: ${String(result.err())}`);
+    }
+}

--- a/packages/kit-plugin-litesvm/src/index.ts
+++ b/packages/kit-plugin-litesvm/src/index.ts
@@ -1,4 +1,22 @@
 import { LiteSVM } from '@loris-sandbox/litesvm-kit';
+
+// Transaction result assertions and type guards
+export {
+    assertIsFailedTransaction,
+    assertIsSuccessfulSimulation,
+    assertIsSuccessfulTransaction,
+    isFailedTransaction,
+    isSuccessfulSimulation,
+    isSuccessfulTransaction,
+} from './assertions';
+export type {
+    FailedTransactionMetadata,
+    SendTransactionResult,
+    SimulatedTransactionInfo,
+    SimulationResult,
+    TransactionMetadata,
+    TransactionResult,
+} from './assertions';
 import {
     AccountInfoBase,
     AccountInfoWithBase64EncodedData,

--- a/packages/kit-plugin-litesvm/test/assertions.test.ts
+++ b/packages/kit-plugin-litesvm/test/assertions.test.ts
@@ -1,0 +1,77 @@
+import { createEmptyClient, generateKeyPairSigner, lamports } from '@solana/kit';
+import { describe, expect, it } from 'vitest';
+
+import {
+    assertIsFailedTransaction,
+    assertIsSuccessfulSimulation,
+    assertIsSuccessfulTransaction,
+    isFailedTransaction,
+    isSuccessfulSimulation,
+    isSuccessfulTransaction,
+    litesvm,
+    type SimulationResult,
+    type TransactionResult,
+} from '../src';
+
+describe('Transaction Assertions', () => {
+    it('type guards correctly identify transaction results', () => {
+        const success = { computeUnitsConsumed: () => 1000n } as unknown as TransactionResult;
+        const failure = { err: () => 'InsufficientFunds' } as unknown as TransactionResult;
+
+        expect(isSuccessfulTransaction(success)).toBe(true);
+        expect(isSuccessfulTransaction(failure)).toBe(false);
+        expect(isSuccessfulTransaction(null)).toBe(false);
+
+        expect(isFailedTransaction(failure)).toBe(true);
+        expect(isFailedTransaction(success)).toBe(false);
+        expect(isFailedTransaction(null)).toBe(false);
+    });
+
+    it('type guards correctly identify simulation results', () => {
+        const success = { meta: () => ({}), postAccounts: () => [] } as unknown as SimulationResult;
+        const failure = { err: () => 'SimulationError' } as unknown as SimulationResult;
+
+        expect(isSuccessfulSimulation(success)).toBe(true);
+        expect(isSuccessfulSimulation(failure)).toBe(false);
+    });
+
+    it('assertIsSuccessfulTransaction throws for failures and null', () => {
+        const failure = { err: () => ({ toString: () => 'InsufficientFunds' }) } as unknown as TransactionResult;
+
+        expect(() => assertIsSuccessfulTransaction(null)).toThrow('Expected successful transaction but got null');
+        expect(() => assertIsSuccessfulTransaction(failure)).toThrow('Transaction failed: InsufficientFunds');
+    });
+
+    it('assertIsFailedTransaction throws for successes and null', () => {
+        const success = { computeUnitsConsumed: () => 1000n } as unknown as TransactionResult;
+
+        expect(() => assertIsFailedTransaction(null)).toThrow('Expected failed transaction but got null');
+        expect(() => assertIsFailedTransaction(success)).toThrow(
+            'Expected failed transaction but got successful result',
+        );
+    });
+
+    it('assertIsSuccessfulSimulation throws for failures', () => {
+        const failure = { err: () => ({ toString: () => 'SimulationError' }) } as unknown as SimulationResult;
+
+        expect(() => assertIsSuccessfulSimulation(failure)).toThrow('Simulation failed: SimulationError');
+    });
+
+    it('works with real airdrop results', async () => {
+        const client = createEmptyClient().use(litesvm());
+        const recipient = await generateKeyPairSigner();
+
+        const result = client.svm.airdrop(recipient.address, lamports(1_000_000_000n));
+
+        expect(isSuccessfulTransaction(result)).toBe(true);
+        assertIsSuccessfulTransaction(result);
+    });
+
+    it('handles null transaction results', () => {
+        const nullResult: TransactionResult = null;
+
+        expect(isSuccessfulTransaction(nullResult)).toBe(false);
+        expect(isFailedTransaction(nullResult)).toBe(false);
+        expect(() => assertIsSuccessfulTransaction(nullResult)).toThrow();
+    });
+});


### PR DESCRIPTION
## Summary of Changes
Add utility functions for type-safe handling of LiteSVM transaction results including:
- Type guards: `isSuccessfulTransaction`, `isFailedTransaction`,` isSuccessfulSimulation`
- Assertions: `assertIsSuccessfulTransaction`, `assertIsFailedTransaction`, `assertIsSuccessfulSimulation`
- Type definitions: `SendTransactionResult`, `TransactionResult`, `SimulationResult`
- Unit tests

## Problem Solved
LiteSVM transaction methods (`sendTransaction`, `airdrop`, `simulateTransaction`, `getTransaction`) return union types that can be successful results, failures, or `null`. Without type guards, developers must write repetitive boilerplate to safely narrow these types before accessing result-specific methods like `computeUnitsConsumed()` or `err()`.  

Alternatively, this could go into LiteSVM sdk directly and reexported here, but I feel ammending your litesvm pr could risk slowing down that merge. WDYT @lorisleiva?