### PR TITLE
Improve error messages from `sendTransaction` and `sendTransactions`

### DIFF
--- a/.changeset/tame-peaches-bathe.md
+++ b/.changeset/tame-peaches-bathe.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-instruction-plan': minor
+---
+
+Re-wrap `FAILED_TO_EXECUTE_TRANSACTION_PLAN` errors into user-facing `FAILED_TO_SEND_TRANSACTION` / `FAILED_TO_SEND_TRANSACTIONS` errors in `sendTransaction` and `sendTransactions`, unwrapping preflight error details.

--- a/packages/kit-plugin-instruction-plan/src/core.ts
+++ b/packages/kit-plugin-instruction-plan/src/core.ts
@@ -1,14 +1,22 @@
 import {
     assertIsSingleTransactionPlan,
+    assertIsSingleTransactionPlanResult,
     assertIsSuccessfulSingleTransactionPlanResult,
+    CanceledSingleTransactionPlanResult,
     ClientWithTransactionPlanning,
     ClientWithTransactionSending,
+    createFailedToSendTransactionError,
+    createFailedToSendTransactionsError,
+    FailedSingleTransactionPlanResult,
+    isSolanaError,
     isTransactionPlan,
     parseInstructionOrTransactionPlanInput,
     parseInstructionPlanInput,
     singleTransactionPlan,
+    SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN,
     TransactionPlanExecutor,
     TransactionPlanner,
+    TransactionPlanResult,
 } from '@solana/kit';
 
 /**
@@ -118,7 +126,17 @@ function getTransactionPlanningAndSendingFunctions(client: {
         config?.abortSignal?.throwIfAborted();
         const transactionPlan = isTransactionPlan(plan) ? plan : await planTransactions(plan, config);
         config?.abortSignal?.throwIfAborted();
-        return await client.transactionPlanExecutor(transactionPlan, config);
+        try {
+            return await client.transactionPlanExecutor(transactionPlan, config);
+        } catch (error) {
+            if (!isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)) {
+                throw error;
+            }
+            throw createFailedToSendTransactionsError(
+                error.context.transactionPlanResult as TransactionPlanResult,
+                error.context.abortReason,
+            );
+        }
     };
 
     const sendTransaction: ClientWithTransactionSending['sendTransaction'] = async (input, config = {}) => {
@@ -128,9 +146,22 @@ function getTransactionPlanningAndSendingFunctions(client: {
             ? plan
             : singleTransactionPlan(await planTransaction(plan, config));
         config?.abortSignal?.throwIfAborted();
-        const result = await client.transactionPlanExecutor(transactionPlan, config);
-        assertIsSuccessfulSingleTransactionPlanResult(result);
-        return result;
+        try {
+            const result = await client.transactionPlanExecutor(transactionPlan, config);
+            assertIsSuccessfulSingleTransactionPlanResult(result);
+            return result;
+        } catch (error) {
+            if (!isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)) {
+                throw error;
+            }
+            assertIsSingleTransactionPlanResult(error.context.transactionPlanResult as TransactionPlanResult);
+            throw createFailedToSendTransactionError(
+                error.context.transactionPlanResult as
+                    | CanceledSingleTransactionPlanResult
+                    | FailedSingleTransactionPlanResult,
+                error.context.abortReason,
+            );
+        }
     };
 
     return { planTransaction, planTransactions, sendTransaction, sendTransactions };

--- a/packages/kit-plugin-instruction-plan/test/core.test.ts
+++ b/packages/kit-plugin-instruction-plan/test/core.test.ts
@@ -2,8 +2,11 @@ import {
     Address,
     canceledSingleTransactionPlanResult,
     createEmptyClient,
+    createFailedToExecuteTransactionPlanError,
     createTransactionMessage,
+    failedSingleTransactionPlanResult,
     Instruction,
+    isSolanaError,
     sequentialInstructionPlan,
     sequentialTransactionPlan,
     sequentialTransactionPlanResult,
@@ -11,8 +14,12 @@ import {
     Signature,
     singleInstructionPlan,
     singleTransactionPlan,
+    SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION,
+    SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS,
     SOLANA_ERROR__INSTRUCTION_PLANS__UNEXPECTED_TRANSACTION_PLAN,
     SOLANA_ERROR__INSTRUCTION_PLANS__UNEXPECTED_TRANSACTION_PLAN_RESULT,
+    SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
+    SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE,
     SolanaError,
     SuccessfulSingleTransactionPlanResult,
     successfulSingleTransactionPlanResult,
@@ -21,7 +28,7 @@ import {
     TransactionPlan,
     TransactionPlanResult,
 } from '@solana/kit';
-import { describe, expect, it, vi } from 'vitest';
+import { assert, describe, expect, it, vi } from 'vitest';
 
 import { planAndSendTransactions, transactionPlanExecutor, transactionPlanner } from '../src';
 
@@ -411,6 +418,75 @@ describe('planAndSendTransactions', () => {
                 abortSignal: undefined,
             });
         });
+
+        it('re-wraps a failed-to-execute error into a failed-to-send-transaction error', async () => {
+            const message = {} as TransactionMessage & TransactionMessageWithFeePayer;
+            const txPlan = singleTransactionPlan(message);
+            const error = new Error('tx failed');
+            const failedResult = failedSingleTransactionPlanResult(message, error);
+            const executionError = createFailedToExecuteTransactionPlanError(failedResult);
+
+            const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
+            const customTransactionPlanExecutor = vi.fn().mockRejectedValue(executionError);
+            const client = createEmptyClient()
+                .use(transactionPlanner(customTransactionPlanner))
+                .use(transactionPlanExecutor(customTransactionPlanExecutor))
+                .use(planAndSendTransactions());
+
+            const thrownError = await client.sendTransaction({} as Instruction).catch((e: unknown) => e);
+            assert(isSolanaError(thrownError, SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION));
+        });
+
+        it('unwraps preflight errors when re-wrapping a failed-to-execute error', async () => {
+            const message = {} as TransactionMessage & TransactionMessageWithFeePayer;
+            const txPlan = singleTransactionPlan(message);
+            const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+            const logs = ['Program log: Error: insufficient funds'];
+            const simulationData = {
+                accounts: null,
+                innerInstructions: null,
+                loadedAccountsDataSize: null,
+                logs,
+                replacementBlockhash: null,
+                returnData: null,
+                unitsConsumed: 200_000n,
+            };
+            const preflightError = new SolanaError(
+                SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
+                { ...simulationData, cause: innerError },
+            );
+            const failedResult = failedSingleTransactionPlanResult(message, preflightError);
+            const executionError = createFailedToExecuteTransactionPlanError(failedResult);
+
+            const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
+            const customTransactionPlanExecutor = vi.fn().mockRejectedValue(executionError);
+            const client = createEmptyClient()
+                .use(transactionPlanner(customTransactionPlanner))
+                .use(transactionPlanExecutor(customTransactionPlanExecutor))
+                .use(planAndSendTransactions());
+
+            const thrownError = await client.sendTransaction({} as Instruction).catch((e: unknown) => e);
+            assert(isSolanaError(thrownError, SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION));
+            expect(thrownError.context.logs).toBe(logs);
+            expect(thrownError.context.preflightData).toMatchObject(simulationData);
+            expect(thrownError.cause).toBe(innerError);
+        });
+
+        it('re-throws non-Solana errors unchanged', async () => {
+            const message = {} as TransactionMessage & TransactionMessageWithFeePayer;
+            const txPlan = singleTransactionPlan(message);
+            const genericError = new Error('something went wrong');
+
+            const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
+            const customTransactionPlanExecutor = vi.fn().mockRejectedValue(genericError);
+            const client = createEmptyClient()
+                .use(transactionPlanner(customTransactionPlanner))
+                .use(transactionPlanExecutor(customTransactionPlanExecutor))
+                .use(planAndSendTransactions());
+
+            const promise = client.sendTransaction({} as Instruction);
+            await expect(promise).rejects.toBe(genericError);
+        });
     });
 
     describe('client.sendTransactions', () => {
@@ -546,6 +622,76 @@ describe('planAndSendTransactions', () => {
             expect(customTransactionPlanExecutor).toHaveBeenCalledExactlyOnceWith(transactionPlan, {
                 abortSignal: undefined,
             });
+        });
+
+        it('re-wraps a failed-to-execute error into a failed-to-send-transactions error', async () => {
+            const message = {} as TransactionMessage & TransactionMessageWithFeePayer;
+            const txPlan = singleTransactionPlan(message);
+            const error = new Error('tx failed');
+            const failedResult = failedSingleTransactionPlanResult(message, error);
+            const executionError = createFailedToExecuteTransactionPlanError(failedResult);
+
+            const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
+            const customTransactionPlanExecutor = vi.fn().mockRejectedValue(executionError);
+            const client = createEmptyClient()
+                .use(transactionPlanner(customTransactionPlanner))
+                .use(transactionPlanExecutor(customTransactionPlanExecutor))
+                .use(planAndSendTransactions());
+
+            const thrownError = await client.sendTransactions({} as Instruction).catch((e: unknown) => e);
+            assert(isSolanaError(thrownError, SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS));
+        });
+
+        it('unwraps preflight errors when re-wrapping a failed-to-execute error', async () => {
+            const message = {} as TransactionMessage & TransactionMessageWithFeePayer;
+            const txPlan = singleTransactionPlan(message);
+            const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+            const logs = ['Program log: Error: insufficient funds'];
+            const simulationData = {
+                accounts: null,
+                innerInstructions: null,
+                loadedAccountsDataSize: null,
+                logs,
+                replacementBlockhash: null,
+                returnData: null,
+                unitsConsumed: 200_000n,
+            };
+            const preflightError = new SolanaError(
+                SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
+                { ...simulationData, cause: innerError },
+            );
+            const failedResult = failedSingleTransactionPlanResult(message, preflightError);
+            const executionError = createFailedToExecuteTransactionPlanError(failedResult);
+
+            const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
+            const customTransactionPlanExecutor = vi.fn().mockRejectedValue(executionError);
+            const client = createEmptyClient()
+                .use(transactionPlanner(customTransactionPlanner))
+                .use(transactionPlanExecutor(customTransactionPlanExecutor))
+                .use(planAndSendTransactions());
+
+            const thrownError = await client.sendTransactions({} as Instruction).catch((e: unknown) => e);
+            assert(isSolanaError(thrownError, SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS));
+            expect(thrownError.context.failedTransactions).toHaveLength(1);
+            expect(thrownError.context.failedTransactions[0].error).toBe(innerError);
+            expect(thrownError.context.failedTransactions[0].logs).toBe(logs);
+            expect(thrownError.context.failedTransactions[0].preflightData).toMatchObject(simulationData);
+        });
+
+        it('re-throws non-Solana errors unchanged', async () => {
+            const message = {} as TransactionMessage & TransactionMessageWithFeePayer;
+            const txPlan = singleTransactionPlan(message);
+            const genericError = new Error('something went wrong');
+
+            const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
+            const customTransactionPlanExecutor = vi.fn().mockRejectedValue(genericError);
+            const client = createEmptyClient()
+                .use(transactionPlanner(customTransactionPlanner))
+                .use(transactionPlanExecutor(customTransactionPlanExecutor))
+                .use(planAndSendTransactions());
+
+            const promise = client.sendTransactions({} as Instruction);
+            await expect(promise).rejects.toBe(genericError);
         });
     });
 });


### PR DESCRIPTION
This PR makes `sendTransaction` and `sendTransactions` catch internal `FAILED_TO_EXECUTE_TRANSACTION_PLAN` errors and re-throw them as `FAILED_TO_SEND_TRANSACTION` or `FAILED_TO_SEND_TRANSACTIONS` errors. Previously, callers would receive the generic "The provided transaction plan failed to execute" message, requiring them to manually dig into the `transactionPlanResult` attribute. Now the actual error details — including program error codes, logs, and preflight simulation data — are unwrapped and surfaced directly on the thrown error.

Fixes https://github.com/anza-xyz/kit-plugins/issues/108