### PR TITLE
Add `skipPreflight` option to `defaultTransactionPlannerAndExecutorFromRpc`

### DIFF
--- a/.changeset/public-bags-guess.md
+++ b/.changeset/public-bags-guess.md
@@ -1,0 +1,13 @@
+---
+'@solana/kit-plugin-instruction-plan': minor
+---
+
+Add `skipPreflight` option to `defaultTransactionPlannerAndExecutorFromRpc`
+
+The executor now handles preflight simulation intelligently based on whether compute unit estimation was performed:
+
+- When estimation succeeds, preflight is skipped (avoiding a redundant second simulation).
+- When the transaction has an explicit compute unit limit (no estimation needed), preflight runs as the only simulation.
+- Setting `skipPreflight: true` always skips preflight, and additionally recovers from failed CU estimation simulations by using the consumed units from the failure to set the compute unit limit.
+
+The compute unit estimation logic has been replaced with a direct use of `estimateComputeUnitLimitFactory` and `findSetComputeUnitLimitInstructionIndexAndUnits` from `@solana-program/compute-budget@0.14.0`, giving the executor full control over the estimation-to-send pipeline.

--- a/packages/kit-plugin-instruction-plan/README.md
+++ b/packages/kit-plugin-instruction-plan/README.md
@@ -114,6 +114,7 @@ const client = await createEmptyClient()
 - `maxConcurrency`: Maximum number of concurrent executions (default: 10).
 - `payer`: Transaction signer for fees (defaults to client's payer if any).
 - `priorityFees`: Priority fees in micro lamports per compute unit.
+- `skipPreflight`: Whether to skip the preflight simulation when sending transactions (default: `false`).
 
 ```ts
 const client = await createEmptyClient()
@@ -126,6 +127,21 @@ const client = await createEmptyClient()
         }),
     );
 ```
+
+### Preflight and Compute Unit Estimation
+
+By default, the executor estimates compute units by simulating the transaction before sending it. When estimation is performed, preflight is skipped to avoid a redundant second simulation. When the transaction has an explicit compute unit limit (no estimation needed), preflight runs as the only simulation.
+
+Setting `skipPreflight: true` changes the behavior:
+
+- Preflight is always skipped regardless of whether estimation was performed.
+- If the compute unit estimation simulation fails, the consumed units from the failed simulation are used to set the compute unit limit (with a 10% buffer) so the transaction still reaches the validator. This is useful for debugging failed transactions in an explorer.
+
+| Scenario            | `skipPreflight: false` (default) | `skipPreflight: true`           |
+| ------------------- | -------------------------------- | ------------------------------- |
+| Estimation succeeds | Set CU, skip preflight           | Set CU, skip preflight          |
+| Estimation fails    | Throw                            | Use consumed CU, skip preflight |
+| Explicit CU limit   | Run preflight                    | Skip preflight                  |
 
 ### Features
 


### PR DESCRIPTION
This PR adds a `skipPreflight` option to `defaultTransactionPlannerAndExecutorFromRpc` and fixes the preflight behavior to be context-aware.

Previously, the executor always set `skipPreflight: true` when sending transactions, even when no simulation had been performed (explicit CU limit case), meaning users got no simulation at all. Now, preflight is only skipped when a CU estimation simulation was already performed. When the transaction has an explicit compute unit limit, preflight runs as the only simulation.

Setting `skipPreflight: true` changes the behavior in two ways: preflight is always skipped, and failed CU estimation simulations are recovered from by using the consumed units to set the CU limit — useful for debugging failed transactions in an explorer.

The CU estimation logic is split into two focused helpers — `needsComputeUnitEstimation` and `estimateAndSetComputeUnitLimit` — using `estimateComputeUnitLimitFactory` and `findSetComputeUnitLimitInstructionIndexAndUnits` from `@solana-program/compute-budget@0.14.0`.