### PR TITLE
Fix outdated API references across READMEs and docblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ client.svm.setAccount(myTestAccount);
 client.svm.addProgramFromFile(myProgramAddress, 'program.so');
 
 // Execute transactions locally
-await client.sendTransactions([myInstruction]);
+await client.sendTransaction([myInstruction]);
 ```
 
 [See all features and configuration options](./packages/kit-client-litesvm/README.md#createclient).
@@ -97,14 +97,16 @@ import { createEmptyClient } from '@solana/kit';
 import { rpc } from '@solana/kit-plugin-rpc';
 import { payerFromFile } from '@solana/kit-plugin-payer';
 import { airdrop } from '@solana/kit-plugin-airdrop';
-import { defaultTransactionPlannerAndExecutorFromRpc, sendTransactions } from '@solana/kit-plugin-instruction-plan';
+import { rpcTransactionPlanner, rpcTransactionPlanExecutor } from '@solana/kit-plugin-rpc';
+import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
 
 const client = await createEmptyClient() // An empty client with a `use` method to install plugins.
     .use(rpc('https://api.devnet.solana.com')) // Adds `client.rpc` and `client.rpcSubscriptions`.
     .use(payerFromFile('path/to/keypair.json')) // Adds `client.payer` using a local keypair file.
     .use(airdrop()) // Adds `client.airdrop` to request SOL from faucets.
-    .use(defaultTransactionPlannerAndExecutorFromRpc()) // Adds `client.transactionPlanner` and `client.transactionPlanExecutor`.
-    .use(sendTransactions()); // Adds `client.sendTransaction(s)` to send transaction messages, instructions or instruction plans.
+    .use(rpcTransactionPlanner()) // Adds `client.transactionPlanner`.
+    .use(rpcTransactionPlanExecutor()) // Adds `client.transactionPlanExecutor`.
+    .use(planAndSendTransactions()); // Adds `client.planTransaction(s)` and `client.sendTransaction(s)`.
 ```
 
 Note that since plugins are defined in `@solana/kit` itself, you're not limited to the plugins in this repo! You can use [community plugins](#community-plugins) or even [create your own](#create-your-own-plugins).
@@ -124,13 +126,13 @@ _Do you know any? Please open a PR to add them here!_
 
 This repo provides the following individual plugin packages. You can learn more about each package by following the links to their READMEs below.
 
-| Package                                                                         | Description                        | Plugins                                                                                                                                                              |
-| ------------------------------------------------------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`@solana/kit-plugin-rpc`](./packages/kit-plugin-rpc)                           | Connect to Solana clusters         | `rpc`, `localhostRpc`                                                                                                                                                |
-| [`@solana/kit-plugin-payer`](./packages/kit-plugin-payer)                       | Manage transaction fee payers      | `payer`, `payerFromFile`, `generatedPayer`, `generatedPayerWithSol`                                                                                                  |
-| [`@solana/kit-plugin-airdrop`](./packages/kit-plugin-airdrop)                   | Request SOL from faucets           | `airdrop`                                                                                                                                                            |
-| [`@solana/kit-plugin-litesvm`](./packages/kit-plugin-litesvm)                   | LiteSVM support                    | `litesvm`                                                                                                                                                            |
-| [`@solana/kit-plugin-instruction-plan`](./packages/kit-plugin-instruction-plan) | Transaction planning and execution | `transactionPlanner`, `transactionPlanExecutor`, `sendTransactions`,`defaultTransactionPlannerAndExecutorFromRpc`, `defaultTransactionPlannerAndExecutorFromLitesvm` |
+| Package                                                                         | Description                        | Plugins                                                                      |
+| ------------------------------------------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------- |
+| [`@solana/kit-plugin-rpc`](./packages/kit-plugin-rpc)                           | Connect to Solana clusters         | `rpc`, `localhostRpc`, `rpcTransactionPlanner`, `rpcTransactionPlanExecutor` |
+| [`@solana/kit-plugin-payer`](./packages/kit-plugin-payer)                       | Manage transaction fee payers      | `payer`, `payerFromFile`, `generatedPayer`, `generatedPayerWithSol`          |
+| [`@solana/kit-plugin-airdrop`](./packages/kit-plugin-airdrop)                   | Request SOL from faucets           | `airdrop`                                                                    |
+| [`@solana/kit-plugin-litesvm`](./packages/kit-plugin-litesvm)                   | LiteSVM support                    | `litesvm`, `litesvmTransactionPlanner`, `litesvmTransactionPlanExecutor`     |
+| [`@solana/kit-plugin-instruction-plan`](./packages/kit-plugin-instruction-plan) | Transaction planning and execution | `transactionPlanner`, `transactionPlanExecutor`, `planAndSendTransactions`   |
 
 ## Community Plugins
 

