### PR TITLE
Replace airdrop function with new `ClientWithAirdrop` interface

### DIFF
--- a/.changeset/vast-bottles-rescue.md
+++ b/.changeset/vast-bottles-rescue.md
@@ -1,0 +1,16 @@
+---
+'@solana/kit-plugin-airdrop': minor
+'@solana/kit-plugin-payer': minor
+'@solana/kit-plugins': minor
+---
+
+Replace the `AirdropFunction` type with the `ClientWithAirdrop` interface from `@solana/kit`. The airdrop plugin now returns `ClientWithAirdrop & T` instead of `T & { airdrop: AirdropFunction }`, and the payer plugin uses `ClientWithAirdrop` directly from `@solana/kit` instead of importing `AirdropFunction` from `@solana/kit-plugin-airdrop`.
+
+**BREAKING CHANGES**
+
+**`AirdropFunction` type removed from `@solana/kit-plugin-airdrop`.** Use `ClientWithAirdrop` from `@solana/kit` instead.
+
+```diff
+- import type { AirdropFunction } from '@solana/kit-plugin-airdrop';
++ import type { ClientWithAirdrop } from '@solana/kit';
+```

--- a/packages/kit-plugin-payer/package.json
+++ b/packages/kit-plugin-payer/package.json
@@ -48,9 +48,6 @@
     "peerDependencies": {
         "@solana/kit": "^6.1.0"
     },
-    "dependencies": {
-        "@solana/kit-plugin-airdrop": "workspace:*"
-    },
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/packages/kit-plugin-payer/src/index.ts
+++ b/packages/kit-plugin-payer/src/index.ts
@@ -1,7 +1,12 @@
 import { readFileSync } from 'node:fs';
 
-import { createKeyPairSignerFromBytes, generateKeyPairSigner, Lamports, TransactionSigner } from '@solana/kit';
-import type { AirdropFunction } from '@solana/kit-plugin-airdrop';
+import {
+    ClientWithAirdrop,
+    createKeyPairSignerFromBytes,
+    generateKeyPairSigner,
+    Lamports,
+    TransactionSigner,
+} from '@solana/kit';
 
 /**
  * Sets the provided `TransactionSigner` as the `payer` property on the client.
@@ -68,7 +73,7 @@ export function generatedPayer() {
  */
 export function generatedPayerWithSol(amount: Lamports) {
     const generatedPayerPlugin = generatedPayer();
-    return async <T extends { airdrop: AirdropFunction }>(client: T) => {
+    return async <T extends ClientWithAirdrop>(client: T) => {
         const clientWithPayer = await generatedPayerPlugin<T>(client);
         if (!clientWithPayer.airdrop) {
             throw new Error('generatedPayerWithSol requires an airdrop function on the client');

--- a/packages/kit-plugins/src/defaults.ts
+++ b/packages/kit-plugins/src/defaults.ts
@@ -1,11 +1,12 @@
 import {
+    ClientWithAirdrop,
     ClusterUrl,
     createEmptyClient,
     DefaultRpcSubscriptionsChannelConfig,
     lamports,
     TransactionSigner,
 } from '@solana/kit';
-import { airdrop, AirdropFunction } from '@solana/kit-plugin-airdrop';
+import { airdrop } from '@solana/kit-plugin-airdrop';
 import {
     defaultTransactionPlannerAndExecutorFromLitesvm,
     defaultTransactionPlannerAndExecutorFromRpc,
@@ -145,7 +146,7 @@ export function createDefaultLiteSVMClient(config: { payer?: TransactionSigner }
  * otherwise generates a new payer and funds it with 100 SOL.
  */
 function payerOrGeneratedPayer(explicitPayer: TransactionSigner | undefined) {
-    return <T extends { airdrop: AirdropFunction }>(client: T): Promise<T & { payer: TransactionSigner }> => {
+    return <T extends ClientWithAirdrop>(client: T): Promise<T & { payer: TransactionSigner }> => {
         if (explicitPayer) {
             return Promise.resolve(payer(explicitPayer)(client));
         }

--- a/packages/kit-plugins/test/defaults.test.ts
+++ b/packages/kit-plugins/test/defaults.test.ts
@@ -1,5 +1,6 @@
 import {
     airdropFactory,
+    ClientWithAirdrop,
     Rpc,
     RpcSubscriptions,
     SolanaRpcApi,
@@ -11,7 +12,6 @@ import {
 import { beforeEach, describe, expect, expectTypeOf, it, Mock, vi } from 'vitest';
 
 import {
-    AirdropFunction,
     createDefaultLiteSVMClient,
     createDefaultLocalhostRpcClient,
     createDefaultRpcClient,
@@ -106,7 +106,7 @@ describe('createDefaultLocalhostRpcClient', () => {
 
         const client = await createDefaultLocalhostRpcClient();
         expect(client.airdrop).toBeTypeOf('function');
-        expectTypeOf(client.airdrop).toEqualTypeOf<AirdropFunction>();
+        expectTypeOf(client).toMatchObjectType<ClientWithAirdrop>();
     });
 
     it('it generates a new payer with SOL by default', async () => {
@@ -194,7 +194,7 @@ describe('createDefaultLiteSVMClient', () => {
     it('it offers an airdrop function', async () => {
         const client = await createDefaultLiteSVMClient();
         expect(client.airdrop).toBeTypeOf('function');
-        expectTypeOf(client.airdrop).toEqualTypeOf<AirdropFunction>();
+        expectTypeOf(client).toMatchObjectType<ClientWithAirdrop>();
     });
 
     it('it generates a new payer by default', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,9 +133,6 @@ importers:
       '@solana/kit':
         specifier: ^6.1.0
         version: 6.1.0(typescript@5.9.3)
-      '@solana/kit-plugin-airdrop':
-        specifier: workspace:*
-        version: link:../kit-plugin-airdrop
 
   packages/kit-plugin-rpc:
     dependencies:


### PR DESCRIPTION
This PR replaces the temporary `AirdropFunction` type with the new `ClientWithAirdrop` interface from `@solana/plugin-interfaces` also available in `@solana/kit`.

This decouples the `@solana/kit-plugin-payer` package from `@solana/kit-plugin-airdrop`.