### PR TITLE
Bump Kit peer dependency

### DIFF
--- a/.changeset/sharp-bikes-run.md
+++ b/.changeset/sharp-bikes-run.md
@@ -1,0 +1,10 @@
+---
+'@solana/kit-plugin-instruction-plan': minor
+'@solana/kit-plugin-airdrop': minor
+'@solana/kit-plugin-litesvm': minor
+'@solana/kit-plugin-payer': minor
+'@solana/kit-plugin-rpc': minor
+'@solana/kit-plugins': minor
+---
+
+Bump @solana/kit version requirement

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "@changesets/changelog-github": "^0.5.2",
         "@changesets/cli": "^2.29.8",
         "@solana/eslint-config-solana": "^6.0.0",
-        "@solana/kit": "^5.5.0",
+        "@solana/kit": "^5.5.1",
         "@solana/prettier-config-solana": "0.0.6",
         "@types/node": "^25",
         "agadoo": "^3.0.0",

--- a/packages/kit-plugin-airdrop/package.json
+++ b/packages/kit-plugin-airdrop/package.json
@@ -45,7 +45,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^5.2.0"
+        "@solana/kit": "^5.5.1"
     },
     "devDependencies": {
         "@solana/kit-plugin-litesvm": "workspace:*",

--- a/packages/kit-plugin-instruction-plan/package.json
+++ b/packages/kit-plugin-instruction-plan/package.json
@@ -46,7 +46,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^5.2.0"
+        "@solana/kit": "^5.5.1"
     },
     "devDependencies": {
         "@solana/kit-plugin-litesvm": "workspace:*",

--- a/packages/kit-plugin-litesvm/package.json
+++ b/packages/kit-plugin-litesvm/package.json
@@ -45,7 +45,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^5.2.0"
+        "@solana/kit": "^5.5.1"
     },
     "dependencies": {
         "@loris-sandbox/litesvm-kit": "^0.5.0"

--- a/packages/kit-plugin-payer/package.json
+++ b/packages/kit-plugin-payer/package.json
@@ -46,7 +46,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^5.2.0"
+        "@solana/kit": "^5.5.1"
     },
     "dependencies": {
         "@solana/kit-plugin-airdrop": "workspace:*"

--- a/packages/kit-plugin-rpc/package.json
+++ b/packages/kit-plugin-rpc/package.json
@@ -45,7 +45,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^5.2.0"
+        "@solana/kit": "^5.5.1"
     },
     "license": "MIT",
     "repository": {

--- a/packages/kit-plugins/package.json
+++ b/packages/kit-plugins/package.json
@@ -47,7 +47,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^5.2.0"
+        "@solana/kit": "^5.5.1"
     },
     "dependencies": {
         "@solana/kit-plugin-airdrop": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@solana/kit': ^5.5.0
+  '@solana/kit': ^5.5.1
 
 importers:
 
@@ -21,8 +21,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(@eslint/js@9.39.2)(@types/eslint@9.6.1)(@types/eslint__js@9.14.0)(eslint-plugin-jest@29.5.0(@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(jest@30.2.0(@types/node@25.0.10))(typescript@5.9.3))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.2))(eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.2))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(globals@14.0.0)(jest@30.2.0(@types/node@25.0.10))(typescript-eslint@8.50.0(eslint@9.39.2)(typescript@5.9.3))(typescript@5.9.3)
       '@solana/kit':
-        specifier: ^5.5.0
-        version: 5.5.0(typescript@5.9.3)
+        specifier: ^5.5.1
+        version: 5.5.1(typescript@5.9.3)
       '@solana/prettier-config-solana':
         specifier: 0.0.6
         version: 0.0.6(prettier@3.8.1)
@@ -66,8 +66,8 @@ importers:
   packages/kit-plugin-airdrop:
     dependencies:
       '@solana/kit':
-        specifier: ^5.5.0
-        version: 5.5.0(typescript@5.9.3)
+        specifier: ^5.5.1
+        version: 5.5.1(typescript@5.9.3)
     devDependencies:
       '@solana/kit-plugin-litesvm':
         specifier: workspace:*
@@ -80,10 +80,10 @@ importers:
     dependencies:
       '@solana-program/compute-budget':
         specifier: ^0.12.0
-        version: 0.12.0(@solana/kit@5.5.0(typescript@5.9.3))
+        version: 0.12.0(@solana/kit@5.5.1(typescript@5.9.3))
       '@solana/kit':
-        specifier: ^5.5.0
-        version: 5.5.0(typescript@5.9.3)
+        specifier: ^5.5.1
+        version: 5.5.1(typescript@5.9.3)
     devDependencies:
       '@solana/kit-plugin-litesvm':
         specifier: workspace:*
