### PR TITLE
Fix node:fs side-effect import leaking into non-Node builds

### DIFF
--- a/.changeset/dry-foxes-rule.md
+++ b/.changeset/dry-foxes-rule.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-payer': patch
+---
+
+Fixed `node:fs` side-effect import leaking into browser and React Native builds

--- a/tsup.config.base.ts
+++ b/tsup.config.base.ts
@@ -47,7 +47,14 @@ export function getBuildConfig(options: BuildOptions): TsupConfig {
         publicDir: true,
         pure: ['process'],
         sourcemap: format !== 'iife',
-        treeshake: true,
+        treeshake: {
+            moduleSideEffects: id => {
+                // This prevents tsup/Rollup from keeping bare `import 'fs'` in browser/RN builds.
+                // @see https://github.com/anza-xyz/kit-plugins/pull/95
+                const bare = id.startsWith('node:') ? id.slice(5) : id;
+                return !['fs', 'path'].includes(bare);
+            },
+        },
     };
 }
 


### PR DESCRIPTION
This PR fixes a bug where `import 'fs'` was present in the browser and React Native build outputs of `@solana/kit-plugin-payer`, even though `payerFromFile` is guarded by `__NODEJS__` and its body is dead-code-eliminated. The root cause: tsup's esbuild stage removes the `readFileSync` binding but converts the import to a bare side-effect import (`import 'fs'`). The subsequent Rollup tree-shaking stage preserves it because it assumes all modules have side effects by default. The fix sets the `treeshake` option in the shared tsup config to a Rollup options object with a `moduleSideEffects` callback that returns `false` for `fs` and `path` modules, allowing Rollup to drop the import when no bindings are used.