### PR TITLE
Add contributing guide, agent instructions, and project-level skills

### DIFF
--- a/.claude/skills/changesets/SKILL.md
+++ b/.claude/skills/changesets/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: changesets
+description: Generate a changeset file with a proper changelog entry for package releases
+argument-hint: '<patch|minor|major>'
+disable-model-invocation: true
+allowed-tools: Bash(npx changeset add --empty)
+---
+
+# Generate Changeset
+
+Create a new changeset file for the current project using the changesets CLI, then fill it with a proper changelog entry based on recent changes.
+
+## Arguments
+
+- `$1` (required): The bump level — `patch`, `minor`, or `major`.
+
+## Process
+
+1. **Determine the change source.** Check `git status` for uncommitted changes. If there are meaningful working tree changes, use those. Otherwise, use the latest commit(s) on the current branch (compared to the base branch from `.changeset/config.json`).
+2. **Identify which packages changed.** Look at which files were modified and map them to their nearest `package.json` to determine affected packages. Ignore changes that are not relevant to a changeset — e.g. typo fixes in comments, dependency version bumps in `package.json`, changes to CI config, docs-only changes in non-doc packages, etc. Use your judgement to filter out noise.
+3. **Run `npx changeset add --empty`** to generate a new changeset file with a random name.
+4. **Identify the newly created file** — it will be the most recently created `.md` file in `.changeset/` (excluding `README.md`).
+5. **Write the changeset file** with the proper frontmatter listing each affected package and the bump level, followed by the changelog entry.
+
+## Changeset Format
+
+```
+---
+'<package-a>': $1
+'<package-b>': $1
+---
+
+<concise changelog entry>
+```
+
+## Changelog Guidelines
+
+- Write a concise but informative changelog entry (1-3 sentences).
+- Start with a verb — e.g. "Add", "Remove", "Replace", "Fix", "Update".
+- Focus on what changed from the user's perspective, not implementation details.
+- Mention renamed or removed APIs explicitly.
+
+## Breaking Changes
+
+Add a `**BREAKING CHANGES**` section (bold paragraph, not a header) after the changelog entry when:
+
+- The bump level is `major`, OR
+- The bump level is `minor` AND the current major version is `0` (i.e. pre-1.0)
+
+...and the changes actually introduce breaking changes.
+
+The breaking changes section should list each breaking change with a bold title summarizing the change, followed by a brief explanation and a `diff` code block showing the before/after migration when applicable. For example:
+
+```
+Replace the `useGranularImports` boolean option with a new `kitImportStrategy` option.
+
+**BREAKING CHANGES**
+
+**`useGranularImports` replaced with `kitImportStrategy`.** The boolean option has been replaced with a string union for finer control.
+
+\`\`\`diff
+- renderVisitor('./output', { useGranularImports: true });
++ renderVisitor('./output', { kitImportStrategy: 'granular' });
+\`\`\`
+
+**Default import behavior changed.** The default strategy is now `'preferRoot'`, which falls back to granular packages for symbols not on the root entrypoint.
+
+\`\`\`diff
+- renderVisitor('./output'); // equivalent to useGranularImports: false
++ renderVisitor('./output'); // equivalent to kitImportStrategy: 'preferRoot'
+\`\`\`
+```
+
+Not every breaking change needs a diff — use them when there's a clear before/after code change to show. For type removals or behavioral changes, a text explanation is sufficient.
+
+## Important
+
+- Do NOT modify any existing changeset files.
+- Only create one new changeset file per invocation.

