### PR TITLE
Simplify client factory export names

### DIFF
--- a/.changeset/rare-baboons-carry.md
+++ b/.changeset/rare-baboons-carry.md
@@ -1,0 +1,7 @@
+---
+'@solana/kit-client-rpc': minor
+'@solana/kit-client-litesvm': minor
+'@solana/kit-plugins': patch
+---
+
+Simplify client factory names to leverage package namespacing: `createDefaultRpcClient` → `createClient`, `createDefaultLocalhostRpcClient` → `createLocalClient` in `@solana/kit-client-rpc`, and `createDefaultLiteSVMClient` → `createClient` in `@solana/kit-client-litesvm`. The umbrella `@solana/kit-plugins` continues to re-export the old names as deprecated aliases.

--- a/packages/kit-client-litesvm/README.md
+++ b/packages/kit-client-litesvm/README.md
@@ -18,14 +18,14 @@ This package provides a pre-configured LiteSVM client for Solana Kit. It bundles
 pnpm install @solana/kit-client-litesvm
 ```
 
-## `createDefaultLiteSVMClient`
+## `createClient`
 
 Pre-configured client using LiteSVM for testing without an RPC connection.
 
 ```ts
-import { createDefaultLiteSVMClient } from '@solana/kit-client-litesvm';
+import { createClient } from '@solana/kit-client-litesvm';
 
-const client = await createDefaultLiteSVMClient();
+const client = await createClient();
 
 // Set up test environment
 client.svm.setAccount(myTestAccount);

--- a/packages/kit-client-litesvm/src/index.browser.ts
+++ b/packages/kit-client-litesvm/src/index.browser.ts
@@ -6,9 +6,9 @@ import { TransactionSigner } from '@solana/kit';
  * @throws Always throws in browser and React Native environments because LiteSVM
  * relies on Node.js APIs.
  */
