### PR TITLE
Split airdrop plugin into `rpcAirdrop` and `litesvmAirdrop`

### DIFF
--- a/.changeset/young-moons-give.md
+++ b/.changeset/young-moons-give.md
@@ -1,0 +1,9 @@
+---
+'@solana/kit-plugin-rpc': minor
+'@solana/kit-plugin-litesvm': minor
+'@solana/kit-plugin-airdrop': minor
+'@solana/kit-client-rpc': patch
+'@solana/kit-client-litesvm': patch
+---
+
+Add dedicated `rpcAirdrop` and `litesvmAirdrop` plugins to `@solana/kit-plugin-rpc` and `@solana/kit-plugin-litesvm` respectively, replacing the unified `airdrop` plugin that used runtime duck-typing to switch between strategies. The `litesvmAirdrop` plugin now throws a `SolanaError` on failure and returns the transaction signature on success. The `airdrop` export from `@solana/kit-plugin-airdrop` is deprecated in favor of the new dedicated plugins.

--- a/packages/kit-client-litesvm/package.json
+++ b/packages/kit-client-litesvm/package.json
@@ -48,7 +48,6 @@
         "@solana/kit": "^6.1.0"
     },
     "dependencies": {
-        "@solana/kit-plugin-airdrop": "workspace:*",
         "@solana/kit-plugin-instruction-plan": "workspace:*",
         "@solana/kit-plugin-litesvm": "workspace:*",
         "@solana/kit-plugin-payer": "workspace:*"

--- a/packages/kit-client-litesvm/src/index.ts
+++ b/packages/kit-client-litesvm/src/index.ts
@@ -1,7 +1,11 @@
 import { createEmptyClient, TransactionSigner } from '@solana/kit';
-import { airdrop } from '@solana/kit-plugin-airdrop';
 import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
-import { litesvm, litesvmTransactionPlanExecutor, litesvmTransactionPlanner } from '@solana/kit-plugin-litesvm';
+import {
+    litesvm,
+    litesvmAirdrop,
+    litesvmTransactionPlanExecutor,
+    litesvmTransactionPlanner,
+} from '@solana/kit-plugin-litesvm';
 import { payerOrGeneratedPayer } from '@solana/kit-plugin-payer';
 
 // Re-export types that appear in the `createClient` return type to make them type-portable.
@@ -51,7 +55,7 @@ export type {
 export function createClient(config: { payer?: TransactionSigner } = {}) {
     return createEmptyClient()
         .use(litesvm())
-        .use(airdrop())
+        .use(litesvmAirdrop())
         .use(payerOrGeneratedPayer(config.payer))
         .use(litesvmTransactionPlanner())
         .use(litesvmTransactionPlanExecutor())

--- a/packages/kit-client-rpc/package.json
+++ b/packages/kit-client-rpc/package.json
@@ -48,7 +48,6 @@
         "@solana/kit": "^6.1.0"
     },
     "dependencies": {
-        "@solana/kit-plugin-airdrop": "workspace:*",
         "@solana/kit-plugin-instruction-plan": "workspace:*",
         "@solana/kit-plugin-payer": "workspace:*",
         "@solana/kit-plugin-rpc": "workspace:*"

--- a/packages/kit-client-rpc/src/index.ts
+++ b/packages/kit-client-rpc/src/index.ts
@@ -5,10 +5,15 @@ import {
     MicroLamports,
     TransactionSigner,
 } from '@solana/kit';
-import { airdrop } from '@solana/kit-plugin-airdrop';
 import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
 import { payer, payerOrGeneratedPayer } from '@solana/kit-plugin-payer';
-import { localhostRpc, rpc, rpcTransactionPlanExecutor, rpcTransactionPlanner } from '@solana/kit-plugin-rpc';
+import {
+    localhostRpc,
+    rpc,
+    rpcAirdrop,
+    rpcTransactionPlanExecutor,
+    rpcTransactionPlanner,
+} from '@solana/kit-plugin-rpc';
 
 /**
  * Configuration options for RPC client factory functions.
@@ -126,7 +131,7 @@ export function createLocalClient(
 ) {
     return createEmptyClient()
         .use(localhostRpc(config.url, config.rpcSubscriptionsConfig))
-        .use(airdrop())
+        .use(rpcAirdrop())
         .use(payerOrGeneratedPayer(config.payer))
         .use(rpcTransactionPlanner({ priorityFees: config.priorityFees }))
         .use(rpcTransactionPlanExecutor({ maxConcurrency: config.maxConcurrency, skipPreflight: config.skipPreflight }))

--- a/packages/kit-plugin-airdrop/src/index.ts
+++ b/packages/kit-plugin-airdrop/src/index.ts
@@ -15,37 +15,30 @@ type RpcClient = {
  * client has LiteSVM installed. Otherwise, it will rely on the
  * `Rpc` and `RpcSubscriptions` clients to perform the airdrop.
  *
+ * @deprecated Use `rpcAirdrop` from `@solana/kit-plugin-rpc` or
+ * `litesvmAirdrop` from `@solana/kit-plugin-litesvm` instead.
+ *
  * @example
  * RPC-based airdrop.
  * ```ts
  * import { createEmptyClient } from '@solana/kit';
- * import { airdrop, localhostRpc } from '@solana/kit-plugins';
+ * import { localhostRpc, rpcAirdrop } from '@solana/kit-plugin-rpc';
  *
- * // Install the airdrop plugin using a localhost RPC.
  * const client = createEmptyClient()
  *     .use(localhostRpc())
- *     .use(airdrop());
- *
- * // Use the airdrop method.
- * client.airdrop(myAddress, lamports(1_000_000_000n));
+ *     .use(rpcAirdrop());
  * ```
  *
  * @example
  * LiteSVM-based airdrop.
  * ```ts
  * import { createEmptyClient } from '@solana/kit';
- * import { airdrop, litesvm } from '@solana/kit-plugins';
+ * import { litesvm, litesvmAirdrop } from '@solana/kit-plugin-litesvm';
  *
- * // Install the airdrop plugin using a LiteSVM instance.
  * const client = createEmptyClient()
  *     .use(litesvm())
- *     .use(airdrop());
- *
- * // Use the airdrop method.
- * client.airdrop(myAddress, lamports(1_000_000_000n));
+ *     .use(litesvmAirdrop());
  * ```
- *
- * @see {@link AirdropFunction}
  */
 export function airdrop() {
     return <T extends LiteSVMClient | RpcClient>(client: T): ClientWithAirdrop & T => {

--- a/packages/kit-plugin-litesvm/README.md
+++ b/packages/kit-plugin-litesvm/README.md
@@ -43,6 +43,28 @@ const client = createEmptyClient().use(litesvm());
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send();
     ```
 
+## `litesvmAirdrop` plugin
+
+This plugin adds an `airdrop` method to your Kit client that airdrops SOL using the underlying LiteSVM instance. It performs error handling and returns the transaction signature on success.
+
+### Installation
+
+The client must have the `litesvm` plugin installed before applying this plugin.
+
+```ts
+import { createEmptyClient } from '@solana/kit';
+import { litesvm, litesvmAirdrop } from '@solana/kit-plugin-litesvm';
+
+const client = createEmptyClient().use(litesvm()).use(litesvmAirdrop());
+```
+
+### Features
+
+- `airdrop`: An asynchronous helper function that airdrops a specified amount of lamports to a given address.
+    ```ts
+    await client.airdrop(address('HQVxiMVDoV9jzG4tpoxmDZsNfWvaHXm8DGGv93Gka75v'), lamports(1_000_000_000n));
+    ```
+
 ## `litesvmTransactionPlanner` plugin
 
 This plugin provides a default transaction planner that creates transaction messages with a fee payer, a provisory compute unit limit, and optional priority fees.

--- a/packages/kit-plugin-litesvm/src/airdrop.ts
+++ b/packages/kit-plugin-litesvm/src/airdrop.ts
@@ -1,0 +1,50 @@
+import { Address, ClientWithAirdrop, getBase58Decoder, Lamports, signature as toSignature } from '@solana/kit';
+
+import { getSolanaErrorFromLiteSvmFailure, isFailedTransaction } from './transaction-error';
+
+type LiteSVMClient = {
+    svm: { airdrop: (address: Address, lamports: Lamports) => unknown };
+};
+
+/**
+ * A plugin that adds an `airdrop` method to the client using the
+ * underlying LiteSVM instance.
+ *
+ * The client must already have a `svm` property installed (e.g. via
+ * the {@link litesvm} plugin). The airdrop is executed synchronously
+ * against the in-process SVM and the resulting transaction signature
+ * is returned.
+ *
+ * @example
+ * ```ts
+ * import { createEmptyClient } from '@solana/kit';
+ * import { litesvm, litesvmAirdrop } from '@solana/kit-plugin-litesvm';
+ *
+ * const client = createEmptyClient()
+ *     .use(litesvm())
+ *     .use(litesvmAirdrop());
+ *
+ * await client.airdrop(myAddress, lamports(1_000_000_000n));
+ * ```
+ *
+ * @see {@link litesvm}
+ */
+export function litesvmAirdrop() {
+    return <T extends LiteSVMClient>(client: T): ClientWithAirdrop & T => {
+        const base58Decoder = getBase58Decoder();
+        return {
+            ...client,
+            airdrop: (address: Address, amount: Lamports) => {
+                const result = client.svm.airdrop(address, amount);
+                if (result == null) {
+                    throw new Error(`Airdrop to ${address} failed: returned null`);
+                }
+                if (isFailedTransaction(result)) {
+                    throw getSolanaErrorFromLiteSvmFailure(result);
+                }
+                const sig = toSignature(base58Decoder.decode((result as { signature: () => Uint8Array }).signature()));
+                return Promise.resolve(sig);
+            },
+        } as ClientWithAirdrop & T;
+    };
+}

--- a/packages/kit-plugin-litesvm/src/index.browser.ts
+++ b/packages/kit-plugin-litesvm/src/index.browser.ts
@@ -9,6 +9,7 @@ export function litesvm(): <T extends object>(_client: T) => never {
     );
 }
 
+export * from './airdrop';
 export * from './transaction-error';
 export * from './transaction-plan-executor';
 export * from './transaction-planner';

--- a/packages/kit-plugin-litesvm/src/index.ts
+++ b/packages/kit-plugin-litesvm/src/index.ts
@@ -1,5 +1,6 @@
 export type { FailedTransactionMetadata, TransactionMetadata } from '@loris-sandbox/litesvm-kit';
 
+export * from './airdrop';
 export * from './litesvm';
 export * from './litesvm-to-rpc';
 export * from './transaction-error';

--- a/packages/kit-plugin-litesvm/test/airdrop.test.ts
+++ b/packages/kit-plugin-litesvm/test/airdrop.test.ts
@@ -1,0 +1,61 @@
+import { address, createEmptyClient, lamports } from '@solana/kit';
+import { describe, expect, it, vi } from 'vitest';
+
+import { litesvm, litesvmAirdrop } from '../src';
+
+describe('litesvmAirdrop', () => {
+    it('provides an airdrop function that relies on a LiteSVM instance', async () => {
+        const mockSignature = new Uint8Array(64).fill(1);
+        const svm = {
+            airdrop: vi.fn().mockReturnValue({
+                signature: () => mockSignature,
+            }),
+        };
+        const client = createEmptyClient()
+            .use(() => ({ svm }))
+            .use(litesvmAirdrop());
+        expect(client).toHaveProperty('airdrop');
+        expect(client.airdrop).toBeTypeOf('function');
+
+        const receiver = address('HQVxiMVDoV9jzG4tpoxmDZsNfWvaHXm8DGGv93Gka75v');
+        const amount = lamports(1_000_000_000n);
+        const sig = await client.airdrop(receiver, amount);
+        expect(svm.airdrop).toHaveBeenCalledWith(receiver, amount);
+        expect(sig).toBeTypeOf('string');
+    });
+
+    it('throws when the airdrop returns null', () => {
+        const svm = { airdrop: vi.fn().mockReturnValue(null) };
+        const client = createEmptyClient()
+            .use(() => ({ svm }))
+            .use(litesvmAirdrop());
+
+        const receiver = address('HQVxiMVDoV9jzG4tpoxmDZsNfWvaHXm8DGGv93Gka75v');
+        expect(() => client.airdrop(receiver, lamports(1n))).toThrow('returned null');
+    });
+
+    it('throws a SolanaError when the airdrop fails', () => {
+        const svm = {
+            airdrop: vi.fn().mockReturnValue({
+                err: () => 2, // AccountNotFound
+            }),
+        };
+        const client = createEmptyClient()
+            .use(() => ({ svm }))
+            .use(litesvmAirdrop());
+
+        const receiver = address('HQVxiMVDoV9jzG4tpoxmDZsNfWvaHXm8DGGv93Gka75v');
+        expect(() => client.airdrop(receiver, lamports(1n))).toThrow();
+    });
+
+    if (__NODEJS__) {
+        it('works with a LiteSVM instance', async () => {
+            const client = createEmptyClient().use(litesvm()).use(litesvmAirdrop());
+            expect(client).toHaveProperty('airdrop');
+
+            const receiver = address('HQVxiMVDoV9jzG4tpoxmDZsNfWvaHXm8DGGv93Gka75v');
+            const sig = await client.airdrop(receiver, lamports(1_000_000_000n));
+            expect(sig).toBeTypeOf('string');
+        });
+    }
+});

--- a/packages/kit-plugin-rpc/README.md
+++ b/packages/kit-plugin-rpc/README.md
@@ -81,6 +81,31 @@ const client = createEmptyClient().use(localhostRpc());
 
 _See the `rpc` plugin for available features_.
 
+## `rpcAirdrop` plugin
+
+This plugin adds an `airdrop` method to your Kit client that requests SOL airdrops via the RPC and RPC Subscriptions transports.
+
+> [!NOTE]
+> Airdrop is only available on test clusters (devnet, testnet) and local validators. Using this plugin with a mainnet RPC will produce a TypeScript error.
+
+### Installation
+
+The client must have `rpc` and `rpcSubscriptions` installed before applying this plugin.
+
+```ts
+import { createEmptyClient } from '@solana/kit';
+import { localhostRpc, rpcAirdrop } from '@solana/kit-plugin-rpc';
+
+const client = createEmptyClient().use(localhostRpc()).use(rpcAirdrop());
+```
+
+### Features
+
+- `airdrop`: An asynchronous helper function that airdrops a specified amount of lamports to a given address.
+    ```ts
+    await client.airdrop(address('HQVxiMVDoV9jzG4tpoxmDZsNfWvaHXm8DGGv93Gka75v'), lamports(1_000_000_000n));
+    ```
+
 ## `rpcTransactionPlanner` plugin
 
 This plugin provides a default transaction planner that creates transaction messages with a fee payer, a provisory compute unit limit, and optional priority fees.

--- a/packages/kit-plugin-rpc/src/airdrop.ts
+++ b/packages/kit-plugin-rpc/src/airdrop.ts
@@ -1,0 +1,49 @@
+import { Address, airdropFactory, ClientWithAirdrop, Lamports } from '@solana/kit';
+
+type RpcClient = {
+    rpc: Parameters<typeof airdropFactory>[0]['rpc'];
+    rpcSubscriptions: Parameters<typeof airdropFactory>[0]['rpcSubscriptions'];
+};
+
+/**
+ * A plugin that adds an `airdrop` method to the client using the
+ * RPC and RPC Subscriptions transports.
+ *
+ * The client must already have `rpc` and `rpcSubscriptions` installed
+ * (e.g. via the {@link rpc} or {@link localhostRpc} plugins). A
+ * TypeScript error is raised when a mainnet RPC is used because
+ * airdrop methods are not available on mainnet.
+ *
+ * @example
+ * ```ts
+ * import { createEmptyClient } from '@solana/kit';
+ * import { localhostRpc, rpcAirdrop } from '@solana/kit-plugin-rpc';
+ *
+ * const client = createEmptyClient()
+ *     .use(localhostRpc())
+ *     .use(rpcAirdrop());
+ *
+ * await client.airdrop(myAddress, lamports(1_000_000_000n));
+ * ```
+ *
+ * @see {@link rpc}
+ * @see {@link localhostRpc}
+ */
+export function rpcAirdrop() {
+    return <T extends RpcClient>(client: T): ClientWithAirdrop & T => {
+        const airdropInternal = airdropFactory({
+            rpc: client.rpc,
+            rpcSubscriptions: client.rpcSubscriptions,
+        });
+        return {
+            ...client,
+            airdrop: (address: Address, amount: Lamports, abortSignal?: AbortSignal) =>
+                airdropInternal({
+                    abortSignal,
+                    commitment: 'confirmed',
+                    lamports: amount,
+                    recipientAddress: address,
+                }),
+        } as ClientWithAirdrop & T;
+    };
+}

--- a/packages/kit-plugin-rpc/src/index.ts
+++ b/packages/kit-plugin-rpc/src/index.ts
@@ -1,3 +1,4 @@
+export * from './airdrop';
 export * from './rpc';
 export * from './transaction-plan-executor';
 export * from './transaction-planner';

--- a/packages/kit-plugin-rpc/test/airdrop.test.ts
+++ b/packages/kit-plugin-rpc/test/airdrop.test.ts
@@ -1,0 +1,38 @@
+import { createEmptyClient, mainnet } from '@solana/kit';
+import { describe, expect, it, vi } from 'vitest';
+
+import { localhostRpc, rpc, rpcAirdrop } from '../src';
+
+describe('rpcAirdrop', () => {
+    it('provides an airdrop function that relies on RPCs', () => {
+        const getSignatureStatuses = vi.fn();
+        const requestAirdrop = vi.fn();
+        const signatureNotifications = vi.fn();
+        const client = createEmptyClient()
+            .use(() => ({
+                rpc: { getSignatureStatuses, requestAirdrop },
+                rpcSubscriptions: { signatureNotifications },
+            }))
+            .use(rpcAirdrop());
+        expect(client).toHaveProperty('airdrop');
+        expect(client.airdrop).toBeTypeOf('function');
+    });
+
+    it('works with an arbitrary RPC', () => {
+        const client = createEmptyClient().use(rpc('https://my-rpc.com')).use(rpcAirdrop());
+        expect(client).toHaveProperty('airdrop');
+    });
+
+    it('works with a localhost RPC', () => {
+        const client = createEmptyClient().use(localhostRpc()).use(rpcAirdrop());
+        expect(client).toHaveProperty('airdrop');
+    });
+
+    it('throws a TypeScript error with a mainnet RPC', () => {
+        const client = createEmptyClient()
+            .use(rpc(mainnet('https://my-rpc.com')))
+            // @ts-expect-error Airdrop RPC methods are not available on mainnet.
+            .use(rpcAirdrop());
+        expect(client).toHaveProperty('airdrop');
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,9 +92,6 @@ importers:
       '@solana/kit':
         specifier: ^6.1.0
         version: 6.1.0(typescript@5.9.3)
-      '@solana/kit-plugin-airdrop':
-        specifier: workspace:*
-        version: link:../kit-plugin-airdrop
       '@solana/kit-plugin-instruction-plan':
         specifier: workspace:*
         version: link:../kit-plugin-instruction-plan
@@ -110,9 +107,6 @@ importers:
       '@solana/kit':
         specifier: ^6.1.0
         version: 6.1.0(typescript@5.9.3)
-      '@solana/kit-plugin-airdrop':
-        specifier: workspace:*
-        version: link:../kit-plugin-airdrop
       '@solana/kit-plugin-instruction-plan':
         specifier: workspace:*
         version: link:../kit-plugin-instruction-plan
@@ -5134,8 +5128,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.50.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.50.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.50.0
+      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.56.1
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:


### PR DESCRIPTION
This PR splits the `airdrop` plugin from `@solana/kit-plugin-airdrop` into two dedicated plugins that live in their natural homes:

- `rpcAirdrop()` in `@solana/kit-plugin-rpc` — uses `airdropFactory` with the client's RPC and RPC Subscriptions transports.
- `litesvmAirdrop()` in `@solana/kit-plugin-litesvm` — calls `svm.airdrop()` directly, throws a `SolanaError` on failure (via the existing `getSolanaErrorFromLiteSvmFailure` utility), and returns the transaction signature on success.

The original `airdrop()` export from `@solana/kit-plugin-airdrop` is deprecated with its code left intact for backward compatibility. The two client factory packages (`kit-client-rpc` and `kit-client-litesvm`) are updated to use the new dedicated plugins and no longer depend on `@solana/kit-plugin-airdrop`.