### PR TITLE
Update examples to import from `kit-client-rpc`

### DIFF
--- a/examples/token-airdrop/package.json
+++ b/examples/token-airdrop/package.json
@@ -5,7 +5,7 @@
         "@solana-program/system": "^0.12.0",
         "@solana-program/token": "^0.11.0",
         "@solana/kit": "^6.1.0",
-        "@solana/kit-plugins": "workspace:*"
+        "@solana/kit-client-rpc": "workspace:*"
     },
     "type": "module",
     "scripts": {

--- a/examples/token-airdrop/src/index.ts
+++ b/examples/token-airdrop/src/index.ts
@@ -6,7 +6,7 @@ import {
     passthroughFailedTransactionPlanExecution,
     sequentialInstructionPlan,
 } from '@solana/kit';
-import { createDefaultLocalhostRpcClient } from '@solana/kit-plugins';
+import { createLocalClient } from '@solana/kit-client-rpc';
 import {
     getSystemErrorMessage,
     isSystemError,
@@ -25,7 +25,7 @@ import {
 // Use `pnpm start --fail` to make the example fail and see error handling
 const shouldFail = process.argv.includes('--fail');
 
-const client = await createDefaultLocalhostRpcClient();
+const client = await createLocalClient();
 const { payer } = client;
 
 // Generate 100 random recipient addresses

--- a/examples/transfer-lamports/package.json
+++ b/examples/transfer-lamports/package.json
@@ -4,7 +4,7 @@
     "dependencies": {
         "@solana-program/system": "^0.12.0",
         "@solana/kit": "^6.1.0",
-        "@solana/kit-plugins": "workspace:*"
+        "@solana/kit-client-rpc": "workspace:*"
     },
     "type": "module",
     "scripts": {

--- a/examples/transfer-lamports/src/index.ts
+++ b/examples/transfer-lamports/src/index.ts
@@ -7,7 +7,7 @@ import {
     SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN,
     type TransactionPlanResult,
 } from '@solana/kit';
-import { createDefaultLocalhostRpcClient } from '@solana/kit-plugins';
+import { createLocalClient } from '@solana/kit-client-rpc';
 import {
     getSystemErrorMessage,
     getTransferSolInstruction,
@@ -19,7 +19,7 @@ import {
 // Use `pnpm start --fail` to make the example fail and see error handling
 const shouldFail = process.argv.includes('--fail');
 
-const client = await createDefaultLocalhostRpcClient();
+const client = await createLocalClient();
 
 // Generate a random recipient address
 const destinationAccountAddress = (await generateKeyPairSigner()).address;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,9 +71,9 @@ importers:
       '@solana/kit':
         specifier: ^6.1.0
         version: 6.1.0(typescript@5.9.3)
-      '@solana/kit-plugins':
+      '@solana/kit-client-rpc':
         specifier: workspace:*
-        version: link:../../packages/kit-plugins
+        version: link:../../packages/kit-client-rpc
 
   examples/transfer-lamports:
     dependencies:
@@ -83,9 +83,9 @@ importers:
       '@solana/kit':
         specifier: ^6.1.0
         version: 6.1.0(typescript@5.9.3)
-      '@solana/kit-plugins':
+      '@solana/kit-client-rpc':
         specifier: workspace:*
-        version: link:../../packages/kit-plugins
+        version: link:../../packages/kit-client-rpc
 
   packages/kit-client-litesvm:
     dependencies:


### PR DESCRIPTION
This PR updates the two example apps to import `createLocalClient` from `@solana/kit-client-rpc` instead of using the deprecated `createDefaultLocalhostRpcClient` from the umbrella package. The dependency in each example's `package.json` is updated accordingly.