--- a/.claude/skills/docblocks/SKILL.md
+++ b/.claude/skills/docblocks/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: docblocks
+description: Add missing JSDoc docblocks to exported symbols in the repository
+argument-hint: '[path] [--all]'
+---
+
+# Add Missing Docblocks
+
+Scan the specified path (or entire repository if no path given) and add missing docblocks to all exported functions, classes, interfaces, types, and constants.
+
+## Arguments
+
+- `$1` (optional): Path to narrow the scope (e.g. `src/utils` or `packages/kit-plugin-rpc/src`).
+- `$2` (optional): Use `--all` flag to include non-exported items.
+
+## Docblock Style Guidelines
+
+Use JSDoc format with the following conventions:
+
+- Start with `/**` on its own line.
+- Use `*` prefix for each line.
+- End with `*/` on its own line.
+- Keep descriptions concise but complete.
+- Start your sentences with a capital letter and end with a period.
+- Limit your usage of em dashes but, when you do use them, use spaces on both sides.
+- Begin with a clear one or two line summary (no `@summary` tag needed).
+- Add a blank line after the summary if adding more details.
+- Include `@param` tags for all parameters.
+- Include `@typeParam` tags for all type parameters. Use `@typeParam`, not `@template`.
+- Include `@return` tag briefly describing the return value.
+- Add `@throws` for functions that may throw errors and list these errors.
+- Include at least one `@example` section whenever usage examples would be helpful. If the file is a TypeScript file, use TypeScript syntax in examples. Try to make the examples realistic but concise and pleasant to read. They must illustrate the concepts clearly at first glance. When more than one example is preferred, use multiple `@example` tags and keep the first one as simple as possible to illustrate the basic usage. Never use `any` type in examples. Display the `import` statements required for the example to work when imports from multiple libraries are required. It is acceptable to use placeholder variable names like `myUser` or even `/* ... */` for parts that are not relevant to the example. When multiple example sections are provided, add a brief description before each code block to quickly explain what the example illustrates.
+- In the rare case where more advanced documentation is also needed for the item, use the `@remarks` tag to add this extra information after any example sections. These remarks can include longer explanations and even additional code blocks if necessary.
+- When an item is deprecated, include a `@deprecated` tag with a brief explanation and, if applicable, suggest an alternative.
+- Use `{@link ...}` tags to reference other items in the codebase when relevant.
+- Add `@see` tags at the very end when applicable to point to other related items or documentation. Use `@see {@link ...}` format when linking to other code items.
+
+## Examples of Good Docblocks
+
+````ts
+/**
+ * Sets the provided `TransactionSigner` as the `payer` property on the client.
+ *
+ * @param payer - The `TransactionSigner` to set as the payer.
+ *
+ * @example
+ * ```ts
+ * import { createEmptyClient } from '@solana/kit';
+ * import { payer } from '@solana/kit-plugins';
+ *
+ * // Install the payer plugin with your signer.
+ * const client = createEmptyClient().use(payer(mySigner));
+ *
+ * // Use the payer in your client.
+ * console.log(client.payer.address);
+ * setTransactionFeePayerSigner(client.payer, transactionMessage);
+ * ```
+ */
+export function payer(payer: TransactionSigner) {
+    return <T extends object>(client: T) => ({ ...client, payer });
+}
+````
+
+````ts
+/**
+ * Fixes a `Uint8Array` to the specified length.
+ *
+ * If the array is longer than the specified length, it is truncated.
+ * If the array is shorter than the specified length, it is padded with zeroes.
+ *
+ * @param bytes - The byte array to truncate or pad.
+ * @param length - The desired length of the byte array.
+ * @return The byte array truncated or padded to the desired length.
+ *
+ * @example
+ * Truncates the byte array to the desired length.
+ * ```ts
+ * const bytes = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+ * const fixedBytes = fixBytes(bytes, 2);
+ * //    ^ [0x01, 0x02]
+ * ```
+ *
+ * @example
+ * Adds zeroes to the end of the byte array to reach the desired length.
+ * ```ts
+ * const bytes = new Uint8Array([0x01, 0x02]);
+ * const fixedBytes = fixBytes(bytes, 4);
+ * //    ^ [0x01, 0x02, 0x00, 0x00]
+ * ```
+ */
+export const fixBytes = (bytes: ReadonlyUint8Array | Uint8Array, length: number): ReadonlyUint8Array | Uint8Array =>
+    padBytes(bytes.length <= length ? bytes : bytes.slice(0, length), length);
+````
+
+````ts
+/**
+ * A set of instructions with constraints on how they can be executed.
+ *
+ * This is structured as a recursive tree of plans in order to allow for
+ * parallel execution, sequential execution and combinations of both.
+ *
+ * Namely the following plans are supported:
+ * - {@link SingleInstructionPlan} - A plan that contains a single instruction.
+ * - {@link ParallelInstructionPlan} - A plan that contains other plans that
+ *   can be executed in parallel.
+ * - {@link SequentialInstructionPlan} - A plan that contains other plans that
+ *   must be executed sequentially.
+ * - {@link MessagePackerInstructionPlan} - A plan that can dynamically pack
+ *   instructions into transaction messages.
+ *
+ * @example
+ * ```ts
+ * const myInstructionPlan: InstructionPlan = parallelInstructionPlan([
+ *    sequentialInstructionPlan([instructionA, instructionB]),
+ *    instructionC,
+ *    instructionD,
+ * ]);
+ * ```
+ *
+ * @see {@link SingleInstructionPlan}
+ * @see {@link ParallelInstructionPlan}
+ * @see {@link SequentialInstructionPlan}
+ * @see {@link MessagePackerInstructionPlan}
+ */
+export type InstructionPlan =
+    | MessagePackerInstructionPlan
+    | ParallelInstructionPlan
+    | SequentialInstructionPlan
+    | SingleInstructionPlan;
+````
+
+## Process
+
+1. If `$1` is provided, scan only that path; otherwise scan the entire repository.
+2. Look for TypeScript/JavaScript files (`.ts`, `.tsx`, `.js`, `.jsx`).
+3. Identify exported items without docblocks:
+    - `export function`
+    - `export class`
+    - `export interface`
+    - `export type`
+    - `export const` (for constants and arrow functions)
+4. If `$2` equals `--all`, also identify non-exported items.
+5. Do not modify real code outside of docblocks! Do not modify existing docblocks!
+6. For each item missing a docblock:
+    - Analyze the code to understand its purpose (this may span multiple files).
+    - Examine parameters, return types, and behavior.
+    - Generate an appropriate docblock following the style guide.
+7. Present all changes clearly, grouped by file. Apply all changes without requiring further approval.

