### PR TITLE
Add 5 new RPC methods to the LiteSVM plugin

### DIFF
--- a/.changeset/shy-beans-play.md
+++ b/.changeset/shy-beans-play.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-litesvm': patch
+---
+
+Add `getBalance`, `getEpochSchedule`, `getMinimumBalanceForRentExemption`, `getSlot`, and `requestAirdrop` RPC methods to the LiteSVM plugin. Extract the LiteSVM-to-RPC adapter into its own `createRpcFromSvm` function.

--- a/packages/kit-plugin-litesvm/README.md
+++ b/packages/kit-plugin-litesvm/README.md
@@ -38,7 +38,7 @@ const client = createEmptyClient().use(litesvm());
     client.svm.setAccount(myAccount);
     client.svm.addProgramFromFile(myProgramAddress, 'my_program.so');
     ```
-- `rpc`: Call a subset of Solana RPC methods against the LiteSVM instance. Currently supported methods are: `getAccountInfo`, `getMultipleAccounts`, and `getLatestBlockhash`.
+- `rpc`: Call a subset of Solana RPC methods against the LiteSVM instance. Currently supported methods are: `getAccountInfo`, `getBalance`, `getEpochSchedule`, `getLatestBlockhash`, `getMinimumBalanceForRentExemption`, `getMultipleAccounts`, `getSlot`, and `requestAirdrop`.
     ```ts
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send();
     ```

--- a/packages/kit-plugin-litesvm/src/index.browser.ts
+++ b/packages/kit-plugin-litesvm/src/index.browser.ts
@@ -1,5 +1,6 @@
 export type { FailedTransactionMetadata, TransactionMetadata } from '@loris-sandbox/litesvm-kit';
-export type { LiteSVM, LiteSvmRpcApi } from './litesvm';
+export type { LiteSVM } from './litesvm';
+export type { LiteSvmRpcApi } from './litesvm-to-rpc';
 
 export function litesvm(): <T extends object>(_client: T) => never {
     throw new Error(

--- a/packages/kit-plugin-litesvm/src/index.ts
+++ b/packages/kit-plugin-litesvm/src/index.ts
@@ -1,6 +1,7 @@
 export type { FailedTransactionMetadata, TransactionMetadata } from '@loris-sandbox/litesvm-kit';
 
 export * from './litesvm';
+export * from './litesvm-to-rpc';
 export * from './transaction-error';
 export * from './transaction-plan-executor';
 export * from './transaction-planner';

--- a/packages/kit-plugin-litesvm/src/litesvm-to-rpc.ts
+++ b/packages/kit-plugin-litesvm/src/litesvm-to-rpc.ts
@@ -1,0 +1,158 @@
+import type { LiteSVM } from '@loris-sandbox/litesvm-kit';
+import {
+    AccountInfoBase,
+    AccountInfoWithBase64EncodedData,
+    Address,
+    Base64EncodedBytes,
+    GetAccountInfoApi,
+    GetBalanceApi,
+    getBase58Decoder,
+    getBase64Decoder,
+    GetEpochScheduleApi,
+    GetLatestBlockhashApi,
+    GetMinimumBalanceForRentExemptionApi,
+    GetMultipleAccountsApi,
+    GetSlotApi,
+    Lamports,
+    lamports,
+    MaybeEncodedAccount,
+    PendingRpcRequest,
+    RequestAirdropApi,
+    Rpc,
+    signature as toSignature,
+    SolanaRpcResponse,
+} from '@solana/kit';
+
+import { getSolanaErrorFromLiteSvmFailure, isFailedTransaction } from './transaction-error';
+
+/**
+ * The RPC API methods available on a LiteSVM-backed client.
+ *
+ * This type represents the subset of Solana RPC methods that
+ * the LiteSVM plugin can serve locally. Use it with
+ * `ClientWithRpc<LiteSvmRpcApi>` to type a client that provides
+ * this RPC interface.
+ *
+ * @example
+ * ```ts
+ * import type { LiteSvmRpcApi } from '@solana/kit-plugin-litesvm';
+ * import type { ClientWithRpc } from '@solana/kit';
+ *
+ * function doSomething(client: ClientWithRpc<LiteSvmRpcApi>) {
+ *     const accountInfo = await client.rpc.getAccountInfo(myAddress).send();
+ * }
+ * ```
+ */
+export type LiteSvmRpcApi = GetAccountInfoApi &
+    GetBalanceApi &
+    GetEpochScheduleApi &
+    GetLatestBlockhashApi &
+    GetMinimumBalanceForRentExemptionApi &
+    GetMultipleAccountsApi &
+    GetSlotApi &
+    RequestAirdropApi;
+
+type Encoding = 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
+
+/**
+ * Creates a Kit {@link Rpc} that delegates to a LiteSVM instance instead
+ * of making network requests.
+ *
+ * The returned RPC supports a subset of the Solana JSON-RPC API. Each
+ * method call is resolved synchronously against the in-process SVM and
+ * wrapped in a `PendingRpcRequest` for API compatibility.
+ *
+ * @param svm - The LiteSVM instance to read from.
+ * @returns An {@link Rpc} implementing {@link LiteSvmRpcApi}.
+ *
+ * @example
+ * ```ts
+ * import { LiteSVM } from '@loris-sandbox/litesvm-kit';
+ * import { createRpcFromSvm } from '@solana/kit-plugin-litesvm';
+ *
+ * const svm = new LiteSVM();
+ * const rpc = createRpcFromSvm(svm);
+ * const { value: balance } = await rpc.getBalance(myAddress).send();
+ * ```
+ */
+export function createRpcFromSvm(svm: LiteSVM): Rpc<LiteSvmRpcApi> {
+    const base64Decoder = getBase64Decoder();
+    const convertMaybeEncodedAccount = (
+        account: MaybeEncodedAccount,
+    ): (AccountInfoBase & AccountInfoWithBase64EncodedData) | null => {
+        if (!account.exists) return null;
+        return {
+            data: [base64Decoder.decode(account.data) as Base64EncodedBytes, 'base64'] as const,
+            executable: account.executable,
+            lamports: account.lamports,
+            owner: account.programAddress,
+            space: account.space,
+        };
+    };
+
+    const base58Decoder = getBase58Decoder();
+
+    return {
+        getAccountInfo: (address: Address, config?: { encoding?: Encoding }) => {
+            assertEncodingIsBase64(config?.encoding);
+            const response = convertMaybeEncodedAccount(svm.getAccount(address));
+            return wrapInPendingRpcRequest(wrapInSolanaRpcResponse(response));
+        },
+        getBalance: (address: Address) => {
+            const response = svm.getBalance(address) ?? lamports(0n);
+            return wrapInPendingRpcRequest(wrapInSolanaRpcResponse(response));
+        },
+        getEpochSchedule: () => {
+            const schedule = svm.getEpochSchedule();
+            const response = {
+                firstNormalEpoch: schedule.firstNormalEpoch,
+                firstNormalSlot: schedule.firstNormalSlot,
+                leaderScheduleSlotOffset: schedule.leaderScheduleSlotOffset,
+                slotsPerEpoch: schedule.slotsPerEpoch,
+                warmup: schedule.warmup,
+            };
+            return wrapInPendingRpcRequest(response);
+        },
+        getLatestBlockhash: () => {
+            const response = { blockhash: svm.latestBlockhash(), lastValidBlockHeight: 0n };
+            return wrapInPendingRpcRequest(wrapInSolanaRpcResponse(response));
+        },
+        getMinimumBalanceForRentExemption: (size: bigint) => {
+            const response = lamports(svm.minimumBalanceForRentExemption(size));
+            return wrapInPendingRpcRequest(response);
+        },
+        getMultipleAccounts: (addresses: readonly Address[], config?: { encoding?: Encoding }) => {
+            assertEncodingIsBase64(config?.encoding);
+            const response = addresses.map(address => convertMaybeEncodedAccount(svm.getAccount(address)));
+            return wrapInPendingRpcRequest(wrapInSolanaRpcResponse(response));
+        },
+        getSlot: () => {
+            return wrapInPendingRpcRequest(svm.getClock().slot);
+        },
+        requestAirdrop: (recipientAddress: Address, amount: Lamports) => {
+            const result = svm.airdrop(recipientAddress, amount);
+            if (result == null) {
+                throw new Error(`Airdrop to ${recipientAddress} failed: returned null`);
+            }
+            if (isFailedTransaction(result)) {
+                throw getSolanaErrorFromLiteSvmFailure(result);
+            }
+            const sig = toSignature(base58Decoder.decode(result.signature()));
+            return wrapInPendingRpcRequest(sig);
+        },
+    } as Rpc<LiteSvmRpcApi>;
+}
+
+function wrapInPendingRpcRequest<T>(response: T): PendingRpcRequest<T> {
+    return { send: () => Promise.resolve(response) };
+}
+
+function wrapInSolanaRpcResponse<T>(value: T): SolanaRpcResponse<T> {
+    return { context: { slot: 0n }, value };
+}
+
+function assertEncodingIsBase64(encoding: Encoding | undefined) {
+    if (encoding && encoding !== 'base64') {
+        throw new Error(`Please use 'base64' encoding when using LiteSVM RPC. Requested encoding: ${encoding}`);
+    }
+}

--- a/packages/kit-plugin-litesvm/src/litesvm.ts
+++ b/packages/kit-plugin-litesvm/src/litesvm.ts
@@ -1,41 +1,9 @@
 import { LiteSVM } from '@loris-sandbox/litesvm-kit';
-import {
-    AccountInfoBase,
-    AccountInfoWithBase64EncodedData,
-    Address,
-    Base64EncodedBytes,
-    GetAccountInfoApi,
-    getBase64Decoder,
-    GetLatestBlockhashApi,
-    GetMultipleAccountsApi,
-    MaybeEncodedAccount,
-    PendingRpcRequest,
-    Rpc,
-    SolanaRpcResponse,
-} from '@solana/kit';
+
+import { createRpcFromSvm } from './litesvm-to-rpc';
 
 // Re-export the LiteSVM type to make the `litesvm` plugin type-portable.
 export type { LiteSVM } from '@loris-sandbox/litesvm-kit';
-
-/**
- * The RPC API methods available on a LiteSVM-backed client.
- *
- * This type represents the subset of Solana RPC methods that
- * the LiteSVM plugin can serve locally. Use it with
- * `ClientWithRpc<LiteSvmRpcApi>` to type a client that provides
- * this RPC interface.
- *
- * @example
- * ```ts
- * import type { LiteSvmRpcApi } from '@solana/kit-plugin-litesvm';
- * import type { ClientWithRpc } from '@solana/kit';
- *
- * function doSomething(client: ClientWithRpc<LiteSvmRpcApi>) {
- *     const accountInfo = await client.rpc.getAccountInfo(myAddress).send();
- * }
- * ```
- */
-export type LiteSvmRpcApi = GetAccountInfoApi & GetLatestBlockhashApi & GetMultipleAccountsApi;
 
 /**
  * A Kit plugin that adds LiteSVM functionality to your client.
@@ -67,53 +35,4 @@ export function litesvm() {
         const rpc = createRpcFromSvm(svm);
         return { ...client, rpc, svm };
     };
-}
-
-type Encoding = 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
-
-function createRpcFromSvm(svm: LiteSVM): Rpc<LiteSvmRpcApi> {
-    const base64Decoder = getBase64Decoder();
-    const convertMaybeEncodedAccount = (
-        account: MaybeEncodedAccount,
-    ): (AccountInfoBase & AccountInfoWithBase64EncodedData) | null => {
-        if (!account.exists) return null;
-        return {
-            data: [base64Decoder.decode(account.data) as Base64EncodedBytes, 'base64'] as const,
-            executable: account.executable,
-            lamports: account.lamports,
-            owner: account.programAddress,
-            space: account.space,
-        };
-    };
-
-    return {
-        getAccountInfo: (address: Address, config?: { encoding?: Encoding }) => {
-            assertEncodingIsBase64(config?.encoding);
-            const response = convertMaybeEncodedAccount(svm.getAccount(address));
-            return wrapInPendingRpcRequest(wrapInSolanaRpcResponse(response));
-        },
-        getLatestBlockhash: () => {
-            const response = { blockhash: svm.latestBlockhash(), lastValidBlockHeight: 0n };
-            return wrapInPendingRpcRequest(wrapInSolanaRpcResponse(response));
-        },
-        getMultipleAccounts: (addresses: readonly Address[], config?: { encoding?: Encoding }) => {
-            assertEncodingIsBase64(config?.encoding);
-            const response = addresses.map(address => convertMaybeEncodedAccount(svm.getAccount(address)));
-            return wrapInPendingRpcRequest(wrapInSolanaRpcResponse(response));
-        },
-    } as Rpc<LiteSvmRpcApi>;
-}
-
-function wrapInPendingRpcRequest<T>(response: T): PendingRpcRequest<T> {
-    return { send: () => Promise.resolve(response) };
-}
-
-function wrapInSolanaRpcResponse<T>(value: T): SolanaRpcResponse<T> {
-    return { context: { slot: 0n }, value };
-}
-
-function assertEncodingIsBase64(encoding: Encoding | undefined) {
-    if (encoding && encoding !== 'base64') {
-        throw new Error(`Please use 'base64' encoding when using LiteSVM RPC. Requested encoding: ${encoding}`);
-    }
 }

--- a/packages/kit-plugin-litesvm/src/transaction-error.ts
+++ b/packages/kit-plugin-litesvm/src/transaction-error.ts
@@ -117,6 +117,20 @@ const INSTRUCTION_ERROR_NAMES: readonly string[] = [
 ];
 
 /**
+ * Checks whether a LiteSVM transaction result is a failed transaction.
+ *
+ * LiteSVM's `sendTransaction` and `airdrop` return `TransactionMetadata`
+ * on success or `FailedTransactionMetadata` on failure. The failure type
+ * has an `err` method while the success type does not.
+ *
+ * @param result - The transaction result to check.
+ * @returns `true` if the result is a {@link FailedTransactionResult}.
+ */
+export function isFailedTransaction(result: object): result is FailedTransactionResult {
+    return 'err' in result && typeof result.err === 'function';
+}
+
+/**
  * Converts a failed transaction result from LiteSVM into a `SolanaError`
  * using the same error codes that the RPC would produce.
  *

--- a/packages/kit-plugin-litesvm/src/transaction-plan-executor.ts
+++ b/packages/kit-plugin-litesvm/src/transaction-plan-executor.ts
@@ -6,20 +6,7 @@ import {
     signTransactionMessageWithSigners,
 } from '@solana/kit';
 
-import { getSolanaErrorFromLiteSvmFailure } from './transaction-error';
-
-/**
- * Checks whether a `sendTransaction` result is a failed transaction.
- *
- * LiteSVM's `sendTransaction` returns `TransactionMetadata` on success
- * or `FailedTransactionMetadata` on failure. The failure type has an
- * `err` method while the success type does not.
- */
-function isFailedTransaction(
-    result: FailedTransactionMetadata | TransactionMetadata,
-): result is FailedTransactionMetadata {
-    return 'err' in result && typeof result.err === 'function';
-}
+import { getSolanaErrorFromLiteSvmFailure, isFailedTransaction } from './transaction-error';
 
 /**
  * A plugin that provides a default transaction plan executor using LiteSVM.

--- a/packages/kit-plugin-litesvm/test/index.test.ts
+++ b/packages/kit-plugin-litesvm/test/index.test.ts
@@ -1,12 +1,14 @@
 import { LiteSVM } from '@loris-sandbox/litesvm-kit';
 import {
-    address,
     createEmptyClient,
-    generateKeyPairSigner,
     GetAccountInfoApi,
+    GetBalanceApi,
+    GetEpochScheduleApi,
     GetLatestBlockhashApi,
+    GetMinimumBalanceForRentExemptionApi,
     GetMultipleAccountsApi,
-    lamports,
+    GetSlotApi,
+    RequestAirdropApi,
     Rpc,
 } from '@solana/kit';
 import { describe, expect, expectTypeOf, it } from 'vitest';
@@ -34,97 +36,24 @@ describe('litesvm', () => {
         expect(client).toHaveProperty('rpc');
         expect(client.rpc).toBeTypeOf('object');
         expect(client.rpc.getAccountInfo).toBeTypeOf('function');
+        expect(client.rpc.getBalance).toBeTypeOf('function');
+        expect(client.rpc.getEpochSchedule).toBeTypeOf('function');
         expect(client.rpc.getLatestBlockhash).toBeTypeOf('function');
+        expect(client.rpc.getMinimumBalanceForRentExemption).toBeTypeOf('function');
         expect(client.rpc.getMultipleAccounts).toBeTypeOf('function');
+        expect(client.rpc.getSlot).toBeTypeOf('function');
+        expect(client.rpc.requestAirdrop).toBeTypeOf('function');
         expectTypeOf(client.rpc).toEqualTypeOf<
-            Rpc<GetAccountInfoApi & GetLatestBlockhashApi & GetMultipleAccountsApi>
+            Rpc<
+                GetAccountInfoApi &
+                    GetBalanceApi &
+                    GetEpochScheduleApi &
+                    GetLatestBlockhashApi &
+                    GetMinimumBalanceForRentExemptionApi &
+                    GetMultipleAccountsApi &
+                    GetSlotApi &
+                    RequestAirdropApi
+            >
         >();
-    });
-
-    it('can fetch an account set on the svm', async () => {
-        const client = createEmptyClient().use(litesvm());
-        const accountAddress = await generateKeyPairSigner().then(signer => signer.address);
-
-        client.svm.setAccount({
-            address: accountAddress,
-            data: new Uint8Array([1, 1]),
-            executable: false,
-            lamports: lamports(1_000_000n),
-            programAddress: address('11111111111111111111111111111111'),
-            space: 2n,
-        });
-
-        const { value } = await client.rpc.getAccountInfo(accountAddress).send();
-        expect(value).toEqual({
-            data: ['AQE=', 'base64'],
-            executable: false,
-            lamports: lamports(1_000_000n),
-            owner: address('11111111111111111111111111111111'),
-            space: 2n,
-        });
-    });
-
-    it('can fetch a missing account on the svm', async () => {
-        const client = createEmptyClient().use(litesvm());
-        const missingAddress = await generateKeyPairSigner().then(signer => signer.address);
-
-        const { value } = await client.rpc.getAccountInfo(missingAddress).send();
-        expect(value).toBeNull();
-    });
-
-    it('can fetch multiple accounts set on the svm', async () => {
-        const client = createEmptyClient().use(litesvm());
-
-        const [addressA, addressB, missingAddressC] = await Promise.all([
-            generateKeyPairSigner().then(signer => signer.address),
-            generateKeyPairSigner().then(signer => signer.address),
-            generateKeyPairSigner().then(signer => signer.address),
-        ]);
-
-        client.svm.setAccount({
-            address: addressA,
-            data: new Uint8Array([1, 1]),
-            executable: false,
-            lamports: lamports(1_000_000n),
-            programAddress: address('11111111111111111111111111111111'),
-            space: 2n,
-        });
-        client.svm.setAccount({
-            address: addressB,
-            data: new Uint8Array([2, 2, 2, 2]),
-            executable: false,
-            lamports: lamports(2_000_000n),
-            programAddress: address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
-            space: 4n,
-        });
-
-        const { value } = await client.rpc.getMultipleAccounts([addressA, addressB, missingAddressC]).send();
-
-        expect(value).toHaveLength(3);
-        expect(value[0]).toEqual({
-            data: ['AQE=', 'base64'],
-            executable: false,
-            lamports: lamports(1_000_000n),
-            owner: address('11111111111111111111111111111111'),
-            space: 2n,
-        });
-        expect(value[1]).toEqual({
-            data: ['AgICAg==', 'base64'],
-            executable: false,
-            lamports: lamports(2_000_000n),
-            owner: address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
-            space: 4n,
-        });
-        expect(value[2]).toBeNull();
-    });
-
-    it('can fetch a the latest blockhash', async () => {
-        const client = createEmptyClient().use(litesvm());
-
-        const { value } = await client.rpc.getLatestBlockhash({ commitment: 'finalized' }).send();
-        expect(value).toStrictEqual({
-            blockhash: client.svm.latestBlockhash(),
-            lastValidBlockHeight: 0n,
-        });
     });
 });

--- a/packages/kit-plugin-litesvm/test/litesvm-to-rpc.test.ts
+++ b/packages/kit-plugin-litesvm/test/litesvm-to-rpc.test.ts
@@ -1,0 +1,165 @@
+import { address, createEmptyClient, generateKeyPairSigner, lamports } from '@solana/kit';
+import { describe, expect, it } from 'vitest';
+
+import { litesvm as nodeLitesvm } from '../src/index';
+import { litesvm as browserLitesvm } from '../src/index.browser';
+const litesvm = __NODEJS__ ? nodeLitesvm : browserLitesvm;
+
+describe('createRpcFromSvm', () => {
+    if (!__NODEJS__) {
+        it.todo('skipped in browser builds');
+        return;
+    }
+
+    it('can fetch an account set on the svm', async () => {
+        const client = createEmptyClient().use(litesvm());
+        const accountAddress = await generateKeyPairSigner().then(signer => signer.address);
+
+        client.svm.setAccount({
+            address: accountAddress,
+            data: new Uint8Array([1, 1]),
+            executable: false,
+            lamports: lamports(1_000_000n),
+            programAddress: address('11111111111111111111111111111111'),
+            space: 2n,
+        });
+
+        const { value } = await client.rpc.getAccountInfo(accountAddress).send();
+        expect(value).toEqual({
+            data: ['AQE=', 'base64'],
+            executable: false,
+            lamports: lamports(1_000_000n),
+            owner: address('11111111111111111111111111111111'),
+            space: 2n,
+        });
+    });
+
+    it('can fetch a missing account on the svm', async () => {
+        const client = createEmptyClient().use(litesvm());
+        const missingAddress = await generateKeyPairSigner().then(signer => signer.address);
+
+        const { value } = await client.rpc.getAccountInfo(missingAddress).send();
+        expect(value).toBeNull();
+    });
+
+    it('can fetch multiple accounts set on the svm', async () => {
+        const client = createEmptyClient().use(litesvm());
+
+        const [addressA, addressB, missingAddressC] = await Promise.all([
+            generateKeyPairSigner().then(signer => signer.address),
+            generateKeyPairSigner().then(signer => signer.address),
+            generateKeyPairSigner().then(signer => signer.address),
+        ]);
+
+        client.svm.setAccount({
+            address: addressA,
+            data: new Uint8Array([1, 1]),
+            executable: false,
+            lamports: lamports(1_000_000n),
+            programAddress: address('11111111111111111111111111111111'),
+            space: 2n,
+        });
+        client.svm.setAccount({
+            address: addressB,
+            data: new Uint8Array([2, 2, 2, 2]),
+            executable: false,
+            lamports: lamports(2_000_000n),
+            programAddress: address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+            space: 4n,
+        });
+
+        const { value } = await client.rpc.getMultipleAccounts([addressA, addressB, missingAddressC]).send();
+
+        expect(value).toHaveLength(3);
+        expect(value[0]).toEqual({
+            data: ['AQE=', 'base64'],
+            executable: false,
+            lamports: lamports(1_000_000n),
+            owner: address('11111111111111111111111111111111'),
+            space: 2n,
+        });
+        expect(value[1]).toEqual({
+            data: ['AgICAg==', 'base64'],
+            executable: false,
+            lamports: lamports(2_000_000n),
+            owner: address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+            space: 4n,
+        });
+        expect(value[2]).toBeNull();
+    });
+
+    it('can fetch the balance of an account set on the svm', async () => {
+        const client = createEmptyClient().use(litesvm());
+        const accountAddress = await generateKeyPairSigner().then(signer => signer.address);
+
+        client.svm.setAccount({
+            address: accountAddress,
+            data: new Uint8Array([]),
+            executable: false,
+            lamports: lamports(5_000_000n),
+            programAddress: address('11111111111111111111111111111111'),
+            space: 0n,
+        });
+
+        const { value } = await client.rpc.getBalance(accountAddress).send();
+        expect(value).toBe(lamports(5_000_000n));
+    });
+
+    it('returns zero balance for a missing account', async () => {
+        const client = createEmptyClient().use(litesvm());
+        const missingAddress = await generateKeyPairSigner().then(signer => signer.address);
+
+        const { value } = await client.rpc.getBalance(missingAddress).send();
+        expect(value).toBe(lamports(0n));
+    });
+
+    it('can fetch the epoch schedule', async () => {
+        const client = createEmptyClient().use(litesvm());
+
+        const response = await client.rpc.getEpochSchedule().send();
+        expect(typeof response.firstNormalEpoch).toBe('bigint');
+        expect(typeof response.firstNormalSlot).toBe('bigint');
+        expect(typeof response.leaderScheduleSlotOffset).toBe('bigint');
+        expect(typeof response.slotsPerEpoch).toBe('bigint');
+        expect(typeof response.warmup).toBe('boolean');
+    });
+
+    it('can fetch the latest blockhash', async () => {
+        const client = createEmptyClient().use(litesvm());
+
+        const { value } = await client.rpc.getLatestBlockhash({ commitment: 'finalized' }).send();
+        expect(value).toStrictEqual({
+            blockhash: client.svm.latestBlockhash(),
+            lastValidBlockHeight: 0n,
+        });
+    });
+
+    it('can fetch the minimum balance for rent exemption', async () => {
+        const client = createEmptyClient().use(litesvm());
+
+        const response = await client.rpc.getMinimumBalanceForRentExemption(100n).send();
+        expect(response).toBeGreaterThan(0n);
+        expect(typeof response).toBe('bigint');
+    });
+
+    it('can fetch the current slot', async () => {
+        const client = createEmptyClient().use(litesvm());
+
+        const slot = await client.rpc.getSlot().send();
+        expect(typeof slot).toBe('bigint');
+        expect(slot).toBeGreaterThanOrEqual(0n);
+    });
+
+    it('can request an airdrop', async () => {
+        const client = createEmptyClient().use(litesvm());
+        const recipientAddress = await generateKeyPairSigner().then(signer => signer.address);
+
+        const signature = await client.rpc.requestAirdrop(recipientAddress, lamports(1_000_000_000n)).send();
+        expect(typeof signature).toBe('string');
+        expect(signature.length).toBeGreaterThan(0);
+
+        // Verify the balance increased.
+        const { value: balance } = await client.rpc.getBalance(recipientAddress).send();
+        expect(balance).toBe(lamports(1_000_000_000n));
+    });
+});


### PR DESCRIPTION
This PR adds 5 new RPC methods to the LiteSVM plugin (`getBalance`, `getEpochSchedule`, `getMinimumBalanceForRentExemption`, `getSlot`, and `requestAirdrop`), bringing the total from 3 to 8.

The LiteSVM-to-RPC adapter logic is extracted from `litesvm.ts` into a dedicated `litesvm-to-rpc.ts` file, exporting both the `LiteSvmRpcApi` type and a public `createRpcFromSvm` function for consumers who want to bring their own `LiteSVM` instance.

Other improvements:
- `requestAirdrop` throws a `SolanaError` via `getSolanaErrorFromLiteSvmFailure` for consistency with the transaction plan executor.
- `isFailedTransaction` is deduplicated into `transaction-error.ts` and shared by both the RPC adapter and the transaction plan executor.