### PR TITLE
Use `unwrapSimulationError` in default transaction plan executors

### DIFF
--- a/.changeset/good-cups-heal.md
+++ b/.changeset/good-cups-heal.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-instruction-plan': minor
+---
+
+Unwrap the original error from nested simulation errors in the default `TransactionPlanExecutors`.

--- a/packages/kit-plugin-instruction-plan/test/litesvm.test.ts
+++ b/packages/kit-plugin-instruction-plan/test/litesvm.test.ts
@@ -1,10 +1,16 @@
 import {
     Address,
     createEmptyClient,
+    createTransactionMessage,
     generateKeyPairSigner,
+    setTransactionMessageFeePayerSigner,
     singleInstructionPlan,
     SingleTransactionPlan,
+    singleTransactionPlan,
     SingleTransactionPlanResult,
+    SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN,
+    SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
+    SolanaError,
     TransactionSigner,
 } from '@solana/kit';
 import type { LiteSVM } from '@solana/kit-plugin-litesvm';
@@ -12,6 +18,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { defaultTransactionPlannerAndExecutorFromLitesvm } from '../src';
 
+const MOCK_BLOCKHASH = { blockhash: '11111111111111111111111111111111', lastValidBlockHeight: 0n };
 const MOCK_INSTRUCTION = {
     programAddress: '11111111111111111111111111111111' as Address,
 };
@@ -42,8 +49,7 @@ describe('defaultTransactionPlannerAndExecutorFromLitesvm', () => {
 
     it('uses the SVM instance to send transactions', async () => {
         const payer = await generateKeyPairSigner();
-        const mockBlockhash = { blockhash: '11111111111111111111111111111111', lastValidBlockHeight: 0n };
-        const latestBlockhashLifetime = vi.fn().mockReturnValueOnce(mockBlockhash);
+        const latestBlockhashLifetime = vi.fn().mockReturnValueOnce(MOCK_BLOCKHASH);
         const sendTransaction = vi.fn();
         const svm = { latestBlockhashLifetime, sendTransaction } as unknown as LiteSVM;
         const client = createEmptyClient()
@@ -58,6 +64,53 @@ describe('defaultTransactionPlannerAndExecutorFromLitesvm', () => {
         expect(transactionPlanResult.kind).toBe('single');
         expect(latestBlockhashLifetime).toHaveBeenCalledOnce();
         expect(sendTransaction).toHaveBeenCalledOnce();
+    });
+
+    it('unwraps simulation errors when executing transactions', async () => {
+        const payer = await generateKeyPairSigner();
+        const latestBlockhashLifetime = vi.fn().mockReturnValueOnce(MOCK_BLOCKHASH);
+        const originalError = new Error('Original transaction error');
+        const sendTransaction = vi.fn().mockImplementation(() => {
+            throw new SolanaError(SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT, {
+                cause: originalError,
+                unitsConsumed: 42,
+            });
+        });
+        const svm = { latestBlockhashLifetime, sendTransaction } as unknown as LiteSVM;
+        const client = createEmptyClient()
+            .use(() => ({ payer, svm }))
+            .use(defaultTransactionPlannerAndExecutorFromLitesvm());
+
+        const transactionPlan = singleTransactionPlan(
+            setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 })),
+        );
+        await expect(client.transactionPlanExecutor(transactionPlan)).rejects.toThrowError(
+            new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
+                cause: originalError,
+            }),
+        );
+    });
+
+    it('does not unwrap non-simulation errors when executing transactions', async () => {
+        const payer = await generateKeyPairSigner();
+        const latestBlockhashLifetime = vi.fn().mockReturnValueOnce(MOCK_BLOCKHASH);
+        const originalError = new Error('Original transaction error');
+        const sendTransaction = vi.fn().mockImplementation(() => {
+            throw originalError;
+        });
+        const svm = { latestBlockhashLifetime, sendTransaction } as unknown as LiteSVM;
+        const client = createEmptyClient()
+            .use(() => ({ payer, svm }))
+            .use(defaultTransactionPlannerAndExecutorFromLitesvm());
+
+        const transactionPlan = singleTransactionPlan(
+            setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 })),
+        );
+        await expect(client.transactionPlanExecutor(transactionPlan)).rejects.toThrowError(
+            new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
+                cause: originalError,
+            }),
+        );
     });
 
     it('requires an svm instance on the client', () => {


### PR DESCRIPTION
This PR wraps the default transaction execution logic (for both RPC and LiteSVM instances) in a try/catch such that any simulation error is unwrapped using the new `unwrapSimulationError` from `@solana/kit`.

This means we no longer need to check inside every possible nested simulation error to access the transaction error:

#### Before

You'd need to check if the original error is returned directly or if it is nested inside a simulation error.

```ts
if (isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)) {
    const failedPlan = getFirstFailedSingleTransactionPlanResult(error.context.transactionPlanResult);
    const nestedError = failedPlan.status.error;
    if (isSystemError(nestedError, failedPlan.message)) {
        console.error(getSystemErrorMessage(nestedError.context.code));
        return;
    }
    if (isSolanaError(nestedError, SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE)) {
        if (isSystemError(nestedError.cause, failedPlan.message)) {
            console.error(getSystemErrorMessage(nestedError.cause.context.code));
            return;
        }
    }
    if (isSolanaError(nestedError, SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT)) {
        if (isSystemError(nestedError.cause, failedPlan.message)) {
            console.error(getSystemErrorMessage(nestedError.cause.context.code));
            return;
        }
    }
}
```

#### After

Simulation errors are unwrapped for you and always give you the original error directly.

```ts
if (isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)) {
    const failedPlan = getFirstFailedSingleTransactionPlanResult(error.context.transactionPlanResult);
    const nestedError = failedPlan.status.error;
    if (isSystemError(nestedError, failedPlan.message)) {
        console.error(getSystemErrorMessage(nestedError.context.code));
        return;
    }
}
```