-export function createDefaultLiteSVMClient(_config?: { payer?: TransactionSigner }): never {
+export function createClient(_config?: { payer?: TransactionSigner }): never {
     throw new Error(
-        'The `createDefaultLiteSVMClient` function is unavailable in browser and react-native. ' +
+        'The LiteSVM `createClient` function is unavailable in browser and react-native. ' +
             'Use this function in a node environment instead.',
     );
 }

--- a/packages/kit-client-litesvm/src/index.ts
+++ b/packages/kit-client-litesvm/src/index.ts
@@ -20,10 +20,10 @@ import { payerOrGeneratedPayer } from '@solana/kit-plugin-payer';
  *
  * @example
  * ```ts
- * import { createDefaultLiteSVMClient } from '@solana/kit-client-litesvm';
+ * import { createClient } from '@solana/kit-client-litesvm';
  *
  * // Creates a client with auto-generated and funded payer
- * const client = await createDefaultLiteSVMClient();
+ * const client = await createClient();
  *
  * // Set up accounts and programs
  * client.svm.setAccount(myAccount);
@@ -36,14 +36,14 @@ import { payerOrGeneratedPayer } from '@solana/kit-plugin-payer';
  * @example
  * Using a custom payer.
  * ```ts
- * import { createDefaultLiteSVMClient } from '@solana/kit-client-litesvm';
+ * import { createClient } from '@solana/kit-client-litesvm';
  * import { generateKeyPairSigner } from '@solana/kit';
  *
  * const customPayer = await generateKeyPairSigner();
- * const client = await createDefaultLiteSVMClient({ payer: customPayer });
+ * const client = await createClient({ payer: customPayer });
  * ```
  */
-export function createDefaultLiteSVMClient(config: { payer?: TransactionSigner } = {}) {
+export function createClient(config: { payer?: TransactionSigner } = {}) {
     return createEmptyClient()
         .use(litesvm())
         .use(airdrop())

--- a/packages/kit-client-litesvm/test/index.test.ts
+++ b/packages/kit-client-litesvm/test/index.test.ts
@@ -3,64 +3,64 @@ import type { LiteSVM } from '@solana/kit-plugin-litesvm';
 import type { RpcFromLiteSVM } from '@solana/kit-plugin-litesvm';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import { createDefaultLiteSVMClient as nodeCreateDefaultLiteSVMClient } from '../src/index';
-import { createDefaultLiteSVMClient as browserCreateDefaultLiteSVMClient } from '../src/index.browser';
-const createDefaultLiteSVMClient = __NODEJS__ ? nodeCreateDefaultLiteSVMClient : browserCreateDefaultLiteSVMClient;
+import { createClient as nodeCreateClient } from '../src/index';
+import { createClient as browserCreateClient } from '../src/index.browser';
+const createClient = __NODEJS__ ? nodeCreateClient : browserCreateClient;
 
-describe('createDefaultLiteSVMClient', () => {
+describe('createClient', () => {
     if (!__NODEJS__) {
         it('it throws in browser builds', () => {
-            expect(() => createDefaultLiteSVMClient()).toThrow(
-                'The `createDefaultLiteSVMClient` function is unavailable in browser and react-native',
+            expect(() => createClient()).toThrow(
+                'The LiteSVM `createClient` function is unavailable in browser and react-native',
             );
         });
         return;
     }
 
     it('it offers a LiteSVM instance', async () => {
-        const client = await createDefaultLiteSVMClient();
+        const client = await createClient();
         expect(client.svm).toBeTypeOf('object');
         expectTypeOf(client.svm).toEqualTypeOf<LiteSVM>();
     });
 
     it('it offers an RPC subset', async () => {
-        const client = await createDefaultLiteSVMClient();
+        const client = await createClient();
         expect(client.rpc).toBeTypeOf('object');
         expectTypeOf(client.rpc).toEqualTypeOf<RpcFromLiteSVM>();
     });
 
     it('it offers an airdrop function', async () => {
-        const client = await createDefaultLiteSVMClient();
+        const client = await createClient();
         expect(client.airdrop).toBeTypeOf('function');
         expectTypeOf(client).toMatchObjectType<ClientWithAirdrop>();
     });
 
     it('it generates a new payer by default', async () => {
-        const client = await createDefaultLiteSVMClient();
+        const client = await createClient();
         expect(client.payer).toBeTypeOf('object');
         expectTypeOf(client.payer).toEqualTypeOf<TransactionSigner>();
     });
 
     it('it uses the provided payer', async () => {
         const payer = {} as TransactionSigner;
-        const client = await createDefaultLiteSVMClient({ payer });
+        const client = await createClient({ payer });
         expect(client.payer).toBe(payer);
     });
 
     it('it offers a default transaction planner', async () => {
-        const client = await createDefaultLiteSVMClient();
+        const client = await createClient();
         expect(client.transactionPlanner).toBeTypeOf('function');
         expectTypeOf(client.transactionPlanner).toEqualTypeOf<TransactionPlanner>();
     });
 
     it('it offers a default transaction plan executor', async () => {
-        const client = await createDefaultLiteSVMClient();
+        const client = await createClient();
         expect(client.transactionPlanExecutor).toBeTypeOf('function');
         expectTypeOf(client.transactionPlanExecutor).toEqualTypeOf<TransactionPlanExecutor>();
     });
 
     it('it provide helper functions to send transactions', async () => {
-        const client = await createDefaultLiteSVMClient();
+        const client = await createClient();
         expect(client.sendTransactions).toBeTypeOf('function');
         expect(client.sendTransaction).toBeTypeOf('function');
     });

--- a/packages/kit-client-rpc/README.md
+++ b/packages/kit-client-rpc/README.md
@@ -15,16 +15,16 @@ This package provides pre-configured RPC clients for Solana Kit. It bundles seve
 pnpm install @solana/kit-client-rpc
 ```
 
-## `createDefaultRpcClient`
+## `createClient`
 
 Pre-configured client for production use with real Solana clusters.
 
 ```ts
-import { createDefaultRpcClient } from '@solana/kit-client-rpc';
+import { createClient } from '@solana/kit-client-rpc';
 import { generateKeyPairSigner } from '@solana/kit';
 
 const payer = await generateKeyPairSigner();
-const client = createDefaultRpcClient({
+const client = createClient({
     url: 'https://api.devnet.solana.com',
     payer,
 });
@@ -50,15 +50,15 @@ await client.sendTransaction([myInstruction]);
 | `payer` (required)       | `TransactionSigner`      | Signer used to pay for transaction fees and on-chain account storage.                          |
 | `rpcSubscriptionsConfig` | `RpcSubscriptionsConfig` | Configuration for RPC subscriptions. Use `rpcSubscriptionsConfig.url` to specify its endpoint. |
 
-## `createDefaultLocalhostRpcClient`
+## `createLocalClient`
 
 Pre-configured client for localhost development with automatic payer funding.
 
 ```ts
-import { createDefaultLocalhostRpcClient } from '@solana/kit-client-rpc';
+import { createLocalClient } from '@solana/kit-client-rpc';
 import { lamports } from '@solana/kit';
 
-const client = await createDefaultLocalhostRpcClient();
+const client = await createLocalClient();
 
 // Payer is automatically generated and funded
 console.log('Payer address:', client.payer.address);

--- a/packages/kit-client-rpc/src/index.ts
+++ b/packages/kit-client-rpc/src/index.ts
@@ -19,11 +19,11 @@ import { localhostRpc, rpc } from '@solana/kit-plugin-rpc';
  *
  * @example
  * ```ts
- * import { createDefaultRpcClient } from '@solana/kit-client-rpc';
+ * import { createClient } from '@solana/kit-client-rpc';
  * import { generateKeyPairSigner } from '@solana/kit';
  *
  * const payer = await generateKeyPairSigner();
- * const client = createDefaultRpcClient({
+ * const client = createClient({
  *   url: 'https://api.mainnet-beta.solana.com',
  *   payer,
  * });
@@ -32,7 +32,7 @@ import { localhostRpc, rpc } from '@solana/kit-plugin-rpc';
  * const result = await client.sendTransaction([myInstruction]);
  * ```
  */
-export function createDefaultRpcClient<TClusterUrl extends ClusterUrl>(config: {
+export function createClient<TClusterUrl extends ClusterUrl>(config: {
     payer: TransactionSigner;
     rpcSubscriptionsConfig?: DefaultRpcSubscriptionsChannelConfig<TClusterUrl>;
     url: TClusterUrl;
@@ -56,10 +56,10 @@ export function createDefaultRpcClient<TClusterUrl extends ClusterUrl>(config: {
  *
  * @example
  * ```ts
- * import { createDefaultLocalhostRpcClient } from '@solana/kit-client-rpc';
+ * import { createLocalClient } from '@solana/kit-client-rpc';
  *
  * // Creates a client with auto-generated and funded payer
- * const client = await createDefaultLocalhostRpcClient();
+ * const client = await createLocalClient();
  *
  * // Use the client
  * const result = await client.sendTransaction([myInstruction]);
@@ -69,14 +69,14 @@ export function createDefaultRpcClient<TClusterUrl extends ClusterUrl>(config: {
  * @example
  * Using a custom payer.
  * ```ts
- * import { createDefaultLocalhostRpcClient } from '@solana/kit-client-rpc';
+ * import { createLocalClient } from '@solana/kit-client-rpc';
  * import { generateKeyPairSigner } from '@solana/kit';
  *
  * const customPayer = await generateKeyPairSigner();
- * const client = await createDefaultLocalhostRpcClient({ payer: customPayer });
+ * const client = await createLocalClient({ payer: customPayer });
  * ```
  */
-export function createDefaultLocalhostRpcClient(
+export function createLocalClient(
     config: { payer?: TransactionSigner; rpcSubscriptionsConfig?: { url: string }; url?: string } = {},
 ) {
     return createEmptyClient()

--- a/packages/kit-client-rpc/test/index.test.ts
+++ b/packages/kit-client-rpc/test/index.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@solana/kit';
 import { beforeEach, describe, expect, expectTypeOf, it, Mock, vi } from 'vitest';
 
-import { createDefaultLocalhostRpcClient, createDefaultRpcClient } from '../src';
+import { createClient, createLocalClient } from '../src';
 
 vi.mock('@solana/kit', async () => {
     const actual = await vi.importActual('@solana/kit');
@@ -22,9 +22,9 @@ beforeEach(() => {
     vi.clearAllMocks();
 });
 
-describe('createDefaultRpcClient', () => {
+describe('createClient', () => {
     it('it offers an RPC client', () => {
-        const client = createDefaultRpcClient({
+        const client = createClient({
             payer: {} as TransactionSigner,
             url: 'https://api.mainnet-beta.solana.com',
         });
@@ -33,7 +33,7 @@ describe('createDefaultRpcClient', () => {
     });
 
     it('it offers an RPC Subscriptions client', () => {
-        const client = createDefaultRpcClient({
+        const client = createClient({
             payer: {} as TransactionSigner,
             url: 'https://api.mainnet-beta.solana.com',
         });
@@ -43,12 +43,12 @@ describe('createDefaultRpcClient', () => {
 
     it('it uses the provided payer', () => {
         const payer = {} as TransactionSigner;
-        const client = createDefaultRpcClient({ payer, url: 'https://api.mainnet-beta.solana.com' });
+        const client = createClient({ payer, url: 'https://api.mainnet-beta.solana.com' });
         expect(client.payer).toBe(payer);
     });
 
     it('it offers a default transaction planner', () => {
-        const client = createDefaultRpcClient({
+        const client = createClient({
             payer: {} as TransactionSigner,
             url: 'https://api.mainnet-beta.solana.com',
         });
@@ -57,7 +57,7 @@ describe('createDefaultRpcClient', () => {
     });
 
     it('it offers a default transaction plan executor', () => {
-        const client = createDefaultRpcClient({
+        const client = createClient({
             payer: {} as TransactionSigner,
             url: 'https://api.mainnet-beta.solana.com',
         });
@@ -66,7 +66,7 @@ describe('createDefaultRpcClient', () => {
     });
 
     it('it provide helper functions to send transactions', () => {
-        const client = createDefaultRpcClient({
+        const client = createClient({
             payer: {} as TransactionSigner,
             url: 'https://api.mainnet-beta.solana.com',
         });
@@ -75,12 +75,12 @@ describe('createDefaultRpcClient', () => {
     });
 });
 
-describe('createDefaultLocalhostRpcClient', () => {
+describe('createLocalClient', () => {
     it('it offers an RPC client', async () => {
         const airdropFn = vi.fn().mockResolvedValue('MockSignature');
         (airdropFactory as Mock).mockReturnValueOnce(airdropFn);
 
-        const client = await createDefaultLocalhostRpcClient();
+        const client = await createLocalClient();
         expect(client.rpc).toBeTypeOf('object');
         expectTypeOf(client.rpc).toEqualTypeOf<Rpc<SolanaRpcApi>>();
     });
@@ -89,7 +89,7 @@ describe('createDefaultLocalhostRpcClient', () => {
         const airdropFn = vi.fn().mockResolvedValue('MockSignature');
         (airdropFactory as Mock).mockReturnValueOnce(airdropFn);
 
-        const client = await createDefaultLocalhostRpcClient();
+        const client = await createLocalClient();
         expect(client.rpcSubscriptions).toBeTypeOf('object');
         expectTypeOf(client.rpcSubscriptions).toEqualTypeOf<RpcSubscriptions<SolanaRpcSubscriptionsApi>>();
     });
@@ -98,7 +98,7 @@ describe('createDefaultLocalhostRpcClient', () => {
         const airdropFn = vi.fn().mockResolvedValue('MockSignature');
         (airdropFactory as Mock).mockReturnValueOnce(airdropFn);
 
-        const client = await createDefaultLocalhostRpcClient();
+        const client = await createLocalClient();
         expect(client.airdrop).toBeTypeOf('function');
         expectTypeOf(client).toMatchObjectType<ClientWithAirdrop>();
     });
@@ -107,7 +107,7 @@ describe('createDefaultLocalhostRpcClient', () => {
         const airdropFn = vi.fn().mockResolvedValue('MockSignature');
         (airdropFactory as Mock).mockReturnValueOnce(airdropFn);
 
-        const client = await createDefaultLocalhostRpcClient();
+        const client = await createLocalClient();
         expect(client.payer).toBeTypeOf('object');
         expectTypeOf(client.payer).toEqualTypeOf<TransactionSigner>();
 
@@ -120,7 +120,7 @@ describe('createDefaultLocalhostRpcClient', () => {
 
     it('it uses the provided payer', async () => {
         const payer = {} as TransactionSigner;
-        const client = await createDefaultLocalhostRpcClient({ payer });
+        const client = await createLocalClient({ payer });
         expect(client.payer).toBe(payer);
     });
 
@@ -128,7 +128,7 @@ describe('createDefaultLocalhostRpcClient', () => {
         const airdropFn = vi.fn().mockResolvedValue('MockSignature');
         (airdropFactory as Mock).mockReturnValueOnce(airdropFn);
 
-        const client = await createDefaultLocalhostRpcClient();
+        const client = await createLocalClient();
         expect(client.transactionPlanner).toBeTypeOf('function');
         expectTypeOf(client.transactionPlanner).toEqualTypeOf<TransactionPlanner>();
     });
@@ -137,7 +137,7 @@ describe('createDefaultLocalhostRpcClient', () => {
         const airdropFn = vi.fn().mockResolvedValue('MockSignature');
         (airdropFactory as Mock).mockReturnValueOnce(airdropFn);
 
-        const client = await createDefaultLocalhostRpcClient();
+        const client = await createLocalClient();
         expect(client.transactionPlanExecutor).toBeTypeOf('function');
         expectTypeOf(client.transactionPlanExecutor).toEqualTypeOf<TransactionPlanExecutor>();
     });
@@ -146,7 +146,7 @@ describe('createDefaultLocalhostRpcClient', () => {
         const airdropFn = vi.fn().mockResolvedValue('MockSignature');
         (airdropFactory as Mock).mockReturnValueOnce(airdropFn);
 
-        const client = await createDefaultLocalhostRpcClient();
+        const client = await createLocalClient();
         expect(client.sendTransactions).toBeTypeOf('function');
         expect(client.sendTransaction).toBeTypeOf('function');
     });
@@ -155,7 +155,7 @@ describe('createDefaultLocalhostRpcClient', () => {
         const airdropFn = vi.fn().mockResolvedValue('MockSignature');
         (airdropFactory as Mock).mockReturnValueOnce(airdropFn);
 
-        const client = await createDefaultLocalhostRpcClient({
+        const client = await createLocalClient({
             rpcSubscriptionsConfig: { url: 'ws://host.docker.internal:8900' },
             url: 'http://host.docker.internal:8899',
         });

--- a/packages/kit-plugins/README.md
+++ b/packages/kit-plugins/README.md
@@ -20,11 +20,11 @@ pnpm install @solana/kit-plugins
 > [!WARNING]
 > The default client factories have moved to dedicated packages. The re-exports below are deprecated and will be removed in a future release.
 >
-> | Function                          | New package                                           |
-> | --------------------------------- | ----------------------------------------------------- |
-> | `createDefaultRpcClient`          | [`@solana/kit-client-rpc`](../kit-client-rpc)         |
-> | `createDefaultLocalhostRpcClient` | [`@solana/kit-client-rpc`](../kit-client-rpc)         |
-> | `createDefaultLiteSVMClient`      | [`@solana/kit-client-litesvm`](../kit-client-litesvm) |
+> | Deprecated re-export              | Use instead                                                               |
+> | --------------------------------- | ------------------------------------------------------------------------- |
+> | `createDefaultRpcClient`          | `createClient` from [`@solana/kit-client-rpc`](../kit-client-rpc)         |
+> | `createDefaultLocalhostRpcClient` | `createLocalClient` from [`@solana/kit-client-rpc`](../kit-client-rpc)    |
+> | `createDefaultLiteSVMClient`      | `createClient` from [`@solana/kit-client-litesvm`](../kit-client-litesvm) |
 
 ## Individual Plugins
 

--- a/packages/kit-plugins/src/defaults.ts
+++ b/packages/kit-plugins/src/defaults.ts
@@ -1,14 +1,14 @@
 /**
- * @deprecated Use `createDefaultRpcClient` from `@solana/kit-client-rpc` instead.
+ * @deprecated Use `createClient` from `@solana/kit-client-rpc` instead.
  */
-export { createDefaultRpcClient } from '@solana/kit-client-rpc';
+export { createClient as createDefaultRpcClient } from '@solana/kit-client-rpc';
 
 /**
- * @deprecated Use `createDefaultLocalhostRpcClient` from `@solana/kit-client-rpc` instead.
+ * @deprecated Use `createLocalClient` from `@solana/kit-client-rpc` instead.
  */
-export { createDefaultLocalhostRpcClient } from '@solana/kit-client-rpc';
+export { createLocalClient as createDefaultLocalhostRpcClient } from '@solana/kit-client-rpc';
 
 /**
- * @deprecated Use `createDefaultLiteSVMClient` from `@solana/kit-client-litesvm` instead.
+ * @deprecated Use `createClient` from `@solana/kit-client-litesvm` instead.
  */
-export { createDefaultLiteSVMClient } from '@solana/kit-client-litesvm';
+export { createClient as createDefaultLiteSVMClient } from '@solana/kit-client-litesvm';


### PR DESCRIPTION
This PR renames the client factory functions to shorter names that leverage the package namespace: `createClient` and `createLocalClient` in `@solana/kit-client-rpc`, `createClient` in `@solana/kit-client-litesvm`. The umbrella `@solana/kit-plugins` re-exports these under the old names (`createDefaultRpcClient`, `createDefaultLocalhostRpcClient`, `createDefaultLiteSVMClient`) with `@deprecated` tags pointing to the new names and packages.