--- a/packages/kit-client-litesvm/README.md
+++ b/packages/kit-client-litesvm/README.md
@@ -43,6 +43,8 @@ await client.sendTransaction([myInstruction]);
 - `client.airdrop`: Function to request SOL from the LiteSVM instance.
 - `client.transactionPlanner`: Plans instructions into transaction messages.
 - `client.transactionPlanExecutor`: Executes planned transaction messages.
+- `client.planTransactions`: Plans transaction messages, instructions or instruction plans into a transaction plan without executing it.
+- `client.planTransaction`: Same as `client.planTransactions` but asserts a single transaction message is returned.
 - `client.sendTransactions`: Sends transaction messages, instructions or instruction plans to the cluster by using the client's transaction planner and executor.
 - `client.sendTransaction`: Same as `client.sendTransactions` but ensuring only a single transaction is sent.
 

--- a/packages/kit-client-rpc/README.md
+++ b/packages/kit-client-rpc/README.md
@@ -39,6 +39,8 @@ await client.sendTransaction([myInstruction]);
 - `client.payer`: The main payer signer for transactions.
 - `client.transactionPlanner`: Plans instructions into transaction messages.
 - `client.transactionPlanExecutor`: Executes planned transaction messages.
+- `client.planTransactions`: Plans transaction messages, instructions or instruction plans into a transaction plan without executing it.
+- `client.planTransaction`: Same as `client.planTransactions` but asserts a single transaction message is returned.
 - `client.sendTransactions`: Sends transaction messages, instructions or instruction plans to the cluster by using the client's transaction planner and executor.
 - `client.sendTransaction`: Same as `client.sendTransactions` but ensuring only a single transaction is sent.
 
@@ -79,6 +81,8 @@ await client.airdrop(client.payer.address, lamports(5_000_000_000n));
 - `client.airdrop`: Function to request SOL from the local faucet.
 - `client.transactionPlanner`: Plans instructions into transaction messages.
 - `client.transactionPlanExecutor`: Executes planned transaction messages.
+- `client.planTransactions`: Plans transaction messages, instructions or instruction plans into a transaction plan without executing it.
+- `client.planTransaction`: Same as `client.planTransactions` but asserts a single transaction message is returned.
 - `client.sendTransactions`: Sends transaction messages, instructions or instruction plans to the cluster by using the client's transaction planner and executor.
 - `client.sendTransaction`: Same as `client.sendTransactions` but ensuring only a single transaction is sent.
 

