### PR TITLE
Fix `@deprecated` tags not propagating on client factory re-exports

### DIFF
--- a/.changeset/ten-olives-brush.md
+++ b/.changeset/ten-olives-brush.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugins': patch
+---
+
+Fix `@deprecated` tags not showing in IDEs for `createDefaultRpcClient`, `createDefaultLocalhostRpcClient`, and `createDefaultLiteSVMClient` re-exports.

--- a/packages/kit-plugins/src/defaults.ts
+++ b/packages/kit-plugins/src/defaults.ts
@@ -1,14 +1,11 @@
-/**
- * @deprecated Use `createClient` from `@solana/kit-client-rpc` instead.
- */
-export { createClient as createDefaultRpcClient } from '@solana/kit-client-rpc';
+import { createClient as createLiteSVMClient } from '@solana/kit-client-litesvm';
+import { createClient as createRpcClient, createLocalClient } from '@solana/kit-client-rpc';
 
-/**
- * @deprecated Use `createLocalClient` from `@solana/kit-client-rpc` instead.
- */
-export { createLocalClient as createDefaultLocalhostRpcClient } from '@solana/kit-client-rpc';
+/** @deprecated Use `createClient` from `@solana/kit-client-rpc` instead. */
+export const createDefaultRpcClient = createRpcClient;
 
-/**
- * @deprecated Use `createClient` from `@solana/kit-client-litesvm` instead.
- */
-export { createClient as createDefaultLiteSVMClient } from '@solana/kit-client-litesvm';
+/** @deprecated Use `createLocalClient` from `@solana/kit-client-rpc` instead. */
+export const createDefaultLocalhostRpcClient = createLocalClient;
+
+/** @deprecated Use `createClient` from `@solana/kit-client-litesvm` instead. */
+export const createDefaultLiteSVMClient = createLiteSVMClient;


### PR DESCRIPTION
This PR fixes `@deprecated` JSDoc tags not showing in IDEs for the `createDefaultRpcClient`, `createDefaultLocalhostRpcClient`, and `createDefaultLiteSVMClient` re-exports in `@solana/kit-plugins`.
TypeScript does not propagate `@deprecated` tags through `export { X as Y }` re-export specifiers — the alias resolution follows the chain to the original declaration, which isn't deprecated. The fix replaces these with `export const Y = X` so the `@deprecated` tag lives on the actual variable declaration that TypeScript resolves to.