### PR TITLE
Make `kit-client-litesvm` types portable by re-exporting LiteSVM plugin types

### DIFF
--- a/.changeset/plain-comics-switch.md
+++ b/.changeset/plain-comics-switch.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-client-litesvm': patch
+---
+
+Re-export `LiteSVM`, `LiteSvmRpcApi`, `FailedTransactionMetadata`, and `TransactionMetadata` types from `@solana/kit-plugin-litesvm` to make the `createClient` return type portable.

--- a/packages/kit-client-litesvm/src/index.browser.ts
+++ b/packages/kit-client-litesvm/src/index.browser.ts
@@ -1,5 +1,13 @@
 import { TransactionSigner } from '@solana/kit';
 
+// Re-export types that appear in the `createClient` return type to make them type-portable.
+export type {
+    FailedTransactionMetadata,
+    LiteSVM,
+    LiteSvmRpcApi,
+    TransactionMetadata,
+} from '@solana/kit-plugin-litesvm';
+
 /**
  * Creates a default LiteSVM client for local blockchain simulation.
  *

--- a/packages/kit-client-litesvm/src/index.ts
+++ b/packages/kit-client-litesvm/src/index.ts
@@ -4,6 +4,14 @@ import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
 import { litesvm, litesvmTransactionPlanExecutor, litesvmTransactionPlanner } from '@solana/kit-plugin-litesvm';
 import { payerOrGeneratedPayer } from '@solana/kit-plugin-payer';
 
+// Re-export types that appear in the `createClient` return type to make them type-portable.
+export type {
+    FailedTransactionMetadata,
+    LiteSVM,
+    LiteSvmRpcApi,
+    TransactionMetadata,
+} from '@solana/kit-plugin-litesvm';
+
 /**
  * Creates a default LiteSVM client for local blockchain simulation.
  *


### PR DESCRIPTION
This PR re-exports `LiteSVM`, `LiteSvmRpcApi`, `FailedTransactionMetadata`, and `TransactionMetadata` types from `@solana/kit-plugin-litesvm` in both the Node and browser entrypoints of `@solana/kit-client-litesvm`.
Without these re-exports, consumers that assign or re-export `createClient` get a TS2742 error because TypeScript traces the return type back to `@loris-sandbox/litesvm-kit` deep in `node_modules/.pnpm/`, which is not accessible from the consumer's dependency tree.
This matches the pattern already established by `kit-plugin-litesvm`.