--- a/.claude/skills/readme/SKILL.md
+++ b/.claude/skills/readme/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: readme
+description: Create or update a README file for a package or the project root
+argument-hint: '[path]'
+disable-model-invocation: true
+---
+
+# Create or Update README
+
+Create a new README or update an existing one for a package, library, or project.
+
+A deep understanding of the project is necessary to create an effective README. Analyze the codebase, key features, and typical usage patterns to inform the content. If the project relies on other libraries or frameworks, consider how those influence usage and installation.
+
+## Arguments
+
+- `$1` (optional): Path to the README file or its directory (e.g. `packages/kit-plugin-rpc` or `packages/kit-plugin-rpc/README.md`). Defaults to the root `README.md` if not provided.
+
+## README Guidelines
+
+Create developer-friendly READMEs. Developers should be excited about installing and using the provided code rather than being overwhelmed by it.
+
+### Structure
+
+The layout of a README will vary from project to project, but they should generally follow these guidelines.
+
+#### 1. Intro Section
+
+- Package/library name as the main heading.
+- Badges for tests, package version, downloads, etc. (npm, GitHub, etc.).
+- **Very brief summary (ELI5)** — A single sentence or short paragraph that anyone can understand at first glance.
+- Only update the intro if you can meaningfully improve the summary; otherwise leave it intact.
+
+#### 2. Installation Section
+
+- Keep it extremely concise (1-2 lines of explanation max if necessary).
+- Show the install command in a code block.
+
+#### 3. Usage Section (Most Critical)
+
+- This is where readers' attention lands first after the intro.
+- Show the **quickest path to success** with this library.
+- **Must include a code snippet** illustrating basic usage.
+- Balance between brevity and clarity to create an "aha moment."
+- Optional: Brief text before/after the snippet if it adds clarity.
+- The code snippet should be realistic, concise, and immediately understandable.
+
+#### 4. Deep Dive Sections
+
+- Structure varies case-by-case based on the project.
+- Document key features, concepts, or use cases.
+- Each section should include **at least one code snippet**. Similar guidelines as the Usage section, that is, realistic and concise (shortest path to "aha moment").
+- Organize logically (e.g. by feature, by use case, by complexity).
+- Common patterns:
+    - **Features**: Individual feature documentation with examples.
+    - **API Reference**: Core APIs or functions.
+    - **Advanced Usage**: More complex scenarios.
+    - **Configuration**: Setup and customization options.
+    - **Examples**: Real-world use cases.
+- No need for a "Requirements" section for peer dependencies. Just mention them in the "Installation" section if necessary to get started.
+
+### Code Snippets
+
+- Use TypeScript syntax for TypeScript projects.
+- Show realistic but concise examples.
+- Include necessary imports when relevant (e.g. when importing from multiple modules).
+- Use descriptive variable names (not `foo`, `bar`).
+- Keep examples focused on one concept at a time when possible.
+- Format for readability (proper indentation, spacing).
+
+### Tone
+
+- Friendly and approachable.
+- Clear and direct.
+- Avoid marketing speak.
+- Focus on practical value.
+- Use active voice.
+- Assume the reader is a developer who wants to get started quickly.
+
+### What to Avoid
+
+- Overly long introductions or preambles.
+- Walls of text without code examples.
+- Complex examples in the Usage section.
+- Unexplained jargon or acronyms.
+- Marketing-heavy language.
+- Duplicating information unnecessarily.
+
+## Monorepo-Specific Guidelines
+
+This project is a monorepo with multiple packages. When working with READMEs:
+
+- **Package READMEs** (`packages/kit-plugin-*/README.md`): Focus on the specific package — its plugins, installation, usage, and features. Each plugin should have its own section with an installation snippet and a features list. Include an installation note pointing to the umbrella package as an alternative.
+- **Root README** (`README.md`): Provides an overview of the entire monorepo, links to individual package READMEs for details. Focus on the quick-start experience and ready-to-use clients rather than deep-diving into each package.
+- **Consistency**: When updating a package README, check other package READMEs for structural consistency (heading levels, section order, code example style).
+
+## Process
+
+1. Determine the target README path:
+    - If `$1` is provided and ends with `.md`, use it directly.
+    - If `$1` is a directory path, use `$1/README.md`.
+    - If `$1` is not provided, use `./README.md`.
+
+2. Check if the README exists:
+    - If it exists, read it to understand the current structure.
+    - If it doesn't exist, prepare to create one from scratch.
+
+3. Analyze the project context:
+    - Examine `package.json` (if exists) for package name, description, dependencies.
+    - Look at the source code to understand what the library does.
+    - Identify key exports, main functions, and typical usage patterns.
+    - Check for existing tests or examples that show usage.
+    - Research any related libraries or frameworks that influence usage.
+    - Examine other package READMEs in the monorepo to ensure consistency in style and structure.
+
+4. Create or update the README:
+    - **For existing READMEs**: Identify missing sections or areas needing improvement.
+    - **For new READMEs**: Build the full structure following the guidelines.
+    - Preserve the intro unless improvements are clear.
+    - Ensure the Usage section has a strong, clear example.
+    - Add or improve deep dive sections as needed.
+    - Include realistic code snippets throughout.
+
+5. Present the complete README for review before applying changes.
+6. Do not update any real code outside of the README file itself! If you identify errors in the codebase, warn the user about them but do not fix them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+# Agent Instructions
+
+You are contributing to **Kit Plugins** (`@solana/kit-plugins`), a plugin library for [Solana Kit](https://github.com/anza-xyz/kit). Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) for full project context including the monorepo structure, available scripts, and code standards.
+
+## Code quality checklist
+
+For every change you make, verify the following before presenting the changes to the user:
+
+- **Docblocks**: All exported symbols (functions, types, interfaces, constants) must have JSDoc docblocks. Use the `/docblocks` skill for the full style guide.
+- **Tests**: New features and bug fixes need tests. Tests use Vitest and run in three environments (Node.js, browser, React Native). Run `pnpm test:unit` in the relevant package directory to verify.
+- **README**: When adding a new public API, add a section to the package's `README.md` following the existing structure. When modifying an existing API, keep the README in sync.
+- **Umbrella package**: The umbrella package (`packages/kit-plugins`) re-exports everything from sub-packages via `export *`. If code in the umbrella (e.g. `defaults.ts`) duplicates logic that now exists in a sub-package, consolidate it by importing from the sub-package instead.
+- **Guidelines**: When adding new packages, renaming public APIs, or changing the monorepo structure, check whether `CLAUDE.md` and `CONTRIBUTING.md` need updates to stay in sync (e.g. package tables, workflow descriptions, naming conventions).
+
+## Shipping protocol
+
+**Never commit, push, create branches, or create PRs without explicit user approval.**
+
+Before any git operation that creates or modifies a commit, present the following to the user as a single review block:
+
+1. **Changeset content** (if applicable) — the full `.changeset/*.md` file contents.
+2. **Commit title** — a concise title for the commit.
+3. **Commit/PR description** — a short description that explains what changed and why.
+
+Wait for the user to approve or request changes before proceeding. This applies to:
+
+- Creating commits or branches.
+- Running `gt create`, `gt modify`, or `git commit`.
+- Creating PRs via `gh pr create` or `gt submit`.
+- Creating or modifying changeset files (present the content for review before writing).
+
+## Git workflow
+
+### Detect the user's tooling
+
+Check if the user is using [Graphite](https://graphite.dev/) by looking for the `gt` CLI (`which gt`). Adapt the workflow accordingly.
+
+### With Graphite (single commit per branch)
+
+When creating a new PR:
+
+```sh
+gt create -am "Commit title" -m "Description body explaining what changed and why."
+```
+
+The first `-m` flag sets the commit title (first line). The second `-m` flag sets the commit body which Graphite uses as the PR description when the stack is submitted. Write the body as a concise flowing summary — avoid excessive blank lines.
+
+When commit titles or descriptions contain backticks (e.g. for package names or code references), escape them with a backslash so the shell passes them through literally: `gt create -am "Align \`kit-plugins\` infrastructure"`.
+
+When amending the current PR with additional changes:
+
+```sh
+gt modify -a
+```
+
+This amends the single commit on the current branch. Since Graphite uses a one-commit-per-branch model, always use `gt modify -a` for follow-up changes on the same PR rather than creating new commits.
+
+### Without Graphite (standard Git)
+
+Use standard `git add` and `git commit` workflows. Follow the same commit message conventions: concise title on the first line, blank line, then the description body.
+
+## Changesets
+
+Any PR that should trigger a package release must include a changeset. Use the `/changesets` skill to generate one, or create it manually following the format in [`CONTRIBUTING.md`](./CONTRIBUTING.md#changesets).
+
+Key rules:
+
+- Identify affected packages by mapping changed files to their nearest `package.json`.
+- Choose the right bump level: `patch` for fixes, `minor` for features, `major` for breaking changes.
+- While the project is pre-1.0, `minor` bumps may be treated as breaking.
+- No changeset needed for: documentation-only changes, CI config, dev dependency updates, test-only changes.
+
+## Available skills
+
+This project includes the following skills in `.claude/skills/`. Use them when relevant:
+
+| Skill      | Invocation                          | Description                                              |
+| ---------- | ----------------------------------- | -------------------------------------------------------- |
+| Changesets | `/changesets <patch\|minor\|major>` | Generate a changeset file with a proper changelog entry. |
+| Docblocks  | `/docblocks [path] [--all]`         | Add missing docblocks to exported symbols.               |
+| README     | `/readme [path]`                    | Create or update a README file.                          |
+
+## CI expectations
+
+Before presenting changes for review, verify locally:
+
+- `pnpm lint` passes (ESLint + Prettier).
+- `pnpm test` passes (type checking + unit tests across all environments).
+- `pnpm build` succeeds and does not produce uncommitted changes in the working tree.
+
+Running these in the relevant package directory (e.g. `pnpm test:unit` in `packages/kit-plugin-payer`) is sufficient for focused changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,153 @@
+# Contributing to Kit Plugins
+
+Thank you for your interest in contributing to Kit Plugins! This guide covers everything you need to get started.
+
+> **AI agents**: See [`CLAUDE.md`](./CLAUDE.md) for agent-specific workflow instructions.
+
+## Project structure
+
+This is a monorepo managed with [pnpm](https://pnpm.io/) and [Turborepo](https://turbo.build/). It contains the following packages:
+
+| Package                                                                         | Description                                                                     |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [`@solana/kit-plugins`](./packages/kit-plugins)                                 | Umbrella package that re-exports all plugins and provides ready-to-use clients. |
+| [`@solana/kit-plugin-rpc`](./packages/kit-plugin-rpc)                           | RPC connection plugins.                                                         |
+| [`@solana/kit-plugin-payer`](./packages/kit-plugin-payer)                       | Transaction fee payer plugins.                                                  |
+| [`@solana/kit-plugin-airdrop`](./packages/kit-plugin-airdrop)                   | SOL airdrop plugin.                                                             |
+| [`@solana/kit-plugin-litesvm`](./packages/kit-plugin-litesvm)                   | LiteSVM support plugin.                                                         |
+| [`@solana/kit-plugin-instruction-plan`](./packages/kit-plugin-instruction-plan) | Transaction planning and execution plugins.                                     |
+
+The umbrella package (`@solana/kit-plugins`) re-exports everything from the individual plugin packages via `export *` statements. When you add a new export to a sub-package, it is automatically available through the umbrella package.
+
+## Getting started
+
+```sh
+# Clone the repository.
+git clone https://github.com/anza-xyz/kit-plugins.git
+cd kit-plugins
+
+# Install dependencies.
+pnpm install
+
+# Build all packages.
+pnpm build
+
+# Run all tests.
+pnpm test
+
+# Run linting.
+pnpm lint
+```
+
+### Useful per-package commands
+
+You can also run commands within individual packages:
+
+```sh
+# Run unit tests for a specific package.
+pnpm test:unit --filter @solana/kit-plugin-payer
+
+# Or navigate to the package directory.
+cd packages/kit-plugin-payer
+pnpm test:unit   # Unit tests only.
+pnpm test:types  # Type checking only.
+pnpm build       # Build only this package.
+pnpm lint        # Lint only this package.
+```
+
+## Code standards
+
+### Docblocks
+
+All exported symbols (functions, types, interfaces, constants) must have JSDoc docblocks. Follow these key conventions:
+
+- Start with a concise one or two line summary.
+- Include `@param` tags for all parameters and `@returns` for return values.
+- Include at least one `@example` section with realistic, concise TypeScript code.
+- Use `{@link ...}` to reference related items and `@see` for related documentation.
+
+For the full style guide with examples, see [`.claude/skills/docblocks/SKILL.md`](./.claude/skills/docblocks/SKILL.md).
+
+### Tests
+
+Every new feature or bug fix should include tests. This project uses [Vitest](https://vitest.dev/) and runs tests across three environments: **Node.js**, **browser**, and **React Native**.
+
+- Write tests in `test/` within the relevant package.
+- Use `vi.fn()` for mocks, `expectTypeOf` for type assertions.
+- Run `pnpm test:unit` in the package directory to verify.
+
+### README
+
+When adding a new public API to a package, update that package's `README.md` with a new section following the existing structure (description, installation example, features). When modifying an existing API, keep the README in sync. See the existing READMEs for the expected format, or use the [`.claude/skills/readme/SKILL.md`](./.claude/skills/readme/SKILL.md) guide.
+
+### Umbrella package
+
+When modifying exports in a sub-package, check whether the umbrella package (`packages/kit-plugins`) needs updates. The `export *` re-exports are automatic, but if code in the umbrella package (e.g. `defaults.ts`) duplicates logic that now exists in a sub-package, consolidate it.
+
+## Pull request workflow
+
+This project uses [Graphite](https://graphite.dev/) for stacked PRs with a **single commit per branch** model. If you are not using Graphite, standard Git workflows are fine.
+
+### Graphite workflow
+
+```sh
+# Create a new PR (single commit).
+gt create -am "Commit title"
+
+# Amend the current PR with new changes.
+gt modify -a
+
+# Submit the stack for review.
+gt submit
+```
+
+The commit message body is used as the PR description by Graphite, so write it as a concise summary that explains what changed and why. Keep it as a single flowing paragraph or short list — avoid excessive blank lines.
+
+### PR description guidelines
+
+- Explain the changes in a few concise sentences focused on what matters to a reviewer.
+- Don't get creative with headers — use them sparingly and only when the PR has clearly distinct sections.
+- Include code examples when they genuinely clarify the change or illustrate a new API feature usage. Not all PRs need them.
+- Don't repeat the full changeset content — the PR description should complement it, not duplicate it.
+
+## Changesets
+
+Any PR that should trigger a new package release must include a [changeset](https://github.com/changesets/changesets). Changesets live in `.changeset/` and describe which packages are affected and at what bump level.
+
+### When to add a changeset
+
+- **New feature**: `minor` bump (or `patch` for small additions).
+- **Bug fix**: `patch` bump.
+- **Breaking change**: `major` bump. Note that while the project is pre-1.0, `minor` bumps are treated as breaking.
+- **No changeset needed**: Documentation-only changes, CI config, dev dependency updates, test-only changes.
+
+### Changeset format
+
+```md
+---
+'@solana/kit-plugin-payer': minor
+'@solana/kit-plugins': minor
+---
+
+Add `payerOrGeneratedPayer` plugin that uses an explicit payer when provided, or generates a new one funded with 100 SOL via airdrop as a fallback.
+```
+
+### Changelog guidelines
+
+- Write 1-3 concise sentences.
+- Start with a verb: "Add", "Remove", "Replace", "Fix", "Update".
+- Focus on what changed from the user's perspective.
+- Mention renamed or removed APIs explicitly.
+- For breaking changes, add a `**BREAKING CHANGES**` section with migration instructions.
+
+For the full changeset guide, see [`.claude/skills/changesets/SKILL.md`](./.claude/skills/changesets/SKILL.md).
+
+## CI
+
+The CI pipeline runs on every pull request and checks:
+
+1. **Linting** (`pnpm lint`) — ESLint and Prettier.
+2. **Tests** (`pnpm test`) — Type checking, tree-shakability, and unit tests across all environments.
+3. **Clean working directory** — Build artifacts must not produce uncommitted changes.
+
+Merging to `main` with a changeset triggers an automated release via the [changesets GitHub action](https://github.com/changesets/action).


### PR DESCRIPTION
This PR adds a CONTRIBUTING.md for human contributors and a CLAUDE.md with agent-specific workflow instructions (code quality checklist, shipping protocol, Graphite workflow, changeset rules). It also adds three project-level skills (.claude/skills/) for changesets, docblocks, and README generation — adapted from personal slash commands to be available to any contributor who clones the repo.