### PR TITLE
Remove provisory compute unit limit from LiteSVM planner

### DIFF
--- a/.changeset/sunny-meals-sing.md
+++ b/.changeset/sunny-meals-sing.md
@@ -1,0 +1,7 @@
+---
+'@solana/kit-plugin-litesvm': patch
+---
+
+Remove provisory compute unit limit from LiteSVM planner
+
+The LiteSVM planner no longer adds a provisory `SetComputeUnitLimit` instruction. This sentinel value (0 CU) was meant to be replaced by a real estimate in the executor, but the LiteSVM executor never performed estimation — causing transactions to fail with "compute budget exceeded". LiteSVM does not enforce compute unit limits by default, so the instruction is unnecessary.

--- a/packages/kit-plugin-litesvm/package.json
+++ b/packages/kit-plugin-litesvm/package.json
@@ -51,6 +51,9 @@
         "@loris-sandbox/litesvm-kit": "^0.5.0",
         "@solana-program/compute-budget": "^0.14.0"
     },
+    "devDependencies": {
+        "@solana-program/system": "^0.12.0"
+    },
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/packages/kit-plugin-litesvm/src/transaction-planner.ts
+++ b/packages/kit-plugin-litesvm/src/transaction-planner.ts
@@ -8,17 +8,13 @@ import {
     setTransactionMessageFeePayerSigner,
     TransactionSigner,
 } from '@solana/kit';
-import {
-    fillProvisorySetComputeUnitLimitInstruction,
-    getSetComputeUnitPriceInstruction,
-} from '@solana-program/compute-budget';
+import { getSetComputeUnitPriceInstruction } from '@solana-program/compute-budget';
 
 /**
  * A plugin that provides a default transaction planner using LiteSVM.
  *
  * The planner creates transaction messages with:
  * - The configured fee payer.
- * - A provisory compute unit limit (to be estimated later by the executor).
  * - Optional priority fees.
  *
  * @param config - Optional configuration for the planner.
@@ -65,7 +61,6 @@ export function litesvmTransactionPlanner(
                 return pipe(
                     createTransactionMessage({ version: 0 }),
                     tx => setTransactionMessageFeePayerSigner(payer, tx),
-                    tx => fillProvisorySetComputeUnitLimitInstruction(tx),
                     tx =>
                         config.priorityFees
                             ? appendTransactionMessageInstruction(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,10 @@ importers:
       '@solana/kit':
         specifier: ^6.1.0
         version: 6.1.0(typescript@5.9.3)
+    devDependencies:
+      '@solana-program/system':
+        specifier: ^0.12.0
+        version: 0.12.0(@solana/kit@6.1.0(typescript@5.9.3))
 
   packages/kit-plugin-payer:
     dependencies:


### PR DESCRIPTION
This PR removes the `fillProvisorySetComputeUnitLimitInstruction` call from the LiteSVM transaction planner. The provisory instruction set a sentinel CU limit of 0, expecting the executor to estimate and replace it — but the LiteSVM executor never did, causing transactions to fail. LiteSVM does not enforce CU limits by default, so the instruction is unnecessary. An end-to-end integration test is added that plans a SOL transfer instruction through the planner and executes it, verifying the full pipeline works.