### PR TITLE
Expose executor and planner options on `kit-client-rpc` factories

### DIFF
--- a/.changeset/purple-taxis-hope.md
+++ b/.changeset/purple-taxis-hope.md
@@ -1,0 +1,6 @@
+---
+'@solana/kit-client-rpc': patch
+'@solana/kit-plugin-rpc': patch
+---
+
+The `createClient` and `createLocalClient` factory functions now accept `skipPreflight`, `maxConcurrency`, and `priorityFees` options, forwarding them to the underlying transaction plan executor and planner plugins. A shared `ClientConfig` type is also exported for use in consumer code. The `localhostRpc` plugin now accepts the full `DefaultRpcSubscriptionsChannelConfig` options instead of only `{ url: string }`.

--- a/packages/kit-client-rpc/README.md
+++ b/packages/kit-client-rpc/README.md
@@ -49,6 +49,9 @@ await client.sendTransaction([myInstruction]);
 | `url` (required)         | `string`                 | URL of the Solana RPC endpoint.                                                                |
 | `payer` (required)       | `TransactionSigner`      | Signer used to pay for transaction fees and on-chain account storage.                          |
 | `rpcSubscriptionsConfig` | `RpcSubscriptionsConfig` | Configuration for RPC subscriptions. Use `rpcSubscriptionsConfig.url` to specify its endpoint. |
+| `priorityFees`           | `MicroLamports`          | Priority fees in micro-lamports per compute unit. Defaults to no priority fees.                |
+| `maxConcurrency`         | `number`                 | Maximum number of concurrent transaction executions. Defaults to `10`.                         |
+| `skipPreflight`          | `boolean`                | Whether to skip preflight simulation when sending transactions. Defaults to `false`.           |
 
 ## `createLocalClient`
 
@@ -81,8 +84,11 @@ await client.airdrop(client.payer.address, lamports(5_000_000_000n));
 
 ### Configuration
 
-| Option                   | Type                | Description                                                                                                     |
-| ------------------------ | ------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `payer`                  | `TransactionSigner` | Signer used to pay for transaction fees and on-chain account storage. Defaults to a generated and funded payer. |
-| `url`                    | `string`            | Custom RPC URL. Defaults to `http://127.0.0.1:8899`.                                                            |
-| `rpcSubscriptionsConfig` | `{ url: string }`   | Custom WebSocket URL. Defaults to `ws://127.0.0.1:8900`.                                                        |
+| Option                   | Type                     | Description                                                                                                     |
+| ------------------------ | ------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `payer`                  | `TransactionSigner`      | Signer used to pay for transaction fees and on-chain account storage. Defaults to a generated and funded payer. |
+| `url`                    | `string`                 | Custom RPC URL. Defaults to `http://127.0.0.1:8899`.                                                            |
+| `rpcSubscriptionsConfig` | `RpcSubscriptionsConfig` | Configuration for RPC subscriptions. Defaults to `{ url: 'ws://127.0.0.1:8900' }`.                              |
+| `priorityFees`           | `MicroLamports`          | Priority fees in micro-lamports per compute unit. Defaults to no priority fees.                                 |
+| `maxConcurrency`         | `number`                 | Maximum number of concurrent transaction executions. Defaults to `10`.                                          |
+| `skipPreflight`          | `boolean`                | Whether to skip preflight simulation when sending transactions. Defaults to `false`.                            |

--- a/packages/kit-plugin-rpc/src/rpc.ts
+++ b/packages/kit-plugin-rpc/src/rpc.ts
@@ -45,6 +45,9 @@ export function rpc<TClusterUrl extends ClusterUrl>(
  * Enhances a client with Solana RPC and RPC Subscriptions capabilities
  * using to a local validator.
  *
+ * @param url - Custom RPC URL. Defaults to `http://127.0.0.1:8899`.
+ * @param rpcSubscriptionsConfig - Configuration for RPC subscriptions. Defaults to `{ url: 'ws://127.0.0.1:8900' }`.
+ *
  * @example
  * ```ts
  * import { createEmptyClient } from '@solana/kit';
@@ -65,6 +68,6 @@ export function rpc<TClusterUrl extends ClusterUrl>(
  *
  * @see {@link rpc}
  */
-export function localhostRpc(url?: string, rpcSubscriptionsConfig?: { url: string }) {
-    return rpc(url ?? 'http://127.0.0.1:8899', rpcSubscriptionsConfig ?? { url: 'ws://127.0.0.1:8900' });
+export function localhostRpc(url?: string, rpcSubscriptionsConfig?: DefaultRpcSubscriptionsChannelConfig<string>) {
+    return rpc<string>(url ?? 'http://127.0.0.1:8899', rpcSubscriptionsConfig ?? { url: 'ws://127.0.0.1:8900' });
 }


### PR DESCRIPTION
This PR exposes `skipPreflight`, `maxConcurrency`, and `priorityFees` options on the `createClient` and `createLocalClient` factory functions in `@solana/kit-client-rpc`, forwarding them to the underlying transaction plan executor and planner plugins. A shared `ClientConfig` type is extracted and exported. The `localhostRpc` plugin in `@solana/kit-plugin-rpc` now accepts the full `DefaultRpcSubscriptionsChannelConfig` options instead of only `{ url: string }`. The README is updated to document the new options.

Fixes #109