@@ -98,14 +98,14 @@ importers:
         specifier: ^0.5.0
         version: 0.5.0(typescript@5.9.3)
       '@solana/kit':
-        specifier: ^5.5.0
-        version: 5.5.0(typescript@5.9.3)
+        specifier: ^5.5.1
+        version: 5.5.1(typescript@5.9.3)
 
   packages/kit-plugin-payer:
     dependencies:
       '@solana/kit':
-        specifier: ^5.5.0
-        version: 5.5.0(typescript@5.9.3)
+        specifier: ^5.5.1
+        version: 5.5.1(typescript@5.9.3)
       '@solana/kit-plugin-airdrop':
         specifier: workspace:*
         version: link:../kit-plugin-airdrop
@@ -113,14 +113,14 @@ importers:
   packages/kit-plugin-rpc:
     dependencies:
       '@solana/kit':
-        specifier: ^5.5.0
-        version: 5.5.0(typescript@5.9.3)
+        specifier: ^5.5.1
+        version: 5.5.1(typescript@5.9.3)
 
   packages/kit-plugins:
     dependencies:
       '@solana/kit':
-        specifier: ^5.5.0
-        version: 5.5.0(typescript@5.9.3)
+        specifier: ^5.5.1
+        version: 5.5.1(typescript@5.9.3)
       '@solana/kit-plugin-airdrop':
         specifier: workspace:*
         version: link:../kit-plugin-airdrop
@@ -1046,20 +1046,20 @@ packages:
   '@solana-program/compute-budget@0.12.0':
     resolution: {integrity: sha512-ysHNVfctUyuY9+mHzJqt97en9ly2quR4n1pvJMQjYf4olwoCqB7+E9b+XZmlj91lFQuAs5z48aw5qDekg78DbQ==}
     peerDependencies:
-      '@solana/kit': ^5.5.0
+      '@solana/kit': ^5.5.1
 
   '@solana-program/system@0.10.0':
     resolution: {integrity: sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==}
     peerDependencies:
-      '@solana/kit': ^5.5.0
+      '@solana/kit': ^5.5.1
 
   '@solana-program/token@0.9.0':
     resolution: {integrity: sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==}
     peerDependencies:
-      '@solana/kit': ^5.5.0
+      '@solana/kit': ^5.5.1
 
