### PR TITLE
Adopt `ClientWith*` helper types and replace `RpcFromLiteSVM` with `LiteSvmRpcApi`

### DIFF
--- a/.changeset/sharp-bobcats-turn.md
+++ b/.changeset/sharp-bobcats-turn.md
@@ -1,0 +1,16 @@
+---
+'@solana/kit-plugin-litesvm': minor
+'@solana/kit-plugin-rpc': patch
+'@solana/kit-plugin-payer': patch
+'@solana/kit-client-litesvm': patch
+---
+
+Adopt `ClientWith*` helper types from `@solana/kit` across plugins and replace `RpcFromLiteSVM` with `LiteSvmRpcApi`.
+
+#### Breaking changes
+
+- **`@solana/kit-plugin-litesvm`**: Removed the `RpcFromLiteSVM` type. Use `ClientWithRpc<LiteSvmRpcApi>` from `@solana/kit` with the new `LiteSvmRpcApi` type instead.
+
+#### New features
+
+- **`@solana/kit-plugin-litesvm`**: Added `LiteSvmRpcApi` type representing the RPC API methods available on a LiteSVM-backed client.

--- a/packages/kit-client-litesvm/test/index.test.ts
+++ b/packages/kit-client-litesvm/test/index.test.ts
@@ -1,6 +1,11 @@
-import { ClientWithAirdrop, TransactionPlanExecutor, TransactionPlanner, TransactionSigner } from '@solana/kit';
-import type { LiteSVM } from '@solana/kit-plugin-litesvm';
-import type { RpcFromLiteSVM } from '@solana/kit-plugin-litesvm';
+import {
+    ClientWithAirdrop,
+    ClientWithRpc,
+    TransactionPlanExecutor,
+    TransactionPlanner,
+    TransactionSigner,
+} from '@solana/kit';
+import type { LiteSVM, LiteSvmRpcApi } from '@solana/kit-plugin-litesvm';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { createClient as nodeCreateClient } from '../src/index';
@@ -26,7 +31,7 @@ describe('createClient', () => {
     it('it offers an RPC subset', async () => {
         const client = await createClient();
         expect(client.rpc).toBeTypeOf('object');
-        expectTypeOf(client.rpc).toEqualTypeOf<RpcFromLiteSVM>();
+        expectTypeOf(client).toMatchObjectType<ClientWithRpc<LiteSvmRpcApi>>();
     });
 
     it('it offers an airdrop function', async () => {

--- a/packages/kit-plugin-litesvm/src/index.browser.ts
+++ b/packages/kit-plugin-litesvm/src/index.browser.ts
@@ -1,3 +1,5 @@
+export type { LiteSVM, LiteSvmRpcApi } from './litesvm';
+
 export function litesvm(): <T extends object>(_client: T) => never {
     throw new Error(
         'The `litesvm` plugin is unavailable in browser and react-native. ' +

--- a/packages/kit-plugin-litesvm/src/litesvm.ts
+++ b/packages/kit-plugin-litesvm/src/litesvm.ts
@@ -18,22 +18,24 @@ import {
 export type { LiteSVM } from '@loris-sandbox/litesvm-kit';
 
 /**
- * The RPC subset provided by the LiteSVM plugin.
+ * The RPC API methods available on a LiteSVM-backed client.
  *
- * This type represents a limited RPC interface that only includes
- * the essential operations supported by LiteSVM.
+ * This type represents the subset of Solana RPC methods that
+ * the LiteSVM plugin can serve locally. Use it with
+ * `ClientWithRpc<LiteSvmRpcApi>` to type a client that provides
+ * this RPC interface.
  *
  * @example
  * ```ts
- * import { litesvm, RpcFromLiteSVM } from '@solana/kit-plugin-litesvm';
- * import { createEmptyClient } from '@solana/kit';
+ * import type { LiteSvmRpcApi } from '@solana/kit-plugin-litesvm';
+ * import type { ClientWithRpc } from '@solana/kit';
  *
- * const client = createEmptyClient().use(litesvm());
- * client.rpc satisfies RpcFromLiteSVM;
- * const accountInfo = await client.rpc.getAccountInfo(myAddress).send();
+ * function doSomething(client: ClientWithRpc<LiteSvmRpcApi>) {
+ *     const accountInfo = await client.rpc.getAccountInfo(myAddress).send();
+ * }
  * ```
  */
-export type RpcFromLiteSVM = Rpc<GetAccountInfoApi & GetLatestBlockhashApi & GetMultipleAccountsApi>;
+export type LiteSvmRpcApi = GetAccountInfoApi & GetLatestBlockhashApi & GetMultipleAccountsApi;
 
 /**
  * A Kit plugin that adds LiteSVM functionality to your client.
@@ -69,7 +71,7 @@ export function litesvm() {
 
 type Encoding = 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
 
-function createRpcFromSvm(svm: LiteSVM): RpcFromLiteSVM {
+function createRpcFromSvm(svm: LiteSVM): Rpc<LiteSvmRpcApi> {
     const base64Decoder = getBase64Decoder();
     const convertMaybeEncodedAccount = (
         account: MaybeEncodedAccount,
@@ -99,7 +101,7 @@ function createRpcFromSvm(svm: LiteSVM): RpcFromLiteSVM {
             const response = addresses.map(address => convertMaybeEncodedAccount(svm.getAccount(address)));
             return wrapInPendingRpcRequest(wrapInSolanaRpcResponse(response));
         },
-    } as RpcFromLiteSVM;
+    } as Rpc<LiteSvmRpcApi>;
 }
 
 function wrapInPendingRpcRequest<T>(response: T): PendingRpcRequest<T> {

--- a/packages/kit-plugin-litesvm/src/transaction-planner.ts
+++ b/packages/kit-plugin-litesvm/src/transaction-planner.ts
@@ -1,5 +1,6 @@
 import {
     appendTransactionMessageInstruction,
+    ClientWithPayer,
     createTransactionMessage,
     createTransactionPlanner,
     MicroLamports,
@@ -50,7 +51,7 @@ export function litesvmTransactionPlanner(
         priorityFees?: MicroLamports;
     } = {},
 ) {
-    return <T extends { payer?: TransactionSigner }>(client: T) => {
+    return <T extends Partial<ClientWithPayer>>(client: T) => {
         const payer = config.payer ?? client.payer;
         if (!payer) {
             throw new Error(

--- a/packages/kit-plugin-payer/src/index.ts
+++ b/packages/kit-plugin-payer/src/index.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 
 import {
     ClientWithAirdrop,
+    ClientWithPayer,
     createKeyPairSignerFromBytes,
     generateKeyPairSigner,
     Lamports,
@@ -144,7 +145,7 @@ export function payerFromFile(path: string) {
  * ```
  */
 export function payerOrGeneratedPayer(explicitPayer: TransactionSigner | undefined) {
-    return <T extends ClientWithAirdrop>(client: T): Promise<T & { payer: TransactionSigner }> => {
+    return <T extends ClientWithAirdrop>(client: T): Promise<ClientWithPayer & T> => {
         if (explicitPayer) {
             return Promise.resolve(payer(explicitPayer)(client));
         }

--- a/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
+++ b/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
@@ -1,13 +1,13 @@
 import {
     assertIsTransactionWithBlockhashLifetime,
+    ClientWithRpc,
+    ClientWithRpcSubscriptions,
     createTransactionPlanExecutor,
     GetEpochInfoApi,
     GetLatestBlockhashApi,
     GetSignatureStatusesApi,
     isSolanaError,
     pipe,
-    Rpc,
-    RpcSubscriptions,
     sendAndConfirmTransactionFactory,
     SendTransactionApi,
     setTransactionMessageLifetimeUsingBlockhash,
@@ -77,16 +77,14 @@ export function rpcTransactionPlanExecutor(
     } = {},
 ) {
     return <
-        T extends {
-            rpc: Rpc<
-                GetEpochInfoApi &
-                    GetLatestBlockhashApi &
-                    GetSignatureStatusesApi &
-                    SendTransactionApi &
-                    SimulateTransactionApi
-            >;
-            rpcSubscriptions: RpcSubscriptions<SignatureNotificationsApi & SlotNotificationsApi>;
-        },
+        T extends ClientWithRpc<
+            GetEpochInfoApi &
+                GetLatestBlockhashApi &
+                GetSignatureStatusesApi &
+                SendTransactionApi &
+                SimulateTransactionApi
+        > &
+            ClientWithRpcSubscriptions<SignatureNotificationsApi & SlotNotificationsApi>,
     >(
         client: T,
     ) => {

--- a/packages/kit-plugin-rpc/src/transaction-planner.ts
+++ b/packages/kit-plugin-rpc/src/transaction-planner.ts
@@ -1,5 +1,6 @@
 import {
     appendTransactionMessageInstruction,
+    ClientWithPayer,
     createTransactionMessage,
     createTransactionPlanner,
     MicroLamports,
@@ -50,7 +51,7 @@ export function rpcTransactionPlanner(
         priorityFees?: MicroLamports;
     } = {},
 ) {
-    return <T extends { payer?: TransactionSigner }>(client: T) => {
+    return <T extends Partial<ClientWithPayer>>(client: T) => {
         const payer = config.payer ?? client.payer;
         if (!payer) {
             throw new Error(


### PR DESCRIPTION
This PR adopts the `ClientWith*` helper types from `@solana/plugin-interfaces` across all plugins. Inline client type constraints like `{ payer?: TransactionSigner }` are replaced with `Partial<ClientWithPayer>`, `{ rpc: Rpc<...>; rpcSubscriptions: ... }` with `ClientWithRpc<...> & ClientWithRpcSubscriptions<...>`, and return types like `T & { payer: TransactionSigner }` with `T & ClientWithPayer`. The `RpcFromLiteSVM` type is replaced with a new `LiteSvmRpcApi` type alias so users can write `ClientWithRpc<LiteSvmRpcApi>` instead.