--- a/packages/kit-plugin-instruction-plan/README.md
+++ b/packages/kit-plugin-instruction-plan/README.md
@@ -57,9 +57,9 @@ const client = createEmptyClient().use(transactionPlanExecutor(myTransactionPlan
     const transactionPlanResult = await client.transactionPlanExecutor(myTransactionPlan);
     ```
 
-## `sendTransactions` plugin
+## `planAndSendTransactions` plugin
 
-The `sendTransactions` plugin adds two helper functions, `sendTransaction` and `sendTransactions`, that combine transaction planning and execution in a single call. They accept transaction messages, instructions or instruction plans as input.
+The `planAndSendTransactions` plugin adds helper functions for planning and sending transactions. They accept transaction messages, instructions or instruction plans as input.
 
 ### Installation
 
@@ -67,23 +67,35 @@ This plugin requires both `transactionPlanner` and `transactionPlanExecutor` to 
 
 ```ts
 import { createEmptyClient } from '@solana/kit';
-import { transactionPlanner, transactionPlanExecutor, sendTransactions } from '@solana/kit-plugins';
+import { transactionPlanner, transactionPlanExecutor, planAndSendTransactions } from '@solana/kit-plugins';
 
 const client = createEmptyClient()
     .use(transactionPlanner(myTransactionPlanner))
     .use(transactionPlanExecutor(myTransactionPlanExecutor))
-    .use(sendTransactions());
+    .use(planAndSendTransactions());
 ```
 
 ### Features
 
-- `sendTransactions`: An asynchronous function that plans and executes transaction messages, instructions or instruction plans in one call.
+- `planTransactions`: Plans transaction messages, instructions or instruction plans into a transaction plan without executing it.
+
+    ```ts
+    const transactionPlan = await client.planTransactions(myInstructionPlan);
+    ```
+
+- `planTransaction`: Same as `planTransactions` but asserts that the result contains a single transaction message.
+
+    ```ts
+    const transactionMessage = await client.planTransaction(myInstructionPlan);
+    ```
+
+- `sendTransactions`: Plans and executes transaction messages, instructions or instruction plans in one call.
 
     ```ts
     const transactionPlanResult = await client.sendTransactions(myInstructionPlan);
     ```
 
-- `sendTransaction`: An asynchronous function that plans and executes a single transaction message, instruction plan or multiple instructions in one call. Should the provided instructions or instruction plan result in multiple transactions, an error will be thrown prior to execution.
+- `sendTransaction`: Same as `sendTransactions` but asserts that the result is successful and contains a single transaction. Should the provided input result in multiple transactions, an error will be thrown.
 
     ```ts
     const transactionPlanResult = await client.sendTransaction(myInstructionPlan);

--- a/packages/kit-plugin-instruction-plan/src/core.ts
+++ b/packages/kit-plugin-instruction-plan/src/core.ts
@@ -52,11 +52,16 @@ export function transactionPlanExecutor(transactionPlanExecutor: TransactionPlan
 }
 
 /**
- * A plugin that adds `sendTransaction` and `sendTransactions` functions on the client to
- * plan and execute transaction messages, instructions or instruction plans in one call.
+ * A plugin that adds `planTransaction`, `planTransactions`, `sendTransaction` and
+ * `sendTransactions` functions on the client to plan and execute transaction messages,
+ * instructions or instruction plans.
  *
  * This expects the client to have both a `transactionPlanner`
  * and a `transactionPlanExecutor` set.
+ *
+ * The `planTransaction` and `planTransactions` functions plan instructions into
+ * transaction plans without executing them. The `sendTransaction` and `sendTransactions`
+ * functions combine planning and execution in a single call.
  *
  * Note that the `sendTransaction` function will assert that the transaction plan result
  * is both successful and contains a single transaction plan. This is slightly different from
@@ -66,17 +71,22 @@ export function transactionPlanExecutor(transactionPlanExecutor: TransactionPlan
  * @example
  * ```ts
  * import { createEmptyClient } from '@solana/kit';
- * import { transactionPlanner, transactionPlanExecutor } from '@solana/kit-plugins';
+ * import { transactionPlanner, transactionPlanExecutor, planAndSendTransactions } from '@solana/kit-plugins';
  *
- * // Install the sendTransactions plugin and its requirements.
+ * // Install the planAndSendTransactions plugin and its requirements.
  * const client = createEmptyClient()
  *     .use(transactionPlanner(myTransactionPlanner))
  *     .use(transactionPlanExecutor(myTransactionPlanExecutor))
- *     .use(sendTransactions());
+ *     .use(planAndSendTransactions());
  *
- * // Use the sendTransaction(s) functions.
+ * // Plan transactions without executing them.
+ * const transactionPlan = await client.planTransactions(myInstructionPlan);
+ * const transactionMessage = await client.planTransaction(myInstructionPlan);
+ *
+ * // Plan and execute transactions in one call.
  * const singleResult = await client.sendTransaction(myInstructionPlan);
  * const result = await client.sendTransactions(myInstructionPlan);
+ * ```
  */
 export function planAndSendTransactions() {
     return <T extends { transactionPlanExecutor: TransactionPlanExecutor; transactionPlanner: TransactionPlanner }>(


### PR DESCRIPTION
This PR updates all READMEs and one source docblock to reflect the current API names.

- Root README: replace `defaultTransactionPlannerAndExecutorFromRpc` and `sendTransactions` with `rpcTransactionPlanner`, `rpcTransactionPlanExecutor`, and `planAndSendTransactions` in the "Build Your Own Client" section.
- Root README: fix "Available Plugins" table to show correct plugin names and package attributions (add planner/executor plugins to RPC and LiteSVM rows, remove nonexistent `default*` entries from instruction-plan row).
- Root README: fix `sendTransactions` to `sendTransaction` (singular) in LiteSVM Quick Start for consistency.
- `kit-plugin-instruction-plan` README: rename `sendTransactions` plugin section to `planAndSendTransactions` and document the new `planTransaction`/`planTransactions` features.
- `kit-client-rpc` and `kit-client-litesvm` READMEs: add `planTransaction`/`planTransactions` to features lists.
- `kit-plugin-instruction-plan/src/core.ts`: update the `planAndSendTransactions` docblock to reference its current name and document all four functions it provides.