### PR TITLE
Rename `client.send` to `client.sendTransactions` and its plugin

### DIFF
--- a/.changeset/frank-baboons-hunt.md
+++ b/.changeset/frank-baboons-hunt.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-instruction-plan': minor
+---
+
+Rename the `client.send` function to `client.sendTransactions`.

--- a/.changeset/smart-fans-love.md
+++ b/.changeset/smart-fans-love.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-instruction-plan': minor
+---
+
+Rename the `sendInstructionPlans` plugin to `sendTransactions`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A plugin library for [Solana Kit](https://github.com/anza-xyz/kit) that provides
 
 - ✨ **Ready-to-use clients** for production, local development, and local testing.
 - ✨ **Modular plugin system** to build custom clients by combining individual plugins.
-- ✨ Default **transaction planning and execution** logic built-in, just call `client.send(myInstructions)`.
+- ✨ Default **transaction planning and execution** logic built-in, just call `client.sendTransactions(myInstructions)`.
 - ✨ Various **useful plugins** for RPC connectivity, payer management, SOL airdrops, LiteSVM support and more.
 
 ## Installation
@@ -43,7 +43,7 @@ const payer = await generateKeyPairSigner();
 const client = createDefaultRpcClient({ payer, url: 'https://api.devnet.solana.com' });
 
 // Send transactions
-await client.send([myInstruction]);
+await client.sendTransactions([myInstruction]);
 ```
 
 [See all features and configuration options](./packages/kit-plugins/README.md#createdefaultrpcclient).
@@ -60,7 +60,7 @@ const client = await createDefaultLocalhostRpcClient();
 
 // Payer is auto-generated and funded with SOL
 console.log('Payer address:', client.payer.address);
-await client.send([myInstruction]);
+await client.sendTransactions([myInstruction]);
 ```
 
 [See all features and configuration options](./packages/kit-plugins/README.md#createdefaultlocalhostrpcclient).
@@ -79,7 +79,7 @@ client.svm.setAccount(myTestAccount);
 client.svm.addProgramFromFile(myProgramAddress, 'program.so');
 
 // Execute transactions locally
-await client.send([myInstruction]);
+await client.sendTransactions([myInstruction]);
 ```
 
 [See all features and configuration options](./packages/kit-plugins/README.md#createdefaultlitesvmclient).
@@ -94,7 +94,7 @@ import {
     rpc,
     payerFromFile,
     airdrop,
-    sendInstructionPlans,
+    sendTransactions,
     defaultTransactionPlannerAndExecutorFromRpc,
 } from '@solana/kit-plugins';
 
@@ -103,7 +103,7 @@ const client = await createEmptyClient() // An empty client with a `use` method 
     .use(payerFromFile('path/to/keypair.json')) // Adds `client.payer` using a local keypair file.
     .use(airdrop()) // Adds `client.airdrop` to request SOL from faucets.
     .use(defaultTransactionPlannerAndExecutorFromRpc()) // Adds `client.transactionPlanner` and `client.transactionPlanExecutor`.
-    .use(sendInstructionPlans()); // Adds `client.send` to send instructions or instruction plans.
+    .use(sendTransactions()); // Adds `client.sendTransaction(s)` to send instructions, instruction plans or transaction messages.
 ```
 
 Note that since plugins are defined in `@solana/kit` itself, you're not limited to the plugins in this package! You can use [community plugins](#community-plugins) or even [create your own](#create-your-own-plugins).
@@ -114,21 +114,21 @@ Note that since plugins are defined in `@solana/kit` itself, you're not limited 
 
 Each of these packages offers one or more plugins. You can import these plugins directly from `@solana/kit-plugins` or install the individual packages if you want more granular control over your dependencies. You can learn more about each package by following the links to their READMEs below.
 
-| Package                                                                        | Description                        | Plugins                                                                                                                                                                  |
-| ------------------------------------------------------------------------------ | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [`@solana/kit-plugin-rpc`](./packages/kit-plugin-rpc)                          | Connect to Solana clusters         | `rpc`, `localhostRpc`                                                                                                                                                    |
-| [`@solana/kit-plugin-payer`](./packages/kit-plugin-payer)                      | Manage transaction fee payers      | `payer`, `payerFromFile`, `generatedPayer`, `generatedPayerWithSol`                                                                                                      |
-| [`@solana/kit-plugin-airdrop`](./packages/kit-plugin-airdrop)                  | Request SOL from faucets           | `airdrop`                                                                                                                                                                |
-| [`@solana/kit-plugin-litesvm`](./packages/kit-plugin-litesvm)                  | LiteSVM support                    | `litesvm`                                                                                                                                                                |
-| [`@solana/kit-plugin-instruction-plan`](./packages/kit-plugin-instruction-plan) | Transaction planning and execution | `transactionPlanner`, `transactionPlanExecutor`, `sendInstructionPlans`,`defaultTransactionPlannerAndExecutorFromRpc`, `defaultTransactionPlannerAndExecutorFromLitesvm` |
+| Package                                                                         | Description                        | Plugins                                                                                                                                                              |
+| ------------------------------------------------------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`@solana/kit-plugin-rpc`](./packages/kit-plugin-rpc)                           | Connect to Solana clusters         | `rpc`, `localhostRpc`                                                                                                                                                |
+| [`@solana/kit-plugin-payer`](./packages/kit-plugin-payer)                       | Manage transaction fee payers      | `payer`, `payerFromFile`, `generatedPayer`, `generatedPayerWithSol`                                                                                                  |
+| [`@solana/kit-plugin-airdrop`](./packages/kit-plugin-airdrop)                   | Request SOL from faucets           | `airdrop`                                                                                                                                                            |
+| [`@solana/kit-plugin-litesvm`](./packages/kit-plugin-litesvm)                   | LiteSVM support                    | `litesvm`                                                                                                                                                            |
+| [`@solana/kit-plugin-instruction-plan`](./packages/kit-plugin-instruction-plan) | Transaction planning and execution | `transactionPlanner`, `transactionPlanExecutor`, `sendTransactions`,`defaultTransactionPlannerAndExecutorFromRpc`, `defaultTransactionPlannerAndExecutorFromLitesvm` |
 
 ## Community Plugins
 
-| Package | Description | Plugins | Maintainers |
-| ------- | ----------- | ------- | ----------- |
-| [`airdrop-token`](https://github.com/amilz/kit-helpers/tree/main/plugins/airdrop-token) _(unpublished)_ | Create token mints, ATAs, and mint tokens for testing | `airdropToken`, `testTokenPlugin` | [@amilz](https://github.com/amilz) |
-| [`local-validator`](https://github.com/amilz/kit-helpers/tree/main/plugins/local-validator) _(unpublished)_ | Solana test validator lifecycle management (start, stop, restart) | `localValidatorPlugin` | [@amilz](https://github.com/amilz) |
-| [`transaction-builder`](https://github.com/amilz/kit-helpers/tree/main/plugins/transaction-builder) _(unpublished)_ | Transaction builder for constructing, signing, and sending transactions | `transactionBuilderPlugin` | [@amilz](https://github.com/amilz) |
+| Package                                                                                                             | Description                                                             | Plugins                           | Maintainers                        |
+| ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | --------------------------------- | ---------------------------------- |
+| [`airdrop-token`](https://github.com/amilz/kit-helpers/tree/main/plugins/airdrop-token) _(unpublished)_             | Create token mints, ATAs, and mint tokens for testing                   | `airdropToken`, `testTokenPlugin` | [@amilz](https://github.com/amilz) |
+| [`local-validator`](https://github.com/amilz/kit-helpers/tree/main/plugins/local-validator) _(unpublished)_         | Solana test validator lifecycle management (start, stop, restart)       | `localValidatorPlugin`            | [@amilz](https://github.com/amilz) |
+| [`transaction-builder`](https://github.com/amilz/kit-helpers/tree/main/plugins/transaction-builder) _(unpublished)_ | Transaction builder for constructing, signing, and sending transactions | `transactionBuilderPlugin`        | [@amilz](https://github.com/amilz) |
 
 _Do you know any? Please open a PR to add them here!_
 

--- a/packages/kit-plugin-instruction-plan/README.md
+++ b/packages/kit-plugin-instruction-plan/README.md
@@ -64,9 +64,9 @@ const client = createEmptyClient().use(transactionPlanExecutor(myTransactionPlan
     const transactionPlanResult = await client.transactionPlanExecutor(myTransactionPlan);
     ```
 
-## `sendInstructionPlans` plugin
+## `sendTransactions` plugin
 
-The `sendInstructionPlans` plugin adds a `send` function that combines transaction planning and execution in a single call.
+The `sendTransactions` plugin adds a `sendTransactions` function that combines transaction planning and execution in a single call.
 
 ### Installation
 
@@ -74,19 +74,19 @@ This plugin requires both `transactionPlanner` and `transactionPlanExecutor` to 
 
 ```ts
 import { createEmptyClient } from '@solana/kit';
-import { transactionPlanner, transactionPlanExecutor, sendInstructionPlans } from '@solana/kit-plugins';
+import { transactionPlanner, transactionPlanExecutor, sendTransactions } from '@solana/kit-plugins';
 
 const client = createEmptyClient()
     .use(transactionPlanner(myTransactionPlanner))
     .use(transactionPlanExecutor(myTransactionPlanExecutor))
-    .use(sendInstructionPlans());
+    .use(sendTransactions());
 ```
 
 ### Features
 
-- `send`: An asynchronous function that plans and executes instruction plans in one call.
+- `sendTransactions`: An asynchronous function that plans and executes instruction plans in one call.
     ```ts
-    const transactionPlanResult = await client.send(myInstructionPlan);
+    const transactionPlanResult = await client.sendTransactions(myInstructionPlan);
     ```
 
 ## `defaultTransactionPlannerAndExecutorFromRpc` plugin

--- a/packages/kit-plugin-instruction-plan/src/core.ts
+++ b/packages/kit-plugin-instruction-plan/src/core.ts
@@ -48,7 +48,7 @@ export function transactionPlanExecutor(transactionPlanExecutor: TransactionPlan
 }
 
 /**
- * A plugin that adds a `send` function on the client to
+ * A plugin that adds a `sendTransactions` function on the client to
  * plan and execute instruction plans in one call.
  *
  * This expects the client to have both a `transactionPlanner`
@@ -59,21 +59,21 @@ export function transactionPlanExecutor(transactionPlanExecutor: TransactionPlan
  * import { createEmptyClient } from '@solana/kit';
  * import { transactionPlanExecutor } from '@solana/kit-plugins';
  *
- * // Install the sendInstructionPlans plugin and its requirements.
+ * // Install the sendTransactions plugin and its requirements.
  * const client = createEmptyClient()
  *     .use(transactionPlanner(myTransactionPlanner))
  *     .use(transactionPlanExecutor(myTransactionPlanExecutor))
- *     .use(sendInstructionPlans());
+ *     .use(sendTransactions());
  *
- * // Use the send function.
- * const transactionPlanResult = await client.send(myInstructionPlan);
+ * // Use the sendTransactions function.
+ * const result = await client.sendTransactions(myInstructionPlan);
  */
-export function sendInstructionPlans() {
+export function sendTransactions() {
     return <T extends { transactionPlanExecutor: TransactionPlanExecutor; transactionPlanner: TransactionPlanner }>(
         client: T,
     ) => ({
         ...client,
-        send: async (
+        sendTransactions: async (
             instructions: Instruction | Instruction[] | InstructionPlan,
             config: {
                 abortSignal?: AbortSignal;

--- a/packages/kit-plugin-instruction-plan/test/core.test.ts
+++ b/packages/kit-plugin-instruction-plan/test/core.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@solana/kit';
 import { describe, expect, it, vi } from 'vitest';
 
-import { sendInstructionPlans, transactionPlanExecutor, transactionPlanner } from '../src';
+import { sendTransactions, transactionPlanExecutor, transactionPlanner } from '../src';
 
 describe('transactionPlanner', () => {
     it('sets the provided transactionPlanner on the client', () => {
@@ -27,8 +27,8 @@ describe('transactionPlanExecutor', () => {
     });
 });
 
-describe('sendInstructionPlans', () => {
-    it('adds a send function on the client that plans and executes instructions', async () => {
+describe('sendTransactions', () => {
+    it('adds a sendTransactions function on the client that plans and executes instructions', async () => {
         const instruction = {} as Instruction;
         const transactionPlan = {} as TransactionPlan;
         const transactionPlanResult = {} as TransactionPlanResult;
@@ -38,10 +38,10 @@ describe('sendInstructionPlans', () => {
         const client = createEmptyClient()
             .use(transactionPlanner(customTransactionPlanner))
             .use(transactionPlanExecutor(customTransactionPlanExecutor))
-            .use(sendInstructionPlans());
+            .use(sendTransactions());
 
-        expect(client).toHaveProperty('send');
-        const result = await client.send(instruction);
+        expect(client).toHaveProperty('sendTransactions');
+        const result = await client.sendTransactions(instruction);
         expect(result).toBe(transactionPlanResult);
         expect(customTransactionPlanner).toHaveBeenCalledExactlyOnceWith(singleInstructionPlan(instruction), {
             abortSignal: undefined,
@@ -57,10 +57,10 @@ describe('sendInstructionPlans', () => {
         const client = createEmptyClient()
             .use(transactionPlanner(customTransactionPlanner))
             .use(transactionPlanExecutor(customTransactionPlanExecutor))
-            .use(sendInstructionPlans());
+            .use(sendTransactions());
 
         const abortSignal = new AbortController().signal;
-        await client.send({} as Instruction, { abortSignal });
+        await client.sendTransactions({} as Instruction, { abortSignal });
         expect(customTransactionPlanner).toHaveBeenCalledExactlyOnceWith(expect.any(Object), { abortSignal });
         expect(customTransactionPlanExecutor).toHaveBeenCalledExactlyOnceWith(expect.any(Object), { abortSignal });
     });
@@ -71,11 +71,11 @@ describe('sendInstructionPlans', () => {
         const client = createEmptyClient()
             .use(transactionPlanner(customTransactionPlanner))
             .use(transactionPlanExecutor(customTransactionPlanExecutor))
-            .use(sendInstructionPlans());
+            .use(sendTransactions());
 
         const abortController = new AbortController();
         abortController.abort();
-        await client.send({} as Instruction, { abortSignal: abortController.signal }).catch(() => {});
+        await client.sendTransactions({} as Instruction, { abortSignal: abortController.signal }).catch(() => {});
         expect(customTransactionPlanner).not.toHaveBeenCalledOnce();
         expect(customTransactionPlanExecutor).not.toHaveBeenCalledOnce();
     });
@@ -86,12 +86,12 @@ describe('sendInstructionPlans', () => {
         const client = createEmptyClient()
             .use(transactionPlanner(transactionPlannerOnTheClient))
             .use(transactionPlanExecutor(transactionPlanExecutorOnTheClient))
-            .use(sendInstructionPlans());
+            .use(sendTransactions());
 
         const overridenTransactionPlanner = vi.fn().mockResolvedValue({});
         const overridenTransactionPlanExecutor = vi.fn().mockResolvedValue({});
 
-        await client.send({} as Instruction, {
+        await client.sendTransactions({} as Instruction, {
             transactionPlanExecutor: overridenTransactionPlanExecutor,
             transactionPlanner: overridenTransactionPlanner,
         });

--- a/packages/kit-plugins/README.md
+++ b/packages/kit-plugins/README.md
@@ -33,7 +33,7 @@ const client = createDefaultRpcClient({
     payer,
 });
 
-await client.send([myInstruction]);
+await client.sendTransactions([myInstruction]);
 ```
 
 #### Features
@@ -43,7 +43,7 @@ await client.send([myInstruction]);
 - `client.payer`: The main payer signer for transactions.
 - `client.transactionPlanner`: Plans instructions into transaction messages.
 - `client.transactionPlanExecutor`: Executes planned transaction messages.
-- `client.send`: Sends instructions or instruction plans to the cluster by using the client's transaction planner and executor.
+- `client.sendTransactions`: Sends instructions or instruction plans to the cluster by using the client's transaction planner and executor.
 
 #### Configuration
 
@@ -65,7 +65,7 @@ const client = await createDefaultLocalhostRpcClient();
 
 // Payer is automatically generated and funded
 console.log('Payer address:', client.payer.address);
-await client.send([myInstruction]);
+await client.sendTransactions([myInstruction]);
 
 // Request additional funding
 await client.airdrop(client.payer.address, lamports(5_000_000_000n));
@@ -79,7 +79,7 @@ await client.airdrop(client.payer.address, lamports(5_000_000_000n));
 - `client.airdrop`: Function to request SOL from the local faucet.
 - `client.transactionPlanner`: Plans instructions into transaction messages.
 - `client.transactionPlanExecutor`: Executes planned transaction messages.
-- `client.send`: Sends instructions or instruction plans to the cluster by using the client's transaction planner and executor.
+- `client.sendTransactions`: Sends instructions or instruction plans to the cluster by using the client's transaction planner and executor.
 
 #### Configuration
 
@@ -101,7 +101,7 @@ client.svm.setAccount(myTestAccount);
 client.svm.addProgramFromFile(myProgramAddress, 'program.so');
 
 // Execute transactions locally
-await client.send([myInstruction]);
+await client.sendTransactions([myInstruction]);
 ```
 
 #### Features
@@ -112,7 +112,7 @@ await client.send([myInstruction]);
 - `client.airdrop`: Function to request SOL from the LiteSVM instance.
 - `client.transactionPlanner`: Plans instructions into transaction messages.
 - `client.transactionPlanExecutor`: Executes planned transaction messages.
-- `client.send`: Sends instructions or instruction plans to the cluster by using the client's transaction planner and executor.
+- `client.sendTransactions`: Sends instructions or instruction plans to the cluster by using the client's transaction planner and executor.
 
 #### Configuration
 

--- a/packages/kit-plugins/src/defaults.ts
+++ b/packages/kit-plugins/src/defaults.ts
@@ -9,7 +9,7 @@ import { airdrop, AirdropFunction } from '@solana/kit-plugin-airdrop';
 import {
     defaultTransactionPlannerAndExecutorFromLitesvm,
     defaultTransactionPlannerAndExecutorFromRpc,
-    sendInstructionPlans,
+    sendTransactions,
 } from '@solana/kit-plugin-instruction-plan';
 import { litesvm } from '@solana/kit-plugin-litesvm';
 import { generatedPayerWithSol, payer } from '@solana/kit-plugin-payer';
@@ -37,7 +37,7 @@ import { localhostRpc, rpc } from '@solana/kit-plugin-rpc';
  * });
  *
  * // Use the client
- * const result = await client.send([myInstruction]);
+ * const result = await client.sendTransactions([myInstruction]);
  * ```
  */
 export function createDefaultRpcClient<TClusterUrl extends ClusterUrl>(config: {
@@ -49,7 +49,7 @@ export function createDefaultRpcClient<TClusterUrl extends ClusterUrl>(config: {
         .use(rpc<TClusterUrl>(config.url, config.rpcSubscriptionsConfig))
         .use(payer(config.payer))
         .use(defaultTransactionPlannerAndExecutorFromRpc())
-        .use(sendInstructionPlans());
+        .use(sendTransactions());
 }
 
 /**
@@ -70,7 +70,7 @@ export function createDefaultRpcClient<TClusterUrl extends ClusterUrl>(config: {
  * const client = await createDefaultLocalhostRpcClient();
  *
  * // Use the client
- * const result = await client.send([myInstruction]);
+ * const result = await client.sendTransactions([myInstruction]);
  * console.log('Payer address:', client.payer.address);
  * ```
  *
@@ -90,7 +90,7 @@ export function createDefaultLocalhostRpcClient(config: { payer?: TransactionSig
         .use(airdrop())
         .use(payerOrGeneratedPayer(config.payer))
         .use(defaultTransactionPlannerAndExecutorFromRpc())
-        .use(sendInstructionPlans());
+        .use(sendTransactions());
 }
 
 /**
@@ -116,7 +116,7 @@ export function createDefaultLocalhostRpcClient(config: { payer?: TransactionSig
  * client.svm.addProgramFromFile(myProgramAddress, 'program.so');
  *
  * // Use the client
- * const result = await client.send([myInstruction]);
+ * const result = await client.sendTransactions([myInstruction]);
  * ```
  *
  * @example
@@ -135,7 +135,7 @@ export function createDefaultLiteSVMClient(config: { payer?: TransactionSigner }
         .use(airdrop())
         .use(payerOrGeneratedPayer(config.payer))
         .use(defaultTransactionPlannerAndExecutorFromLitesvm())
-        .use(sendInstructionPlans());
+        .use(sendTransactions());
 }
 
 /**

--- a/packages/kit-plugins/test/defaults.test.ts
+++ b/packages/kit-plugins/test/defaults.test.ts
@@ -71,12 +71,12 @@ describe('createDefaultRpcClient', () => {
         expectTypeOf(client.transactionPlanExecutor).toEqualTypeOf<TransactionPlanExecutor>();
     });
 
-    it('it provide a helper function to send instruction plans', () => {
+    it('it provide a helper function to send transactions', () => {
         const client = createDefaultRpcClient({
             payer: {} as TransactionSigner,
             url: 'https://api.mainnet-beta.solana.com',
         });
-        expect(client.send).toBeTypeOf('function');
+        expect(client.sendTransactions).toBeTypeOf('function');
     });
 });
 
@@ -147,12 +147,12 @@ describe('createDefaultLocalhostRpcClient', () => {
         expectTypeOf(client.transactionPlanExecutor).toEqualTypeOf<TransactionPlanExecutor>();
     });
 
-    it('it provide a helper function to send instruction plans', async () => {
+    it('it provide a helper function to send transactions', async () => {
         const airdropFn = vi.fn().mockResolvedValue('MockSignature');
         (airdropFactory as Mock).mockReturnValueOnce(airdropFn);
 
         const client = await createDefaultLocalhostRpcClient();
-        expect(client.send).toBeTypeOf('function');
+        expect(client.sendTransactions).toBeTypeOf('function');
     });
 });
 
@@ -199,8 +199,8 @@ describe('createDefaultLiteSVMClient', () => {
         expectTypeOf(client.transactionPlanExecutor).toEqualTypeOf<TransactionPlanExecutor>();
     });
 
-    it('it provide a helper function to send instruction plans', async () => {
+    it('it provide a helper function to send transactions', async () => {
         const client = await createDefaultLiteSVMClient();
-        expect(client.send).toBeTypeOf('function');
+        expect(client.sendTransactions).toBeTypeOf('function');
     });
 });


### PR DESCRIPTION
This PR renames the `sendInstructionPlans` plugin to `sendTransactions`. It also renames the `client.send` function provided by this plugin to `client.sendTransactions`. This is to offer a more consistent naming and giving space for a new upcoming `client.sendTransaction` helper that ensures only a single transaction is executed.