### PR TITLE
Add `payerOrGeneratedPayer` plugin to `@solana/kit-plugin-payer`

### DIFF
--- a/.changeset/puny-shirts-walk.md
+++ b/.changeset/puny-shirts-walk.md
@@ -1,0 +1,6 @@
+---
+'@solana/kit-plugin-payer': minor
+'@solana/kit-plugins': minor
+---
+
+Add `payerOrGeneratedPayer` plugin that uses an explicit payer when provided, or generates a new one funded with 100 SOL via airdrop as a fallback.

--- a/packages/kit-plugin-payer/README.md
+++ b/packages/kit-plugin-payer/README.md
@@ -86,6 +86,32 @@ const client = await createEmptyClient()
 
 _See the `payer` plugin for available features_.
 
+## `payerOrGeneratedPayer` plugin
+
+This asynchronous plugin uses the provided `TransactionSigner` as the payer if one is given. Otherwise, it generates a new random `KeyPairSigner`, airdrops 100 SOL to it, and sets it as the `payer` property on the client. This is useful when you want to optionally accept a payer from the caller but fall back to a generated and funded payer for convenience (e.g. in testing or local development).
+
+### Installation
+
+When no explicit payer is given, this plugin requires the `airdrop` plugin to be installed on the client beforehand which itself either requires an RPC connection or a LiteSVM instance.
+
+```ts
+import { createEmptyClient } from '@solana/kit';
+import { airdrop, localhostRpc, payerOrGeneratedPayer } from '@solana/kit-plugins';
+
+// With an explicit payer — no airdrop needed.
+const client = await createEmptyClient().use(payerOrGeneratedPayer(mySigner));
+
+// Without a payer — generates one and airdrops 100 SOL.
+const client = await createEmptyClient()
+    .use(localhostRpc()) // or .use(litesvm())
+    .use(airdrop())
+    .use(payerOrGeneratedPayer(undefined));
+```
+
+### Features
+
+_See the `payer` plugin for available features_.
+
 ## `payerFromFile` plugin
 
 This plugin loads a `KeyPairSigner` from a local file and sets it as the `payer` property on the client.

--- a/packages/kit-plugins/src/defaults.ts
+++ b/packages/kit-plugins/src/defaults.ts
@@ -1,11 +1,4 @@
-import {
-    ClientWithAirdrop,
-    ClusterUrl,
-    createEmptyClient,
-    DefaultRpcSubscriptionsChannelConfig,
-    lamports,
-    TransactionSigner,
-} from '@solana/kit';
+import { ClusterUrl, createEmptyClient, DefaultRpcSubscriptionsChannelConfig, TransactionSigner } from '@solana/kit';
 import { airdrop } from '@solana/kit-plugin-airdrop';
 import {
     defaultTransactionPlannerAndExecutorFromLitesvm,
@@ -13,7 +6,7 @@ import {
     planAndSendTransactions,
 } from '@solana/kit-plugin-instruction-plan';
 import { litesvm } from '@solana/kit-plugin-litesvm';
-import { generatedPayerWithSol, payer } from '@solana/kit-plugin-payer';
+import { payer, payerOrGeneratedPayer } from '@solana/kit-plugin-payer';
 import { localhostRpc, rpc } from '@solana/kit-plugin-rpc';
 
 /**
@@ -139,17 +132,4 @@ export function createDefaultLiteSVMClient(config: { payer?: TransactionSigner }
         .use(payerOrGeneratedPayer(config.payer))
         .use(defaultTransactionPlannerAndExecutorFromLitesvm())
         .use(planAndSendTransactions());
-}
-
-/**
- * Helper function that uses the provided payer if any,
- * otherwise generates a new payer and funds it with 100 SOL.
- */
-function payerOrGeneratedPayer(explicitPayer: TransactionSigner | undefined) {
-    return <T extends ClientWithAirdrop>(client: T): Promise<T & { payer: TransactionSigner }> => {
-        if (explicitPayer) {
-            return Promise.resolve(payer(explicitPayer)(client));
-        }
-        return generatedPayerWithSol(lamports(100_000_000_000n))(client);
-    };
 }


### PR DESCRIPTION
This PR adds a `payerOrGeneratedPayer` plugin to `@solana/kit-plugin-payer` that uses an explicit `TransactionSigner` as the payer when one is provided, or generates a new random `KeyPairSigner` funded with 100 SOL via airdrop as a fallback. This is useful when you want to optionally accept a payer from the caller but fall back to a generated and funded payer for convenience (e.g. in testing or local development).