### PR TITLE
Add `client.sendTransaction` to `sendTransactions` plugin

### DIFF
--- a/.changeset/little-kings-wonder.md
+++ b/.changeset/little-kings-wonder.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-instruction-plan': minor
+---
+
+Add a new `client.sendTransaction` helper in the `sendTransactions` plugin. This helper ensures only a single transaction is executed, regardless of the number of instructions provided. Should these instructions not fit in a transaction, an error will be thrown.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A plugin library for [Solana Kit](https://github.com/anza-xyz/kit) that provides
 
 - ✨ **Ready-to-use clients** for production, local development, and local testing.
 - ✨ **Modular plugin system** to build custom clients by combining individual plugins.
-- ✨ Default **transaction planning and execution** logic built-in, just call `client.sendTransactions(myInstructions)`.
+- ✨ Default **transaction planning and execution** logic built-in, just call `client.sendTransaction(myInstructions)`.
 - ✨ Various **useful plugins** for RPC connectivity, payer management, SOL airdrops, LiteSVM support and more.
 
 ## Installation
@@ -43,7 +43,7 @@ const payer = await generateKeyPairSigner();
 const client = createDefaultRpcClient({ payer, url: 'https://api.devnet.solana.com' });
 
 // Send transactions
-await client.sendTransactions([myInstruction]);
+await client.sendTransaction([myInstruction]);
 ```
 
 [See all features and configuration options](./packages/kit-plugins/README.md#createdefaultrpcclient).
@@ -60,7 +60,7 @@ const client = await createDefaultLocalhostRpcClient();
 
 // Payer is auto-generated and funded with SOL
 console.log('Payer address:', client.payer.address);
-await client.sendTransactions([myInstruction]);
+await client.sendTransaction([myInstruction]);
 ```
 
 [See all features and configuration options](./packages/kit-plugins/README.md#createdefaultlocalhostrpcclient).
@@ -103,7 +103,7 @@ const client = await createEmptyClient() // An empty client with a `use` method 
     .use(payerFromFile('path/to/keypair.json')) // Adds `client.payer` using a local keypair file.
     .use(airdrop()) // Adds `client.airdrop` to request SOL from faucets.
     .use(defaultTransactionPlannerAndExecutorFromRpc()) // Adds `client.transactionPlanner` and `client.transactionPlanExecutor`.
-    .use(sendTransactions()); // Adds `client.sendTransaction(s)` to send instructions, instruction plans or transaction messages.
+    .use(sendTransactions()); // Adds `client.sendTransaction(s)` to send transaction messages, instructions or instruction plans.
 ```
 
 Note that since plugins are defined in `@solana/kit` itself, you're not limited to the plugins in this package! You can use [community plugins](#community-plugins) or even [create your own](#create-your-own-plugins).

--- a/packages/kit-plugin-instruction-plan/README.md
+++ b/packages/kit-plugin-instruction-plan/README.md
@@ -66,7 +66,7 @@ const client = createEmptyClient().use(transactionPlanExecutor(myTransactionPlan
 
 ## `sendTransactions` plugin
 
-The `sendTransactions` plugin adds a `sendTransactions` function that combines transaction planning and execution in a single call.
+The `sendTransactions` plugin adds two helper functions, `sendTransaction` and `sendTransactions`, that combine transaction planning and execution in a single call. They accept transaction messages, instructions or instruction plans as input.
 
 ### Installation
 
@@ -84,9 +84,16 @@ const client = createEmptyClient()
 
 ### Features
 
-- `sendTransactions`: An asynchronous function that plans and executes instruction plans in one call.
+- `sendTransactions`: An asynchronous function that plans and executes transaction messages, instructions or instruction plans in one call.
+
     ```ts
     const transactionPlanResult = await client.sendTransactions(myInstructionPlan);
+    ```
+
+- `sendTransaction`: An asynchronous function that plans and executes a single transaction message, instruction plan or multiple instructions in one call. Should the provided instructions or instruction plan result in multiple transactions, an error will be thrown prior to execution.
+
+    ```ts
+    const transactionPlanResult = await client.sendTransaction(myInstructionPlan);
     ```
 
 ## `defaultTransactionPlannerAndExecutorFromRpc` plugin

--- a/packages/kit-plugin-instruction-plan/test/core.test.ts
+++ b/packages/kit-plugin-instruction-plan/test/core.test.ts
@@ -1,7 +1,20 @@
 import {
+    canceledSingleTransactionPlanResult,
     createEmptyClient,
     Instruction,
+    sequentialInstructionPlan,
+    sequentialTransactionPlan,
+    sequentialTransactionPlanResult,
+    Signature,
     singleInstructionPlan,
+    singleTransactionPlan,
+    SOLANA_ERROR__INSTRUCTION_PLANS__UNEXPECTED_TRANSACTION_PLAN,
+    SOLANA_ERROR__INSTRUCTION_PLANS__UNEXPECTED_TRANSACTION_PLAN_RESULT,
+    SolanaError,
+    SuccessfulSingleTransactionPlanResult,
+    successfulSingleTransactionPlanResultFromSignature,
+    TransactionMessage,
+    TransactionMessageWithFeePayer,
     TransactionPlan,
     TransactionPlanResult,
 } from '@solana/kit';
@@ -28,76 +41,238 @@ describe('transactionPlanExecutor', () => {
 });
 
 describe('sendTransactions', () => {
-    it('adds a sendTransactions function on the client that plans and executes instructions', async () => {
-        const instruction = {} as Instruction;
-        const transactionPlan = {} as TransactionPlan;
-        const transactionPlanResult = {} as TransactionPlanResult;
+    describe('client.sendTransaction', () => {
+        it('adds a sendTransaction function on the client that plans and executes instructions', async () => {
+            const instruction = {} as Instruction;
+            const transactionPlan = singleTransactionPlan({} as TransactionMessage & TransactionMessageWithFeePayer);
+            const transactionPlanResult = successfulSingleTransactionPlanResultFromSignature(
+                {} as TransactionMessage & TransactionMessageWithFeePayer,
+                'signature' as Signature,
+            );
 
-        const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
-        const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
-        const client = createEmptyClient()
-            .use(transactionPlanner(customTransactionPlanner))
-            .use(transactionPlanExecutor(customTransactionPlanExecutor))
-            .use(sendTransactions());
+            const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
+            const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
+            const client = createEmptyClient()
+                .use(transactionPlanner(customTransactionPlanner))
+                .use(transactionPlanExecutor(customTransactionPlanExecutor))
+                .use(sendTransactions());
 
-        expect(client).toHaveProperty('sendTransactions');
-        const result = await client.sendTransactions(instruction);
-        expect(result).toBe(transactionPlanResult);
-        expect(customTransactionPlanner).toHaveBeenCalledExactlyOnceWith(singleInstructionPlan(instruction), {
-            abortSignal: undefined,
+            expect(client).toHaveProperty('sendTransaction');
+            const result = await client.sendTransaction(instruction);
+            result satisfies SuccessfulSingleTransactionPlanResult;
+
+            expect(result).toBe(transactionPlanResult);
+            expect(customTransactionPlanner).toHaveBeenCalledExactlyOnceWith(singleInstructionPlan(instruction), {
+                abortSignal: undefined,
+            });
+            expect(customTransactionPlanExecutor).toHaveBeenCalledExactlyOnceWith(transactionPlan, {
+                abortSignal: undefined,
+            });
         });
-        expect(customTransactionPlanExecutor).toHaveBeenCalledExactlyOnceWith(transactionPlan, {
-            abortSignal: undefined,
+
+        it('fails if the transaction plan is not a single transaction plan', async () => {
+            const instructionPlan = sequentialInstructionPlan([{} as Instruction]);
+            const transactionPlan = sequentialTransactionPlan([
+                {} as TransactionMessage & TransactionMessageWithFeePayer,
+            ]);
+            const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
+            const customTransactionPlanExecutor = vi.fn();
+            const client = createEmptyClient()
+                .use(transactionPlanner(customTransactionPlanner))
+                .use(transactionPlanExecutor(customTransactionPlanExecutor))
+                .use(sendTransactions());
+
+            const promise = client.sendTransaction(instructionPlan);
+            await expect(promise).rejects.toThrowError(
+                new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__UNEXPECTED_TRANSACTION_PLAN, {
+                    actualKind: 'sequential',
+                    expectedKind: 'single',
+                    transactionPlan,
+                }),
+            );
+        });
+
+        it('fails if the transaction plan result is not a single transaction plan result', async () => {
+            const instructionPlan = sequentialInstructionPlan([{} as Instruction]);
+            const transactionPlan = singleTransactionPlan({} as TransactionMessage & TransactionMessageWithFeePayer);
+            const transactionPlanResult = sequentialTransactionPlanResult([
+                successfulSingleTransactionPlanResultFromSignature(
+                    {} as TransactionMessage & TransactionMessageWithFeePayer,
+                    'signature' as Signature,
+                ),
+            ]);
+            const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
+            const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
+            const client = createEmptyClient()
+                .use(transactionPlanner(customTransactionPlanner))
+                .use(transactionPlanExecutor(customTransactionPlanExecutor))
+                .use(sendTransactions());
+
+            const promise = client.sendTransaction(instructionPlan);
+            await expect(promise).rejects.toThrowError(
+                new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__UNEXPECTED_TRANSACTION_PLAN_RESULT, {
+                    actualKind: 'sequential',
+                    expectedKind: 'successful single',
+                    transactionPlanResult,
+                }),
+            );
+        });
+
+        it('fails if the transaction plan result is not a successful single transaction plan result', async () => {
+            const instructionPlan = sequentialInstructionPlan([{} as Instruction]);
+            const transactionPlan = singleTransactionPlan({} as TransactionMessage & TransactionMessageWithFeePayer);
+            const transactionPlanResult = canceledSingleTransactionPlanResult(
+                {} as TransactionMessage & TransactionMessageWithFeePayer,
+            );
+            const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
+            const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
+            const client = createEmptyClient()
+                .use(transactionPlanner(customTransactionPlanner))
+                .use(transactionPlanExecutor(customTransactionPlanExecutor))
+                .use(sendTransactions());
+
+            const promise = client.sendTransaction(instructionPlan);
+            await expect(promise).rejects.toThrowError(
+                new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__UNEXPECTED_TRANSACTION_PLAN_RESULT, {
+                    actualKind: 'canceled single',
+                    expectedKind: 'successful single',
+                    transactionPlanResult,
+                }),
+            );
+        });
+
+        it('passes the abort signal through the planner and executor', async () => {
+            const transactionPlan = singleTransactionPlan({} as TransactionMessage & TransactionMessageWithFeePayer);
+            const transactionPlanResult = successfulSingleTransactionPlanResultFromSignature(
+                {} as TransactionMessage & TransactionMessageWithFeePayer,
+                'signature' as Signature,
+            );
+            const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
+            const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
+            const client = createEmptyClient()
+                .use(transactionPlanner(customTransactionPlanner))
+                .use(transactionPlanExecutor(customTransactionPlanExecutor))
+                .use(sendTransactions());
+
+            const abortSignal = new AbortController().signal;
+            await client.sendTransaction({} as Instruction, { abortSignal });
+            expect(customTransactionPlanner).toHaveBeenCalledExactlyOnceWith(expect.any(Object), { abortSignal });
+            expect(customTransactionPlanExecutor).toHaveBeenCalledExactlyOnceWith(expect.any(Object), { abortSignal });
+        });
+
+        it('does not call the planner if the abort signal is already triggered', async () => {
+            const customTransactionPlanner = vi.fn();
+            const customTransactionPlanExecutor = vi.fn();
+            const client = createEmptyClient()
+                .use(transactionPlanner(customTransactionPlanner))
+                .use(transactionPlanExecutor(customTransactionPlanExecutor))
+                .use(sendTransactions());
+
+            const abortController = new AbortController();
+            abortController.abort();
+            await client.sendTransaction({} as Instruction, { abortSignal: abortController.signal }).catch(() => {});
+            expect(customTransactionPlanner).not.toHaveBeenCalledOnce();
+            expect(customTransactionPlanExecutor).not.toHaveBeenCalledOnce();
+        });
+
+        it('can override the planner and executor set on the client', async () => {
+            const transactionPlan = singleTransactionPlan({} as TransactionMessage & TransactionMessageWithFeePayer);
+            const transactionPlanResult = successfulSingleTransactionPlanResultFromSignature(
+                {} as TransactionMessage & TransactionMessageWithFeePayer,
+                'signature' as Signature,
+            );
+            const transactionPlannerOnTheClient = vi.fn().mockResolvedValue(transactionPlan);
+            const transactionPlanExecutorOnTheClient = vi.fn().mockResolvedValue(transactionPlanResult);
+            const client = createEmptyClient()
+                .use(transactionPlanner(transactionPlannerOnTheClient))
+                .use(transactionPlanExecutor(transactionPlanExecutorOnTheClient))
+                .use(sendTransactions());
+
+            const overridenTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
+            const overridenTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
+
+            await client.sendTransaction(singleInstructionPlan({} as Instruction), {
+                transactionPlanExecutor: overridenTransactionPlanExecutor,
+                transactionPlanner: overridenTransactionPlanner,
+            });
+            expect(overridenTransactionPlanner).toHaveBeenCalledOnce();
+            expect(overridenTransactionPlanExecutor).toHaveBeenCalledOnce();
+            expect(transactionPlannerOnTheClient).not.toHaveBeenCalledOnce();
+            expect(transactionPlanExecutorOnTheClient).not.toHaveBeenCalledOnce();
         });
     });
+    describe('client.sendTransactions', () => {
+        it('adds a sendTransactions function on the client that plans and executes instructions', async () => {
+            const instruction = {} as Instruction;
+            const transactionPlan = {} as TransactionPlan;
+            const transactionPlanResult = {} as TransactionPlanResult;
 
-    it('passes the abort signal through the planner and executor', async () => {
-        const customTransactionPlanner = vi.fn().mockResolvedValue({});
-        const customTransactionPlanExecutor = vi.fn().mockResolvedValue({});
-        const client = createEmptyClient()
-            .use(transactionPlanner(customTransactionPlanner))
-            .use(transactionPlanExecutor(customTransactionPlanExecutor))
-            .use(sendTransactions());
+            const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
+            const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
+            const client = createEmptyClient()
+                .use(transactionPlanner(customTransactionPlanner))
+                .use(transactionPlanExecutor(customTransactionPlanExecutor))
+                .use(sendTransactions());
 
-        const abortSignal = new AbortController().signal;
-        await client.sendTransactions({} as Instruction, { abortSignal });
-        expect(customTransactionPlanner).toHaveBeenCalledExactlyOnceWith(expect.any(Object), { abortSignal });
-        expect(customTransactionPlanExecutor).toHaveBeenCalledExactlyOnceWith(expect.any(Object), { abortSignal });
-    });
-
-    it('does not call the planner if the abort signal is already triggered', async () => {
-        const customTransactionPlanner = vi.fn();
-        const customTransactionPlanExecutor = vi.fn();
-        const client = createEmptyClient()
-            .use(transactionPlanner(customTransactionPlanner))
-            .use(transactionPlanExecutor(customTransactionPlanExecutor))
-            .use(sendTransactions());
-
-        const abortController = new AbortController();
-        abortController.abort();
-        await client.sendTransactions({} as Instruction, { abortSignal: abortController.signal }).catch(() => {});
-        expect(customTransactionPlanner).not.toHaveBeenCalledOnce();
-        expect(customTransactionPlanExecutor).not.toHaveBeenCalledOnce();
-    });
-
-    it('can override the planner and executor set on the client', async () => {
-        const transactionPlannerOnTheClient = vi.fn().mockResolvedValue({});
-        const transactionPlanExecutorOnTheClient = vi.fn().mockResolvedValue({});
-        const client = createEmptyClient()
-            .use(transactionPlanner(transactionPlannerOnTheClient))
-            .use(transactionPlanExecutor(transactionPlanExecutorOnTheClient))
-            .use(sendTransactions());
-
-        const overridenTransactionPlanner = vi.fn().mockResolvedValue({});
-        const overridenTransactionPlanExecutor = vi.fn().mockResolvedValue({});
-
-        await client.sendTransactions({} as Instruction, {
-            transactionPlanExecutor: overridenTransactionPlanExecutor,
-            transactionPlanner: overridenTransactionPlanner,
+            expect(client).toHaveProperty('sendTransactions');
+            const result = await client.sendTransactions(instruction);
+            expect(result).toBe(transactionPlanResult);
+            expect(customTransactionPlanner).toHaveBeenCalledExactlyOnceWith(singleInstructionPlan(instruction), {
+                abortSignal: undefined,
+            });
+            expect(customTransactionPlanExecutor).toHaveBeenCalledExactlyOnceWith(transactionPlan, {
+                abortSignal: undefined,
+            });
         });
-        expect(overridenTransactionPlanner).toHaveBeenCalledOnce();
-        expect(overridenTransactionPlanExecutor).toHaveBeenCalledOnce();
-        expect(transactionPlannerOnTheClient).not.toHaveBeenCalledOnce();
-        expect(transactionPlanExecutorOnTheClient).not.toHaveBeenCalledOnce();
+
+        it('passes the abort signal through the planner and executor', async () => {
+            const customTransactionPlanner = vi.fn().mockResolvedValue({});
+            const customTransactionPlanExecutor = vi.fn().mockResolvedValue({});
+            const client = createEmptyClient()
+                .use(transactionPlanner(customTransactionPlanner))
+                .use(transactionPlanExecutor(customTransactionPlanExecutor))
+                .use(sendTransactions());
+
+            const abortSignal = new AbortController().signal;
+            await client.sendTransactions({} as Instruction, { abortSignal });
+            expect(customTransactionPlanner).toHaveBeenCalledExactlyOnceWith(expect.any(Object), { abortSignal });
+            expect(customTransactionPlanExecutor).toHaveBeenCalledExactlyOnceWith(expect.any(Object), { abortSignal });
+        });
+
+        it('does not call the planner if the abort signal is already triggered', async () => {
+            const customTransactionPlanner = vi.fn();
+            const customTransactionPlanExecutor = vi.fn();
+            const client = createEmptyClient()
+                .use(transactionPlanner(customTransactionPlanner))
+                .use(transactionPlanExecutor(customTransactionPlanExecutor))
+                .use(sendTransactions());
+
+            const abortController = new AbortController();
+            abortController.abort();
+            await client.sendTransactions({} as Instruction, { abortSignal: abortController.signal }).catch(() => {});
+            expect(customTransactionPlanner).not.toHaveBeenCalledOnce();
+            expect(customTransactionPlanExecutor).not.toHaveBeenCalledOnce();
+        });
+
+        it('can override the planner and executor set on the client', async () => {
+            const transactionPlannerOnTheClient = vi.fn().mockResolvedValue({});
+            const transactionPlanExecutorOnTheClient = vi.fn().mockResolvedValue({});
+            const client = createEmptyClient()
+                .use(transactionPlanner(transactionPlannerOnTheClient))
+                .use(transactionPlanExecutor(transactionPlanExecutorOnTheClient))
+                .use(sendTransactions());
+
+            const overridenTransactionPlanner = vi.fn().mockResolvedValue({});
+            const overridenTransactionPlanExecutor = vi.fn().mockResolvedValue({});
+
+            await client.sendTransactions({} as Instruction, {
+                transactionPlanExecutor: overridenTransactionPlanExecutor,
+                transactionPlanner: overridenTransactionPlanner,
+            });
+            expect(overridenTransactionPlanner).toHaveBeenCalledOnce();
+            expect(overridenTransactionPlanExecutor).toHaveBeenCalledOnce();
+            expect(transactionPlannerOnTheClient).not.toHaveBeenCalledOnce();
+            expect(transactionPlanExecutorOnTheClient).not.toHaveBeenCalledOnce();
+        });
     });
 });

--- a/packages/kit-plugins/README.md
+++ b/packages/kit-plugins/README.md
@@ -33,7 +33,7 @@ const client = createDefaultRpcClient({
     payer,
 });
 
-await client.sendTransactions([myInstruction]);
+await client.sendTransaction([myInstruction]);
 ```
 
 #### Features
@@ -43,7 +43,8 @@ await client.sendTransactions([myInstruction]);
 - `client.payer`: The main payer signer for transactions.
 - `client.transactionPlanner`: Plans instructions into transaction messages.
 - `client.transactionPlanExecutor`: Executes planned transaction messages.
-- `client.sendTransactions`: Sends instructions or instruction plans to the cluster by using the client's transaction planner and executor.
+- `client.sendTransactions`: Sends transaction messages, instructions or instruction plans to the cluster by using the client's transaction planner and executor.
+- `client.sendTransaction`: Same as `client.sendTransactions` but ensuring only a single transaction is sent.
 
 #### Configuration
 
@@ -65,7 +66,7 @@ const client = await createDefaultLocalhostRpcClient();
 
 // Payer is automatically generated and funded
 console.log('Payer address:', client.payer.address);
-await client.sendTransactions([myInstruction]);
+await client.sendTransaction([myInstruction]);
 
 // Request additional funding
 await client.airdrop(client.payer.address, lamports(5_000_000_000n));
@@ -79,7 +80,8 @@ await client.airdrop(client.payer.address, lamports(5_000_000_000n));
 - `client.airdrop`: Function to request SOL from the local faucet.
 - `client.transactionPlanner`: Plans instructions into transaction messages.
 - `client.transactionPlanExecutor`: Executes planned transaction messages.
-- `client.sendTransactions`: Sends instructions or instruction plans to the cluster by using the client's transaction planner and executor.
+- `client.sendTransactions`: Sends transaction messages, instructions or instruction plans to the cluster by using the client's transaction planner and executor.
+- `client.sendTransaction`: Same as `client.sendTransactions` but ensuring only a single transaction is sent.
 
 #### Configuration
 
@@ -101,7 +103,7 @@ client.svm.setAccount(myTestAccount);
 client.svm.addProgramFromFile(myProgramAddress, 'program.so');
 
 // Execute transactions locally
-await client.sendTransactions([myInstruction]);
+await client.sendTransaction([myInstruction]);
 ```
 
 #### Features
@@ -112,7 +114,8 @@ await client.sendTransactions([myInstruction]);
 - `client.airdrop`: Function to request SOL from the LiteSVM instance.
 - `client.transactionPlanner`: Plans instructions into transaction messages.
 - `client.transactionPlanExecutor`: Executes planned transaction messages.
-- `client.sendTransactions`: Sends instructions or instruction plans to the cluster by using the client's transaction planner and executor.
+- `client.sendTransactions`: Sends transaction messages, instructions or instruction plans to the cluster by using the client's transaction planner and executor.
+- `client.sendTransaction`: Same as `client.sendTransactions` but ensuring only a single transaction is sent.
 
 #### Configuration
 

--- a/packages/kit-plugins/src/defaults.ts
+++ b/packages/kit-plugins/src/defaults.ts
@@ -37,7 +37,7 @@ import { localhostRpc, rpc } from '@solana/kit-plugin-rpc';
  * });
  *
  * // Use the client
- * const result = await client.sendTransactions([myInstruction]);
+ * const result = await client.sendTransaction([myInstruction]);
  * ```
  */
 export function createDefaultRpcClient<TClusterUrl extends ClusterUrl>(config: {
@@ -70,7 +70,7 @@ export function createDefaultRpcClient<TClusterUrl extends ClusterUrl>(config: {
  * const client = await createDefaultLocalhostRpcClient();
  *
  * // Use the client
- * const result = await client.sendTransactions([myInstruction]);
+ * const result = await client.sendTransaction([myInstruction]);
  * console.log('Payer address:', client.payer.address);
  * ```
  *
@@ -116,7 +116,7 @@ export function createDefaultLocalhostRpcClient(config: { payer?: TransactionSig
  * client.svm.addProgramFromFile(myProgramAddress, 'program.so');
  *
  * // Use the client
- * const result = await client.sendTransactions([myInstruction]);
+ * const result = await client.sendTransaction([myInstruction]);
  * ```
  *
  * @example

--- a/packages/kit-plugins/test/defaults.test.ts
+++ b/packages/kit-plugins/test/defaults.test.ts
@@ -71,12 +71,13 @@ describe('createDefaultRpcClient', () => {
         expectTypeOf(client.transactionPlanExecutor).toEqualTypeOf<TransactionPlanExecutor>();
     });
 
-    it('it provide a helper function to send transactions', () => {
+    it('it provide helper functions to send transactions', () => {
         const client = createDefaultRpcClient({
             payer: {} as TransactionSigner,
             url: 'https://api.mainnet-beta.solana.com',
         });
         expect(client.sendTransactions).toBeTypeOf('function');
+        expect(client.sendTransaction).toBeTypeOf('function');
     });
 });
 
@@ -147,12 +148,13 @@ describe('createDefaultLocalhostRpcClient', () => {
         expectTypeOf(client.transactionPlanExecutor).toEqualTypeOf<TransactionPlanExecutor>();
     });
 
-    it('it provide a helper function to send transactions', async () => {
+    it('it provide helper functions to send transactions', async () => {
         const airdropFn = vi.fn().mockResolvedValue('MockSignature');
         (airdropFactory as Mock).mockReturnValueOnce(airdropFn);
 
         const client = await createDefaultLocalhostRpcClient();
         expect(client.sendTransactions).toBeTypeOf('function');
+        expect(client.sendTransaction).toBeTypeOf('function');
     });
 });
 
@@ -199,8 +201,9 @@ describe('createDefaultLiteSVMClient', () => {
         expectTypeOf(client.transactionPlanExecutor).toEqualTypeOf<TransactionPlanExecutor>();
     });
 
-    it('it provide a helper function to send transactions', async () => {
+    it('it provide helper functions to send transactions', async () => {
         const client = await createDefaultLiteSVMClient();
         expect(client.sendTransactions).toBeTypeOf('function');
+        expect(client.sendTransaction).toBeTypeOf('function');
     });
 });


### PR DESCRIPTION
This PR adds a new `client.sendTransaction` helper in the `sendTransactions` plugin.

This helper ensures only a single transaction is executed, regardless of the instruction plan or instruction array provided. Should these instructions not fit in a single transaction, an error will be thrown before trying to execute it.

Note that I prematurely updated the README and docblocks to also mention the transaction message input so that I didn't have to revamp the documentation every five minutes but this change will be implemented in the next PRs of this stack.