### PR TITLE
Use the actual SVM slot in RPC response context

### DIFF
--- a/.changeset/spotty-sloths-act.md
+++ b/.changeset/spotty-sloths-act.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-litesvm': patch
+---
+
+Use the actual SVM clock slot in RPC response context instead of hardcoding `0n`.


### PR DESCRIPTION
This PR updates `wrapInSolanaRpcResponse` in the LiteSVM-to-RPC adapter to use `svm.getClock().slot` instead of hardcoding `0n` in the response context. This makes the `context.slot` field returned by `getAccountInfo`, `getBalance`, `getLatestBlockhash`, and `getMultipleAccounts` reflect the actual SVM clock state.