### PR TITLE
Avoid doing two simulations per transaction execution

### DIFF
--- a/.changeset/slow-toes-try.md
+++ b/.changeset/slow-toes-try.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-instruction-plan': patch
+---
+
+Avoid doing two simulations per transaction execution

--- a/packages/kit-plugin-instruction-plan/src/rpc.ts
+++ b/packages/kit-plugin-instruction-plan/src/rpc.ts
@@ -144,7 +144,11 @@ export function defaultTransactionPlannerAndExecutorFromRpc(
                     );
 
                     assertIsTransactionWithBlockhashLifetime(signedTransaction);
-                    await sendAndConfirmTransaction(signedTransaction, { commitment: 'confirmed', ...config });
+                    await sendAndConfirmTransaction(signedTransaction, {
+                        commitment: 'confirmed',
+                        skipPreflight: true,
+                        ...config,
+                    });
                     return { transaction: signedTransaction };
                 } catch (error) {
                     throw unwrapSimulationError(error);


### PR DESCRIPTION
This PR adds the `skipPreflight: true` to the `sendAndConfirmTransaction` call since we are already performing a simulation in the default RPC `TransactionPlanExecutor` in order to estimate the required amount of Compute Unit limit to set.