-  '@solana/accounts@5.5.0':
-    resolution: {integrity: sha512-doojuLD2d4GkHqe3m+1ejtZnaO16dzZW0k/xuACZ/cDhVE+ocFMfKFaks+HIBk0tKWXKIRCEfTPRFcMuTE8GYQ==}
+  '@solana/accounts@5.5.1':
+    resolution: {integrity: sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1067,8 +1067,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/addresses@5.5.0':
-    resolution: {integrity: sha512-RX3iivQJGzdBB9Rl2DHub0NiAvwuqtTlHSfCrH1+hQsBfOEqvVFtH/Ypipih6qaC/9MHIDnNAIb75GHklGjwXg==}
+  '@solana/addresses@5.5.1':
+    resolution: {integrity: sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1076,8 +1076,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/assertions@5.5.0':
-    resolution: {integrity: sha512-BDVgEM5HonJFPNIYZbr4AM9TBJBRy789HKGfCPxWLZm9wjNFcjhFpSfGFLWg9W+WjsMvM60GxgMKfAVl+y67Ug==}
+  '@solana/assertions@5.5.1':
+    resolution: {integrity: sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1085,8 +1085,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-core@5.5.0':
-    resolution: {integrity: sha512-ehjH9i8EwulGVMXzJ1+mcSx2P0Kj0HgYrLLOcku6tPa6ms2M+MNyls7yg8iLhltn+30x1DSp6XuPoeWuqnZTLA==}
+  '@solana/codecs-core@5.5.1':
+    resolution: {integrity: sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1094,8 +1094,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-data-structures@5.5.0':
-    resolution: {integrity: sha512-NZUU+SlVMuIg2oCi8VyRiPGtPer8sN1fcLWd/ks7Q5g8V8fOHcV2moWDW10FZJxnZWOaR/4k5DuYzdyGfjXYNg==}
+  '@solana/codecs-data-structures@5.5.1':
+    resolution: {integrity: sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1103,8 +1103,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-numbers@5.5.0':
-    resolution: {integrity: sha512-JX/GdKzVtNdWxAlrbTIv72BD6+KjyRt4alup0RJ1K87JJvYoJ6649xYP8+SHBuSewIq+248ftihTqRjbUr4fvg==}
+  '@solana/codecs-numbers@5.5.1':
+    resolution: {integrity: sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1112,8 +1112,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-strings@5.5.0':
-    resolution: {integrity: sha512-bAfTJys0P8gss3sNanC1/WX70jeuZYVsAyGGX/KluALtRLtN0y7uTLR74I8uygpMkFUAeLdmjogwzKnnNiDfQw==}
+  '@solana/codecs-strings@5.5.1':
+    resolution: {integrity: sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
@@ -1124,8 +1124,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs@5.5.0':
-    resolution: {integrity: sha512-emJrjDkjiLzYypWuJrrxO6jQUN/Hmwg3fw2o1BmPz3EUUty3iSgm3xIA7qpyvObEt1oueQEI9Y4nZea7B+NoKA==}
+  '@solana/codecs@5.5.1':
+    resolution: {integrity: sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1133,8 +1133,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/errors@5.5.0':
-    resolution: {integrity: sha512-9/HHQNf0Y1QyxIvGJvo98SJYAEV8FowaR2k6mqHE60h8JVKslOn7vWKYaue4tj0s7evf8wNUKbi/tao/gUoHUA==}
+  '@solana/errors@5.5.1':
+    resolution: {integrity: sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
@@ -1160,8 +1160,8 @@ packages:
       typescript: ^5.9.3
       typescript-eslint: ^8.49.0
 
-  '@solana/fast-stable-stringify@5.5.0':
-    resolution: {integrity: sha512-sIk9UBRAvL1VOt5ZyFiTGrdSCV5aDl+BhQtQflWS4nwBydtXl5byt9txJaRxwbSGkedSQO3yeyuq9LFtfxn7vg==}
+  '@solana/fast-stable-stringify@5.5.1':
+    resolution: {integrity: sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1169,8 +1169,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/functional@5.5.0':
-    resolution: {integrity: sha512-ma/yCpmRyU05R9F/IvtKDOx3lPL3jDjdoQajFqU7oZeXNQooKjpOJo3a/VDRQy/KZhk/AFSyUOOrCMiOtH3r3g==}
+  '@solana/functional@5.5.1':
+    resolution: {integrity: sha512-tTHoJcEQq3gQx5qsdsDJ0LEJeFzwNpXD80xApW9o/PPoCNimI3SALkZl+zNW8VnxRrV3l3yYvfHWBKe/X3WG3w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1178,8 +1178,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/instruction-plans@5.5.0':
-    resolution: {integrity: sha512-cGqxdLNB2DO5So1uHw9872zVkD6J/ByjCadqtnNQ0na3voN158Jia2lOcxHneDMSgpr2kfMAe0membj9zxZwTg==}
+  '@solana/instruction-plans@5.5.1':
+    resolution: {integrity: sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1187,8 +1187,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/instructions@5.5.0':
-    resolution: {integrity: sha512-YEcZC43A0hoRFpMaI//EkddhhtjI2RSaHxJHykHpiJ4b4X9WyJ+V/cq7Qna94wtrXKSo9J1y0YuZdB+6Covttw==}
+  '@solana/instructions@5.5.1':
+    resolution: {integrity: sha512-h0G1CG6S+gUUSt0eo6rOtsaXRBwCq1+Js2a+Ps9Bzk9q7YHNFA75/X0NWugWLgC92waRp66hrjMTiYYnLBoWOQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1196,8 +1196,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/keys@5.5.0':
-    resolution: {integrity: sha512-P24pLS37xwigqJFH8s+EiSY6+mLs+3/BFgFP8oB2mWExLbD2IWPBa2NINYCkirePJJYKi40V2FLSUVFiziPN5A==}
+  '@solana/keys@5.5.1':
+    resolution: {integrity: sha512-KRD61cL7CRL+b4r/eB9dEoVxIf/2EJ1Pm1DmRYhtSUAJD2dJ5Xw8QFuehobOGm9URqQ7gaQl+Fkc1qvDlsWqKg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1205,8 +1205,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/kit@5.5.0':
-    resolution: {integrity: sha512-0jM3Ki3nCp+KuqB1L36327bVwFIQwIkQOGhRebhTzVIgWrgMdlBROSFmhiLAr0vDdNNUA4/FD8e0LJPkZAoL2Q==}
+  '@solana/kit@5.5.1':
+    resolution: {integrity: sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1214,8 +1214,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/nominal-types@5.5.0':
-    resolution: {integrity: sha512-PpAVh+D976Gg4Pvq6EWbL6AYI8SDyi+AkCQw9K+If2TEQ3VM+QKVfeHdVg5clcoQnWPtUJ5v5x2licTzvMtBTw==}
+  '@solana/nominal-types@5.5.1':
+    resolution: {integrity: sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1223,8 +1223,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/offchain-messages@5.5.0':
-    resolution: {integrity: sha512-rCM2V4UG6lpI+K9bHLWJY9dQSQSX5S1c6pegDXt8EUyhmHXeoPtlwuikRX3JZXC0i0QmexK+IAJPV2IsGteSbQ==}
+  '@solana/offchain-messages@5.5.1':
+    resolution: {integrity: sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1232,8 +1232,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/options@5.5.0':
-    resolution: {integrity: sha512-y6/AofplBpAcCXzZl7vHpQQPoF43qWpgLfHjvinuloN1jfePHdl+KsYNJAV1Al+XrAOgr+WIx/xvKFNcCVkSqg==}
+  '@solana/options@5.5.1':
+    resolution: {integrity: sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1241,8 +1241,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/plugin-core@5.5.0':
-    resolution: {integrity: sha512-TsKTzHTwxUPOxuq1TiQ3IBWmiinzhRsdtVN+paZPNjt2DdTjNYwDBl9KzHuTGGRZtptf5iJ2xghbPjcCYw8fqw==}
+  '@solana/plugin-core@5.5.1':
+    resolution: {integrity: sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1255,8 +1255,8 @@ packages:
     peerDependencies:
       prettier: ^3.7.4
 
-  '@solana/programs@5.5.0':
-    resolution: {integrity: sha512-7jNPrEE9pQyQBxE5+hTsOkViTsJ63dOjtdrSWDvmGvx/mIyEYm2WqsySpFH7qKbUvW1KXC+qxN2vZiicpCqWOg==}
+  '@solana/programs@5.5.1':
+    resolution: {integrity: sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1264,8 +1264,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/promises@5.5.0':
-    resolution: {integrity: sha512-DGMPznCYVGVUWy5LsYlV5fOdnrRAjHhpofWjHCVLG8Ttnq653b7Gdr8yRSgqhXv88QiAwz8gaFE27rL3CWFvNA==}
+  '@solana/promises@5.5.1':
+    resolution: {integrity: sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1273,8 +1273,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-api@5.5.0':
-    resolution: {integrity: sha512-cS/b4fL0IM5BwXsKX9MhS7kVXrE+vo+nFGZpVlq2FZrxdLKyJjlpRzWg/NnMfGSqtj9m94Y8vI6gh8pLvWJL+A==}
+  '@solana/rpc-api@5.5.1':
+    resolution: {integrity: sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1282,8 +1282,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-parsed-types@5.5.0':
-    resolution: {integrity: sha512-paVFiOLcyngTQ1mxzF5e13f3+EjWQsJ2ED4kuzEOR9rQgtBR6QsrKA1n85mHEF4dU46eAY9JSFK0JsCUe7tUMw==}
+  '@solana/rpc-parsed-types@5.5.1':
+    resolution: {integrity: sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1291,8 +1291,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-spec-types@5.5.0':
-    resolution: {integrity: sha512-rhHwxTUO10Pcdtuh8slfQEnP/VfzqNp4RYftGCM5hiSpZMjO6qcGMAQiWy5dRvdHQKZBV4CLEjdx3LCWhGvG9w==}
+  '@solana/rpc-spec-types@5.5.1':
+    resolution: {integrity: sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1300,8 +1300,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-spec@5.5.0':
-    resolution: {integrity: sha512-tM+Fnd1KMTomx1HmCpqyOUM14YAlNkR+HURJISR7Zc7V3V6Ck6RwlXgWGiTylUnpJWS47SkB3DpiVih27EoRXg==}
+  '@solana/rpc-spec@5.5.1':
+    resolution: {integrity: sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1309,8 +1309,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-api@5.5.0':
-    resolution: {integrity: sha512-YiaW8L4LNJH1QQHebBokX9zg0/l8TURFNrd6dYF4/WKYVoV4ftA/YrYUevkl7Bz3z5a0XgjWKS9X6EeJjI02Lw==}
+  '@solana/rpc-subscriptions-api@5.5.1':
+    resolution: {integrity: sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1318,8 +1318,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-channel-websocket@5.5.0':
-    resolution: {integrity: sha512-fvsbGyEFlyDizoUtm+MtQw77/MIzd/PAkFQGUpzX2flyIZt+TPFcQxW0SCPl/Wv2BsPWEhh6fTdj60hAOgiDfQ==}
+  '@solana/rpc-subscriptions-channel-websocket@5.5.1':
+    resolution: {integrity: sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1327,8 +1327,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-spec@5.5.0':
-    resolution: {integrity: sha512-z5tQj/+NTiOcJnpEUhg8cUsKmCdCe9Fk5ms2oPtUBGH6XwJN67+4+dRFMccpUccZ+FxsDGMVYbNJwfTe7QheVA==}
+  '@solana/rpc-subscriptions-spec@5.5.1':
+    resolution: {integrity: sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1336,8 +1336,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions@5.5.0':
-    resolution: {integrity: sha512-lmoWvUEQMPdi6FOMwv6icZGmlWH7ydhcck4b49X/YK2s22ClMoBa0MYwvFzOH+vm4adOHWzwwGW/4pS95RjQ1Q==}
+  '@solana/rpc-subscriptions@5.5.1':
+    resolution: {integrity: sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1345,8 +1345,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-transformers@5.5.0':
-    resolution: {integrity: sha512-g33shwjsfwyUBhbYIYxaYGfe+JF/4aCOpK5bK63Wr7POnht1E4EshK+xHTJ+PK7xSRUH99FtdIOsTG4GIlM+0A==}
+  '@solana/rpc-transformers@5.5.1':
+    resolution: {integrity: sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1354,8 +1354,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-transport-http@5.5.0':
-    resolution: {integrity: sha512-wcNsZ1MJsIkWdRCwLutAjLu2chJZ6HPsMcghiM3//YBJNGq3obz6OUhhQeM79Rp8ZRpNePO6C7iP4SMgRC98zA==}
+  '@solana/rpc-transport-http@5.5.1':
+    resolution: {integrity: sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1363,8 +1363,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-types@5.5.0':
-    resolution: {integrity: sha512-FBVkBA+nw2+DWT9hlR+T8JTBHM05ZKy6RWKXr78UU/UJj9oWQbsWCK65zKCSMPskWbsYlGncFABIgl5DRzCZww==}
+  '@solana/rpc-types@5.5.1':
+    resolution: {integrity: sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1372,8 +1372,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc@5.5.0':
-    resolution: {integrity: sha512-76rEsoP1ZC3M+BNhQnTlm8c8bP0rYYIoUhMk35j7oBIsAR0bl1WpkFK2dsIcbP+Yag9msHHqSvGaIPYDhNm4bQ==}
+  '@solana/rpc@5.5.1':
+    resolution: {integrity: sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1381,8 +1381,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/signers@5.5.0':
-    resolution: {integrity: sha512-Cs7RVTHdIapGxwWMyiN3serNU7QJJ3pLJmlCaAuNQn6aCi0zTZ6AhOKe7AsCbnFr4+ZBknbTwT0TvT4eSvDe3A==}
+  '@solana/signers@5.5.1':
+    resolution: {integrity: sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1390,8 +1390,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/subscribable@5.5.0':
-    resolution: {integrity: sha512-3MOIOiHJGjHhiw+1tR+61t/esUWTvctHtO6WGlXZ0a0UZmc0J2NZBU8zr4nC19KzDd40J8gtRPwCq48jon7MaQ==}
+  '@solana/subscribable@5.5.1':
+    resolution: {integrity: sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1399,8 +1399,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/sysvars@5.5.0':
-    resolution: {integrity: sha512-A+JkWgvoPnvTzZkfiMhekrvGxOCoQ4TmClJiMsWi+YwzBZ0unblXaA7etd/tFrrcZ19VWRUWKCC2gqlea5dXaQ==}
+  '@solana/sysvars@5.5.1':
+    resolution: {integrity: sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1408,8 +1408,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/transaction-confirmation@5.5.0':
-    resolution: {integrity: sha512-CmT5KDzXbXezcmoxWJ8fu6ZdxYlQ1t4wBKjMxnZqSOPyYikoPbWrsd6XXl7BRHEzJIN+Y06blBKliYtTjozlvQ==}
+  '@solana/transaction-confirmation@5.5.1':
+    resolution: {integrity: sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1417,8 +1417,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/transaction-messages@5.5.0':
-    resolution: {integrity: sha512-FQc4DSA0pyeWWmLHVo2Ip43mh7rpwlUBlKPx2bANVoxX4ypjOQ63heuUdHxqFeUFsuj9n2zeOAoUuh8AVb0hbQ==}
+  '@solana/transaction-messages@5.5.1':
+    resolution: {integrity: sha512-aXyhMCEaAp3M/4fP0akwBBQkFPr4pfwoC5CLDq999r/FUwDax2RE/h4Ic7h2Xk+JdcUwsb+rLq85Y52hq84XvQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1426,8 +1426,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/transactions@5.5.0':
-    resolution: {integrity: sha512-sdHdvEwjHwzX9nA9QJfQ2HDbeqEreo0pmjPPPxGcECDp8R02Py0y/zfPiU8JQyZcn7Si2UJUKJ2ds/sA8fXl9A==}
+  '@solana/transactions@5.5.1':
+    resolution: {integrity: sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -4194,9 +4194,9 @@ snapshots:
 
   '@loris-sandbox/litesvm-kit@0.5.0(typescript@5.9.3)':
     dependencies:
-      '@solana-program/system': 0.10.0(@solana/kit@5.5.0(typescript@5.9.3))
-      '@solana-program/token': 0.9.0(@solana/kit@5.5.0(typescript@5.9.3))
-      '@solana/kit': 5.5.0(typescript@5.9.3)
+      '@solana-program/system': 0.10.0(@solana/kit@5.5.1(typescript@5.9.3))
+      '@solana-program/token': 0.9.0(@solana/kit@5.5.1(typescript@5.9.3))
+      '@solana/kit': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       '@loris-sandbox/litesvm-kit-darwin-arm64': 0.5.0
       '@loris-sandbox/litesvm-kit-darwin-x64': 0.5.0
@@ -4405,91 +4405,91 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@solana-program/compute-budget@0.12.0(@solana/kit@5.5.0(typescript@5.9.3))':
+  '@solana-program/compute-budget@0.12.0(@solana/kit@5.5.1(typescript@5.9.3))':
     dependencies:
-      '@solana/kit': 5.5.0(typescript@5.9.3)
+      '@solana/kit': 5.5.1(typescript@5.9.3)
 
-  '@solana-program/system@0.10.0(@solana/kit@5.5.0(typescript@5.9.3))':
+  '@solana-program/system@0.10.0(@solana/kit@5.5.1(typescript@5.9.3))':
     dependencies:
-      '@solana/kit': 5.5.0(typescript@5.9.3)
+      '@solana/kit': 5.5.1(typescript@5.9.3)
 
-  '@solana-program/token@0.9.0(@solana/kit@5.5.0(typescript@5.9.3))':
+  '@solana-program/token@0.9.0(@solana/kit@5.5.1(typescript@5.9.3))':
     dependencies:
-      '@solana/kit': 5.5.0(typescript@5.9.3)
+      '@solana/kit': 5.5.1(typescript@5.9.3)
 
-  '@solana/accounts@5.5.0(typescript@5.9.3)':
+  '@solana/accounts@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-spec': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.0(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@5.5.0(typescript@5.9.3)':
+  '@solana/addresses@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/assertions': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/nominal-types': 5.5.0(typescript@5.9.3)
+      '@solana/assertions': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/assertions@5.5.0(typescript@5.9.3)':
+  '@solana/assertions@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.5.0(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-core@5.5.0(typescript@5.9.3)':
+  '@solana/codecs-core@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.5.0(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-data-structures@5.5.0(typescript@5.9.3)':
+  '@solana/codecs-data-structures@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-numbers@5.5.0(typescript@5.9.3)':
+  '@solana/codecs-numbers@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-strings@5.5.0(typescript@5.9.3)':
+  '@solana/codecs-strings@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs@5.5.0(typescript@5.9.3)':
+  '@solana/codecs@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.0(typescript@5.9.3)
-      '@solana/options': 5.5.0(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/options': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/errors@5.5.0(typescript@5.9.3)':
+  '@solana/errors@5.5.1(typescript@5.9.3)':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.2
@@ -4512,70 +4512,70 @@ snapshots:
       typescript: 5.9.3
       typescript-eslint: 8.50.0(eslint@9.39.2)(typescript@5.9.3)
 
-  '@solana/fast-stable-stringify@5.5.0(typescript@5.9.3)':
+  '@solana/fast-stable-stringify@5.5.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/functional@5.5.0(typescript@5.9.3)':
+  '@solana/functional@5.5.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/instruction-plans@5.5.0(typescript@5.9.3)':
+  '@solana/instruction-plans@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/instructions': 5.5.0(typescript@5.9.3)
-      '@solana/keys': 5.5.0(typescript@5.9.3)
-      '@solana/promises': 5.5.0(typescript@5.9.3)
-      '@solana/transaction-messages': 5.5.0(typescript@5.9.3)
-      '@solana/transactions': 5.5.0(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/instructions': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/promises': 5.5.1(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/instructions@5.5.0(typescript@5.9.3)':
+  '@solana/instructions@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/keys@5.5.0(typescript@5.9.3)':
+  '@solana/keys@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/assertions': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/nominal-types': 5.5.0(typescript@5.9.3)
+      '@solana/assertions': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@5.5.0(typescript@5.9.3)':
+  '@solana/kit@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/accounts': 5.5.0(typescript@5.9.3)
-      '@solana/addresses': 5.5.0(typescript@5.9.3)
-      '@solana/codecs': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/functional': 5.5.0(typescript@5.9.3)
-      '@solana/instruction-plans': 5.5.0(typescript@5.9.3)
-      '@solana/instructions': 5.5.0(typescript@5.9.3)
-      '@solana/keys': 5.5.0(typescript@5.9.3)
-      '@solana/offchain-messages': 5.5.0(typescript@5.9.3)
-      '@solana/plugin-core': 5.5.0(typescript@5.9.3)
-      '@solana/programs': 5.5.0(typescript@5.9.3)
-      '@solana/rpc': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-api': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-parsed-types': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.0(typescript@5.9.3)
-      '@solana/signers': 5.5.0(typescript@5.9.3)
-      '@solana/sysvars': 5.5.0(typescript@5.9.3)
-      '@solana/transaction-confirmation': 5.5.0(typescript@5.9.3)
-      '@solana/transaction-messages': 5.5.0(typescript@5.9.3)
-      '@solana/transactions': 5.5.0(typescript@5.9.3)
+      '@solana/accounts': 5.5.1(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/functional': 5.5.1(typescript@5.9.3)
+      '@solana/instruction-plans': 5.5.1(typescript@5.9.3)
+      '@solana/instructions': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/offchain-messages': 5.5.1(typescript@5.9.3)
+      '@solana/plugin-core': 5.5.1(typescript@5.9.3)
+      '@solana/programs': 5.5.1(typescript@5.9.3)
+      '@solana/rpc': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-api': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/signers': 5.5.1(typescript@5.9.3)
+      '@solana/sysvars': 5.5.1(typescript@5.9.3)
+      '@solana/transaction-confirmation': 5.5.1(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4583,38 +4583,38 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/nominal-types@5.5.0(typescript@5.9.3)':
+  '@solana/nominal-types@5.5.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/offchain-messages@5.5.0(typescript@5.9.3)':
+  '@solana/offchain-messages@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/keys': 5.5.0(typescript@5.9.3)
-      '@solana/nominal-types': 5.5.0(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/options@5.5.0(typescript@5.9.3)':
+  '@solana/options@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/plugin-core@5.5.0(typescript@5.9.3)':
+  '@solana/plugin-core@5.5.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
@@ -4622,72 +4622,72 @@ snapshots:
     dependencies:
       prettier: 3.8.1
 
-  '@solana/programs@5.5.0(typescript@5.9.3)':
+  '@solana/programs@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/promises@5.5.0(typescript@5.9.3)':
+  '@solana/promises@5.5.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-api@5.5.0(typescript@5.9.3)':
+  '@solana/rpc-api@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/keys': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-parsed-types': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-spec': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-transformers': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.0(typescript@5.9.3)
-      '@solana/transaction-messages': 5.5.0(typescript@5.9.3)
-      '@solana/transactions': 5.5.0(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-parsed-types@5.5.0(typescript@5.9.3)':
+  '@solana/rpc-parsed-types@5.5.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-spec-types@5.5.0(typescript@5.9.3)':
+  '@solana/rpc-spec-types@5.5.1(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-spec@5.5.0(typescript@5.9.3)':
+  '@solana/rpc-spec@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 5.5.0(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-subscriptions-api@5.5.0(typescript@5.9.3)':
+  '@solana/rpc-subscriptions-api@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.0(typescript@5.9.3)
-      '@solana/keys': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-spec': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-transformers': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.0(typescript@5.9.3)
-      '@solana/transaction-messages': 5.5.0(typescript@5.9.3)
-      '@solana/transactions': 5.5.0(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@5.5.0(typescript@5.9.3)':
+  '@solana/rpc-subscriptions-channel-websocket@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/functional': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-spec': 5.5.0(typescript@5.9.3)
-      '@solana/subscribable': 5.5.0(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/functional': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.9.3)
+      '@solana/subscribable': 5.5.1(typescript@5.9.3)
       ws: 8.19.0
     optionalDependencies:
       typescript: 5.9.3
@@ -4695,28 +4695,28 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@solana/rpc-subscriptions-spec@5.5.0(typescript@5.9.3)':
+  '@solana/rpc-subscriptions-spec@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/promises': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 5.5.0(typescript@5.9.3)
-      '@solana/subscribable': 5.5.0(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/promises': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
+      '@solana/subscribable': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-subscriptions@5.5.0(typescript@5.9.3)':
+  '@solana/rpc-subscriptions@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/fast-stable-stringify': 5.5.0(typescript@5.9.3)
-      '@solana/functional': 5.5.0(typescript@5.9.3)
-      '@solana/promises': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-api': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-channel-websocket': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-spec': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-transformers': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.0(typescript@5.9.3)
-      '@solana/subscribable': 5.5.0(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 5.5.1(typescript@5.9.3)
+      '@solana/functional': 5.5.1(typescript@5.9.3)
+      '@solana/promises': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-api': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-channel-websocket': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/subscribable': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4724,101 +4724,101 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/rpc-transformers@5.5.0(typescript@5.9.3)':
+  '@solana/rpc-transformers@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/functional': 5.5.0(typescript@5.9.3)
-      '@solana/nominal-types': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.0(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/functional': 5.5.1(typescript@5.9.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-transport-http@5.5.0(typescript@5.9.3)':
+  '@solana/rpc-transport-http@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-spec': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 5.5.0(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
       undici-types: 7.19.2
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-types@5.5.0(typescript@5.9.3)':
+  '@solana/rpc-types@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/nominal-types': 5.5.0(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc@5.5.0(typescript@5.9.3)':
+  '@solana/rpc@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/fast-stable-stringify': 5.5.0(typescript@5.9.3)
-      '@solana/functional': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-api': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-spec': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-transformers': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-transport-http': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.0(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 5.5.1(typescript@5.9.3)
+      '@solana/functional': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-api': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-spec-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-transformers': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-transport-http': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@5.5.0(typescript@5.9.3)':
+  '@solana/signers@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/instructions': 5.5.0(typescript@5.9.3)
-      '@solana/keys': 5.5.0(typescript@5.9.3)
-      '@solana/nominal-types': 5.5.0(typescript@5.9.3)
-      '@solana/offchain-messages': 5.5.0(typescript@5.9.3)
-      '@solana/transaction-messages': 5.5.0(typescript@5.9.3)
-      '@solana/transactions': 5.5.0(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/instructions': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
+      '@solana/offchain-messages': 5.5.1(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/subscribable@5.5.0(typescript@5.9.3)':
+  '@solana/subscribable@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.5.0(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/sysvars@5.5.0(typescript@5.9.3)':
+  '@solana/sysvars@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/accounts': 5.5.0(typescript@5.9.3)
-      '@solana/codecs': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.0(typescript@5.9.3)
+      '@solana/accounts': 5.5.1(typescript@5.9.3)
+      '@solana/codecs': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@5.5.0(typescript@5.9.3)':
+  '@solana/transaction-confirmation@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/keys': 5.5.0(typescript@5.9.3)
-      '@solana/promises': 5.5.0(typescript@5.9.3)
-      '@solana/rpc': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.0(typescript@5.9.3)
-      '@solana/transaction-messages': 5.5.0(typescript@5.9.3)
-      '@solana/transactions': 5.5.0(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/promises': 5.5.1(typescript@5.9.3)
+      '@solana/rpc': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
+      '@solana/transactions': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4826,36 +4826,36 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/transaction-messages@5.5.0(typescript@5.9.3)':
+  '@solana/transaction-messages@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/functional': 5.5.0(typescript@5.9.3)
-      '@solana/instructions': 5.5.0(typescript@5.9.3)
-      '@solana/nominal-types': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.0(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/functional': 5.5.1(typescript@5.9.3)
+      '@solana/instructions': 5.5.1(typescript@5.9.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@5.5.0(typescript@5.9.3)':
+  '@solana/transactions@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-core': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.5.0(typescript@5.9.3)
-      '@solana/codecs-strings': 5.5.0(typescript@5.9.3)
-      '@solana/errors': 5.5.0(typescript@5.9.3)
-      '@solana/functional': 5.5.0(typescript@5.9.3)
-      '@solana/instructions': 5.5.0(typescript@5.9.3)
-      '@solana/keys': 5.5.0(typescript@5.9.3)
-      '@solana/nominal-types': 5.5.0(typescript@5.9.3)
-      '@solana/rpc-types': 5.5.0(typescript@5.9.3)
-      '@solana/transaction-messages': 5.5.0(typescript@5.9.3)
+      '@solana/addresses': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+      '@solana/functional': 5.5.1(typescript@5.9.3)
+      '@solana/instructions': 5.5.1(typescript@5.9.3)
+      '@solana/keys': 5.5.1(typescript@5.9.3)
+      '@solana/nominal-types': 5.5.1(typescript@5.9.3)
+      '@solana/rpc-types': 5.5.1(typescript@5.9.3)
+      '@solana/transaction-messages': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:


### PR DESCRIPTION
This PR bumps the `@solana/kit` peer dependency from `5.2` to `5.5.1` since we are about to use features from it that was released on `5.5.1` such as:
- `unwrapSimulationErrors`
- `SuccessfulSingleTransactionPlanResult`
- `passthroughFailedTransactionPlanExecution`
- `assertIsSuccessfulTransactionPlan`
- `getFirstFailedSingleTransactionPlanResult`