### PR TITLE
Align kit-plugins package infrastructure with sub-packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
         "@solana/prettier-config-solana": "0.0.6",
         "@types/node": "^25",
         "agadoo": "^3.0.0",
-        "browserslist-to-esbuild": "^2.1.1",
         "eslint": "^9.39.2",
         "happy-dom": "^20.7.0",
         "prettier": "^3.8.1",

--- a/packages/kit-plugins/package.json
+++ b/packages/kit-plugins/package.json
@@ -18,9 +18,6 @@
         "./dist/index.node.cjs": "./dist/index.browser.cjs",
         "./dist/index.node.mjs": "./dist/index.browser.mjs"
     },
-    "jsdelivr": "./dist/index.production.min.js",
-    "umd": "./dist/index.production.min.js",
-    "unpkg": "./dist/index.production.min.js",
     "main": "./dist/index.node.cjs",
     "module": "./dist/index.node.mjs",
     "react-native": "./dist/index.react-native.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       agadoo:
         specifier: ^3.0.0
         version: 3.0.0
-      browserslist-to-esbuild:
-        specifier: ^2.1.1
-        version: 2.1.1(browserslist@4.28.1)
       eslint:
         specifier: ^9.39.2
         version: 9.39.2
@@ -1940,13 +1937,6 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist-to-esbuild@2.1.1:
-    resolution: {integrity: sha512-KN+mty6C3e9AN8Z5dI1xeN15ExcRNeISoC3g7V0Kax/MMF9MSoYA2G7lkTTcVUFntiEjkpI0HNgqJC1NjdyNUw==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      browserslist: '*'
-
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -2745,10 +2735,6 @@ packages:
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
-
-  meow@13.2.0:
-    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
-    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -5499,11 +5485,6 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist-to-esbuild@2.1.1(browserslist@4.28.1):
-    dependencies:
-      browserslist: 4.28.1
-      meow: 13.2.0
-
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.10.0
@@ -6470,8 +6451,6 @@ snapshots:
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
-
-  meow@13.2.0: {}
 
   merge-stream@2.0.0: {}
 


### PR DESCRIPTION
This PR removes unused IIFE build infrastructure from the umbrella package and shared tsup config. The jsdelivr, umd, and unpkg fields in @solana/kit-plugins's package.json pointed to dist/index.production.min.js, a file that was never produced since no build config included the iife format. The corresponding dead IIFE plumbing in the shared tsup base config (browserslist targets, minification branch, iife output extension, conditional sourcemaps) and the browserslist-to-esbuild dev dependency are also removed. The umbrella package's package.json now matches the sub-packages exactly.