### PR TITLE
Remove redundant `unwrapSimulationError` from RPC executor

### DIFF
--- a/.changeset/afraid-pianos-report.md
+++ b/.changeset/afraid-pianos-report.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-rpc': patch
+---
+
+Remove redundant `unwrapSimulationError` call from the default RPC executor. Simulation errors are now unwrapped by `sendTransaction` and `sendTransactions` instead.

--- a/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
+++ b/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
@@ -17,7 +17,6 @@ import {
     SlotNotificationsApi,
     SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
     TransactionPlanExecutorConfig,
-    unwrapSimulationError,
 } from '@solana/kit';
 import {
     estimateComputeUnitLimitFactory,
@@ -103,35 +102,31 @@ export function rpcTransactionPlanExecutor(
 
         const transactionPlanExecutor = createTransactionPlanExecutor({
             executeTransactionMessage: limitFunction(async (context, transactionMessage, executorConfig) => {
-                try {
-                    const needsCuEstimation = needsComputeUnitEstimation(transactionMessage);
-                    const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send(executorConfig);
-                    const signedTransaction = await pipe(
-                        setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, transactionMessage),
-                        tx => (context.message = tx),
-                        async tx =>
-                            needsCuEstimation
-                                ? await estimateAndSetComputeUnitLimit(
-                                      tx,
-                                      estimateCULimit,
-                                      config.skipPreflight ?? false,
-                                      executorConfig,
-                                  )
-                                : tx,
-                        async tx => (context.message = await tx),
-                        async tx => await signTransactionMessageWithSigners(await tx, executorConfig),
-                        async tx => (context.transaction = await tx),
-                    );
-                    assertIsTransactionWithBlockhashLifetime(signedTransaction);
-                    await sendAndConfirmTransaction(signedTransaction, {
-                        commitment: 'confirmed',
-                        skipPreflight: config.skipPreflight || needsCuEstimation,
-                        ...executorConfig,
-                    });
-                    return signedTransaction;
-                } catch (error) {
-                    throw unwrapSimulationError(error);
-                }
+                const needsCuEstimation = needsComputeUnitEstimation(transactionMessage);
+                const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send(executorConfig);
+                const signedTransaction = await pipe(
+                    setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, transactionMessage),
+                    tx => (context.message = tx),
+                    async tx =>
+                        needsCuEstimation
+                            ? await estimateAndSetComputeUnitLimit(
+                                  tx,
+                                  estimateCULimit,
+                                  config.skipPreflight ?? false,
+                                  executorConfig,
+                              )
+                            : tx,
+                    async tx => (context.message = await tx),
+                    async tx => await signTransactionMessageWithSigners(await tx, executorConfig),
+                    async tx => (context.transaction = await tx),
+                );
+                assertIsTransactionWithBlockhashLifetime(signedTransaction);
+                await sendAndConfirmTransaction(signedTransaction, {
+                    commitment: 'confirmed',
+                    skipPreflight: config.skipPreflight || needsCuEstimation,
+                    ...executorConfig,
+                });
+                return signedTransaction;
             }, config.maxConcurrency ?? 10),
         } as TransactionPlanExecutorConfig);
 

--- a/packages/kit-plugin-rpc/test/transaction-plan-executor.test.ts
+++ b/packages/kit-plugin-rpc/test/transaction-plan-executor.test.ts
@@ -12,9 +12,6 @@ import {
     singleInstructionPlan,
     singleTransactionPlan,
     SingleTransactionPlanResult,
-    SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN,
-    SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
-    SolanaError,
     SolanaRpcApi,
     SolanaRpcSubscriptionsApi,
 } from '@solana/kit';
@@ -227,67 +224,6 @@ describe('rpcTransactionPlanExecutor', () => {
             commitment: 'confirmed',
             skipPreflight: true,
         });
-    });
-
-    it('unwraps simulation errors when executing transactions', async () => {
-        const payer = await generateKeyPairSigner();
-        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
-        const simulateTransaction = vi.fn().mockResolvedValue({ value: { unitsConsumed: 42 } });
-        const rpc = {
-            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
-            simulateTransaction: () => ({ send: simulateTransaction }),
-        } as unknown as Rpc<SolanaRpcApi>;
-        const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-        const originalError = new Error('Original transaction error');
-        const sendAndConfirmTransaction = vi.fn().mockRejectedValue(
-            new SolanaError(SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT, {
-                cause: originalError,
-                unitsConsumed: 42,
-            }),
-        );
-        (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
-
-        const client = createEmptyClient()
-            .use(() => ({ payer, rpc, rpcSubscriptions }))
-            .use(rpcTransactionPlanExecutor());
-
-        const transactionPlan = singleTransactionPlan(
-            setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 })),
-        );
-        const promise = client.transactionPlanExecutor(transactionPlan);
-        await expect(promise).rejects.toThrowError(
-            new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
-                cause: originalError,
-            }),
-        );
-    });
-
-    it('does not unwrap non-simulation errors when executing transactions', async () => {
-        const payer = await generateKeyPairSigner();
-        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
-        const simulateTransaction = vi.fn().mockResolvedValue({ value: { unitsConsumed: 42 } });
-        const rpc = {
-            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
-            simulateTransaction: () => ({ send: simulateTransaction }),
-        } as unknown as Rpc<SolanaRpcApi>;
-        const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-        const originalError = new Error('Original transaction error');
-        const sendAndConfirmTransaction = vi.fn().mockRejectedValue(originalError);
-        (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
-
-        const client = createEmptyClient()
-            .use(() => ({ payer, rpc, rpcSubscriptions }))
-            .use(rpcTransactionPlanExecutor());
-
-        const transactionPlan = singleTransactionPlan(
-            setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 })),
-        );
-        const promise = client.transactionPlanExecutor(transactionPlan);
-        await expect(promise).rejects.toThrowError(
-            new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
-                cause: originalError,
-            }),
-        );
     });
 
     it('limits the number of concurrent executions for parallel transaction plans', async () => {


### PR DESCRIPTION
This PR removes the `unwrapSimulationError` call from the default RPC transaction plan executor. Since `sendTransaction` and `sendTransactions` now unwrap simulation and preflight errors when re-wrapping execution failures into user-facing errors, the executor no longer needs to do this itself. This also means the raw simulation error is preserved in the `transactionPlanResult` for callers who interact with the executor directly.