### PR TITLE
Bump `@solana-program/compute-budget` to ^0.15.0 and `@solana/kit` to ^6.3.0

### DIFF
--- a/examples/token-airdrop/package.json
+++ b/examples/token-airdrop/package.json
@@ -4,7 +4,7 @@
     "dependencies": {
         "@solana-program/system": "^0.12.0",
         "@solana-program/token": "^0.12.0",
-        "@solana/kit": "^6.2.0",
+        "@solana/kit": "^6.3.0",
         "@solana/kit-client-rpc": "workspace:*"
     },
     "type": "module",

--- a/examples/transfer-lamports/package.json
+++ b/examples/transfer-lamports/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "dependencies": {
         "@solana-program/system": "^0.12.0",
-        "@solana/kit": "^6.2.0",
+        "@solana/kit": "^6.3.0",
         "@solana/kit-client-rpc": "workspace:*"
     },
     "type": "module",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "@changesets/changelog-github": "^0.6.0",
         "@changesets/cli": "^2.30.0",
         "@solana/eslint-config-solana": "^6.0.0",
-        "@solana/kit": "^6.2.0",
+        "@solana/kit": "^6.3.0",
         "@solana/prettier-config-solana": "0.0.6",
         "@types/node": "^25",
         "agadoo": "^3.0.0",

--- a/packages/kit-client-litesvm/package.json
+++ b/packages/kit-client-litesvm/package.json
@@ -45,7 +45,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.2.0"
+        "@solana/kit": "^6.3.0"
     },
     "dependencies": {
         "@solana/kit-plugin-instruction-plan": "workspace:*",

--- a/packages/kit-client-rpc/package.json
+++ b/packages/kit-client-rpc/package.json
@@ -45,7 +45,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.2.0"
+        "@solana/kit": "^6.3.0"
     },
     "dependencies": {
         "@solana/kit-plugin-instruction-plan": "workspace:*",

--- a/packages/kit-plugin-airdrop/package.json
+++ b/packages/kit-plugin-airdrop/package.json
@@ -45,7 +45,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.2.0"
+        "@solana/kit": "^6.3.0"
     },
     "devDependencies": {
         "@solana/kit-plugin-litesvm": "workspace:*",

--- a/packages/kit-plugin-instruction-plan/package.json
+++ b/packages/kit-plugin-instruction-plan/package.json
@@ -46,7 +46,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.2.0"
+        "@solana/kit": "^6.3.0"
     },
     "license": "MIT",
     "repository": {

--- a/packages/kit-plugin-litesvm/package.json
+++ b/packages/kit-plugin-litesvm/package.json
@@ -45,11 +45,11 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.2.0"
+        "@solana/kit": "^6.3.0"
     },
     "dependencies": {
         "@loris-sandbox/litesvm-kit": "^0.5.0",
-        "@solana-program/compute-budget": "^0.14.0"
+        "@solana-program/compute-budget": "^0.15.0"
     },
     "devDependencies": {
         "@solana-program/system": "^0.12.0"

--- a/packages/kit-plugin-payer/package.json
+++ b/packages/kit-plugin-payer/package.json
@@ -46,7 +46,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.2.0"
+        "@solana/kit": "^6.3.0"
     },
     "license": "MIT",
     "repository": {

--- a/packages/kit-plugin-rpc/package.json
+++ b/packages/kit-plugin-rpc/package.json
@@ -45,10 +45,10 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.2.0"
+        "@solana/kit": "^6.3.0"
     },
     "dependencies": {
-        "@solana-program/compute-budget": "^0.14.0"
+        "@solana-program/compute-budget": "^0.15.0"
     },
     "license": "MIT",
     "repository": {

--- a/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
+++ b/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
@@ -183,7 +183,10 @@ async function estimateAndSetComputeUnitLimit<
         ) {
             // Use consumed units from the failed simulation so the
             // transaction can still reach the validator for debugging.
-            estimatedUnits = error.context.unitsConsumed;
+            // The unitsConsumed field is a raw bigint from the RPC response,
+            // so we downcast it to a u32 number, capping at 4_294_967_295.
+            const bigintUnits = error.context.unitsConsumed ?? 0n;
+            estimatedUnits = bigintUnits > 4_294_967_295n ? 4_294_967_295 : Number(bigintUnits);
         } else {
             throw error;
         }

--- a/packages/kit-plugins/package.json
+++ b/packages/kit-plugins/package.json
@@ -44,7 +44,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.2.0"
+        "@solana/kit": "^6.3.0"
     },
     "dependencies": {
         "@solana/kit-client-litesvm": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@solana/kit': ^6.2.0
+  '@solana/kit': ^6.3.0
 
 importers:
 
@@ -21,8 +21,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(@eslint/js@9.39.2)(@types/eslint@9.6.1)(@types/eslint__js@9.14.0)(eslint-plugin-jest@29.5.0(@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(jest@30.2.0(@types/node@25.4.0))(typescript@5.9.3))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.2))(eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.2))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(globals@14.0.0)(jest@30.2.0(@types/node@25.4.0))(typescript-eslint@8.50.0(eslint@9.39.2)(typescript@5.9.3))(typescript@5.9.3)
       '@solana/kit':
-        specifier: ^6.2.0
-        version: 6.2.0(typescript@5.9.3)
+        specifier: ^6.3.0
+        version: 6.3.0(typescript@5.9.3)
       '@solana/prettier-config-solana':
         specifier: 0.0.6
         version: 0.0.6(prettier@3.8.1)
@@ -64,13 +64,13 @@ importers:
     dependencies:
       '@solana-program/system':
         specifier: ^0.12.0
-        version: 0.12.0(@solana/kit@6.2.0(typescript@5.9.3))
+        version: 0.12.0(@solana/kit@6.3.0(typescript@5.9.3))
       '@solana-program/token':
         specifier: ^0.12.0
-        version: 0.12.0(@solana/kit@6.2.0(typescript@5.9.3))
+        version: 0.12.0(@solana/kit@6.3.0(typescript@5.9.3))
       '@solana/kit':
-        specifier: ^6.2.0
-        version: 6.2.0(typescript@5.9.3)
+        specifier: ^6.3.0
+        version: 6.3.0(typescript@5.9.3)
       '@solana/kit-client-rpc':
         specifier: workspace:*
         version: link:../../packages/kit-client-rpc
@@ -79,10 +79,10 @@ importers:
     dependencies:
       '@solana-program/system':
         specifier: ^0.12.0
-        version: 0.12.0(@solana/kit@6.2.0(typescript@5.9.3))
+        version: 0.12.0(@solana/kit@6.3.0(typescript@5.9.3))
       '@solana/kit':
-        specifier: ^6.2.0
-        version: 6.2.0(typescript@5.9.3)
+        specifier: ^6.3.0
+        version: 6.3.0(typescript@5.9.3)
       '@solana/kit-client-rpc':
         specifier: workspace:*
         version: link:../../packages/kit-client-rpc
@@ -90,8 +90,8 @@ importers:
   packages/kit-client-litesvm:
     dependencies:
       '@solana/kit':
-        specifier: ^6.2.0
-        version: 6.2.0(typescript@5.9.3)
+        specifier: ^6.3.0
+        version: 6.3.0(typescript@5.9.3)
       '@solana/kit-plugin-instruction-plan':
         specifier: workspace:*
         version: link:../kit-plugin-instruction-plan
@@ -105,8 +105,8 @@ importers:
   packages/kit-client-rpc:
     dependencies:
       '@solana/kit':
-        specifier: ^6.2.0
-        version: 6.2.0(typescript@5.9.3)
+        specifier: ^6.3.0
+        version: 6.3.0(typescript@5.9.3)
       '@solana/kit-plugin-instruction-plan':
         specifier: workspace:*
         version: link:../kit-plugin-instruction-plan
@@ -120,8 +120,8 @@ importers:
   packages/kit-plugin-airdrop:
     dependencies:
       '@solana/kit':
-        specifier: ^6.2.0
-        version: 6.2.0(typescript@5.9.3)
+        specifier: ^6.3.0
+        version: 6.3.0(typescript@5.9.3)
     devDependencies:
       '@solana/kit-plugin-litesvm':
         specifier: workspace:*
@@ -133,8 +133,8 @@ importers:
   packages/kit-plugin-instruction-plan:
     dependencies:
       '@solana/kit':
-        specifier: ^6.2.0
-        version: 6.2.0(typescript@5.9.3)
+        specifier: ^6.3.0
+        version: 6.3.0(typescript@5.9.3)
 
   packages/kit-plugin-litesvm:
     dependencies:
@@ -142,36 +142,36 @@ importers:
         specifier: ^0.5.0
         version: 0.5.0(typescript@5.9.3)
       '@solana-program/compute-budget':
-        specifier: ^0.14.0
-        version: 0.14.0(@solana/kit@6.2.0(typescript@5.9.3))
+        specifier: ^0.15.0
+        version: 0.15.0(@solana/kit@6.3.0(typescript@5.9.3))
       '@solana/kit':
-        specifier: ^6.2.0
-        version: 6.2.0(typescript@5.9.3)
+        specifier: ^6.3.0
+        version: 6.3.0(typescript@5.9.3)
     devDependencies:
       '@solana-program/system':
         specifier: ^0.12.0
-        version: 0.12.0(@solana/kit@6.2.0(typescript@5.9.3))
+        version: 0.12.0(@solana/kit@6.3.0(typescript@5.9.3))
 
   packages/kit-plugin-payer:
     dependencies:
       '@solana/kit':
-        specifier: ^6.2.0
-        version: 6.2.0(typescript@5.9.3)
+        specifier: ^6.3.0
+        version: 6.3.0(typescript@5.9.3)
 
   packages/kit-plugin-rpc:
     dependencies:
       '@solana-program/compute-budget':
-        specifier: ^0.14.0
-        version: 0.14.0(@solana/kit@6.2.0(typescript@5.9.3))
+        specifier: ^0.15.0
+        version: 0.15.0(@solana/kit@6.3.0(typescript@5.9.3))
       '@solana/kit':
-        specifier: ^6.2.0
-        version: 6.2.0(typescript@5.9.3)
+        specifier: ^6.3.0
+        version: 6.3.0(typescript@5.9.3)
 
   packages/kit-plugins:
     dependencies:
       '@solana/kit':
-        specifier: ^6.2.0
-        version: 6.2.0(typescript@5.9.3)
+        specifier: ^6.3.0
+        version: 6.3.0(typescript@5.9.3)
       '@solana/kit-client-litesvm':
         specifier: workspace:*
         version: link:../kit-client-litesvm
@@ -1096,33 +1096,33 @@ packages:
   '@sinonjs/fake-timers@13.0.5':
     resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
 
-  '@solana-program/compute-budget@0.14.0':
-    resolution: {integrity: sha512-tgvey/2bT35gUlb1lC84Hh2VqkOLoSa6KvaVz5DT037Mg8ECM+f2Q5Prv6V9yKQjRGGF2Y8BZgpOoUg6lTUl/Q==}
+  '@solana-program/compute-budget@0.15.0':
+    resolution: {integrity: sha512-toejNdIkzpUTqLSIzP0Nofr/EFel8QpPWuTtIKzfCcjn+mXpkThHxPJaNesk251rSTiWaxDZ3WxG7RxYwTWTqA==}
     peerDependencies:
-      '@solana/kit': ^6.2.0
+      '@solana/kit': ^6.3.0
 
   '@solana-program/system@0.10.0':
     resolution: {integrity: sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==}
     peerDependencies:
-      '@solana/kit': ^6.2.0
+      '@solana/kit': ^6.3.0
 
   '@solana-program/system@0.12.0':
     resolution: {integrity: sha512-ZnAAWeGVMWNtJhw3GdifI2HnhZ0A0H0qs8tBkcFvxp/8wIavvO+GOM4Jd0N22u2+Lni2zcwvcrxrsxj6Mjphng==}
     peerDependencies:
-      '@solana/kit': ^6.2.0
+      '@solana/kit': ^6.3.0
 
   '@solana-program/token@0.12.0':
     resolution: {integrity: sha512-hnidRNuFhmqUdW5aWkKTJ+cdzuotVMNwLsTyAk0Nd8VjLDld+vQC0fugHWqm5GPrvYe0hCNAhtpJcZVnNp7rOA==}
     peerDependencies:
-      '@solana/kit': ^6.2.0
+      '@solana/kit': ^6.3.0
 
   '@solana-program/token@0.9.0':
     resolution: {integrity: sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==}
     peerDependencies:
-      '@solana/kit': ^6.2.0
+      '@solana/kit': ^6.3.0
 
-  '@solana/accounts@6.2.0':
-    resolution: {integrity: sha512-6XfdN44nqibyxZDUyJ6o8Jmrh7y3E8Vu02PAuKBlld8mszPBqikKXloZEyjRPjnjpBStepvulOmgmHcmlWYCWw==}
+  '@solana/accounts@6.3.0':
+    resolution: {integrity: sha512-Ojd1Wz/xBveE8in4GiNEE4vd5/QbIXyCHKSAPh+ggA/iGNFv+cqFHF1EwKCXkI4FkCU7eS9JzGeh2ZuJo3bNYg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1130,8 +1130,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/addresses@6.2.0':
-    resolution: {integrity: sha512-IC0vkLZqPgM/3ugqlLRVIZ/QXPwLZT8jMnEP7KjeIVrLBGIS7tJpBWJuWMjuTjBGSVsKEC3aZgPA4CMY5kJ7lA==}
+  '@solana/addresses@6.3.0':
+    resolution: {integrity: sha512-if/HpMyoRf4+6SPBjn7UB9LKLb3fDuJn1I502FAjpXHLY13NT7JGqPPiRZuXR3U4NkZTXw6zYksO3RPIFDaWVQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1139,8 +1139,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/assertions@6.2.0':
-    resolution: {integrity: sha512-8T4tsyGnCpRz+zKSciDtUe5l1r8qCu3cXOb2njSsLAi1k1izz+laJd4nBtbnhoHCCP88mgWOIMZj5uZ+GXXMyA==}
+  '@solana/assertions@6.3.0':
+    resolution: {integrity: sha512-3eRFQofn7VLuCHmFy2XmuzqaG5SVVtSbgSSrs5BycP55hwAf2baU0hKCjj/WgumIY3UuNkfeZgfZ4FcjSERiRw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1148,8 +1148,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-core@6.2.0':
-    resolution: {integrity: sha512-HTStXi9t07g3A8PHeNIaa+BYVfqxYXn9WEpuOpSV7XFoahlxGcryChbm59VtOzb3a8tSaVL/1yd5hCbe+WwI8g==}
+  '@solana/codecs-core@6.3.0':
+    resolution: {integrity: sha512-lBrGfCa9971IInFWoh1y4a3Z824f/Rl1J/A6jKxXAu8rWLWtQFzuijE/fPlpBcxiwRh7xJOLfQc3+1YAlhd43w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1157,8 +1157,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-data-structures@6.2.0':
-    resolution: {integrity: sha512-w2pnl/nTK34e4+zs6DBdfkZdaEe9nk24xNjmeC7T0lN/mQiawO2uYgJ/I0bQg1J7qMZBN9UsasbSTWfnWQrVOQ==}
+  '@solana/codecs-data-structures@6.3.0':
+    resolution: {integrity: sha512-D89S6Fi8g5lN4fvKYQri3A1x64XmOMqsda3rn4ycCvNjgJIh3Vmhixt1GwdJ61r/nhURRAaQhlvywo7OtztZCQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1166,8 +1166,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-numbers@6.2.0':
-    resolution: {integrity: sha512-4bA0eWxY5bZ9N3MNFxZIvd7N+qIHoEemIg5o/UC2d8pgIBx4zwyyvy3p9a7Mfnj+s+Iia3HbnVl7kYcakuFeBw==}
+  '@solana/codecs-numbers@6.3.0':
+    resolution: {integrity: sha512-FPDaNA9loTsEfhMm8RwLWe4xMZkrnzD8xv9MDLj5u7q6hZT5R8wCDq5l1SYOl115S3RvuUaIaccxYCnhdcUkwA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1175,8 +1175,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-strings@6.2.0':
-    resolution: {integrity: sha512-y7OY5jGDqHlEi4IIfxWnHocRrjarjUujnu56cCYmK1MVgGa3qmLxpSIzPPJlHQiTBLP/iLeVjvQjF8MWOMZSiw==}
+  '@solana/codecs-strings@6.3.0':
+    resolution: {integrity: sha512-Y2zu90M+iLLGNfuGS1B+G69exd9z8Xka6iyAXm4r2BebVl+wd0vjAtfcua/KGcwKT89bxrtjS3Oerc5rtxBeWg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
@@ -1187,8 +1187,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs@6.2.0':
-    resolution: {integrity: sha512-vIHbT/qo6A0Go4j87RpsM9eDJQXK1mmGkWq5/6Q73j/xerjZxa7cFif0GMVCmORoyLZJ1LoGICRpqaZYxKSP1Q==}
+  '@solana/codecs@6.3.0':
+    resolution: {integrity: sha512-tPcvU7Iv2B0kD1NVBFsqgTn92bPtWqbv8YEqR++mJieRmbd6vq7aBx+7AXh3vHfBhtrxPx982OXOzBr8DXaOMw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1196,8 +1196,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/errors@6.2.0':
-    resolution: {integrity: sha512-GckKPJY+0AfIWHtVnccQFjpCXgIxz12RVDOgCJa7Nc/EcxisOGpTqgPYnZ4Q16jOuBI5dgeRxYNGBdyJJgWy3g==}
+  '@solana/errors@6.3.0':
+    resolution: {integrity: sha512-NGd0NQ7BoB7s5JDv87/CvlKrKuLBoPgT5eVXogmaRorFqXPU7wGwBgykfoyAh0eRDUT1dUvD+8xdZMSj6huKCw==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
@@ -1223,8 +1223,8 @@ packages:
       typescript: ^5.9.3
       typescript-eslint: ^8.49.0
 
-  '@solana/fast-stable-stringify@6.2.0':
-    resolution: {integrity: sha512-Bt8OU0HNdqh0Dr9lTgiBwKAl5AUpXk5TD18hHX1jtGhuFOsRvRdPLa59D/32x/gaxls/03kaXDVKZ60MCdf5VQ==}
+  '@solana/fast-stable-stringify@6.3.0':
+    resolution: {integrity: sha512-Ah4TVY/JfRjd/HoyLmJud2C47eu7QICfVjSZm/LcTinT/8iDGOjQGEY6NeZ4HkmMl/PMg4GMR9PkrD+0PO25+w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1232,8 +1232,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/functional@6.2.0':
-    resolution: {integrity: sha512-vurCNEtWx/kQuO7yuQZGftZWTJAehwNuL6V/v7ZmA11i7OwUBs9W7RYzkP/vr0De1uGn96xsTbN9p/EbsF45Gw==}
+  '@solana/functional@6.3.0':
+    resolution: {integrity: sha512-rAUOPsoOAvPQMGWaVJZVPEWTPKx9/sHYKjg5PkS8mPNeelfyTlnDS+NxxbfSLUYieFKGGhyT0OfBhOKNnLPGMQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1241,8 +1241,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/instruction-plans@6.2.0':
-    resolution: {integrity: sha512-XGt7iclH4HFFH9Jrct2Te23y06nuuk2YD1fJRuR21nnb74cAeXJi6+PCK6zNCINTR8l9CxKR3pzWDq6BD+jwXg==}
+  '@solana/instruction-plans@6.3.0':
+    resolution: {integrity: sha512-qKkTLBNjDmisGSajcpRYSbvIF0p5mZLHeYhxX9Py1XdX/gDiIzmPhDt+DvuD9Z0H8y5jCfhksGzmRIzy7UEu7g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1250,8 +1250,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/instructions@6.2.0':
-    resolution: {integrity: sha512-eBYE4ucmJ5Xc7w4UJek0/GbcbzJoWWk/aolDAt9xkea0lDxSC+y3fW58CvBc9vz1qxnEcFrxa+pgUBqwZ1BIFg==}
+  '@solana/instructions@6.3.0':
+    resolution: {integrity: sha512-7nQGafBhZF17bOKA1Jjq9HEImvSi5zqQqCxnuWfCV2XyOsXsQ+IdYfVJEk7EFIN8KMFSzzI8Z2hG6VtVRn9T6g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1259,8 +1259,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/keys@6.2.0':
-    resolution: {integrity: sha512-1CE14VNpB3DIQNtOdrvYUuDTDcdtRXnnM9dAhvTeHbQeDa30sWFBqBL2dVDIVP8F/UosX8fEzMR9SQvI19IivQ==}
+  '@solana/keys@6.3.0':
+    resolution: {integrity: sha512-vCvtVv2iIVfvVmg5dgVpHLO6y1zTM+GYogdF/xWGJxiHGWqUx1Mlj2GBAcVxTMJUkrKv6ktNxxAVuhG+sKMhbw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1268,8 +1268,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/kit@6.2.0':
-    resolution: {integrity: sha512-T9fRFHAFZ8CMtetpukPhCB9HoumuoOYTgCXrry5G2yhTO86a5PMkIwZI+kya6iDh0Qp9srOjtuGrVh4xA+BLFQ==}
+  '@solana/kit@6.3.0':
+    resolution: {integrity: sha512-+p0S2ezNdHgVItqiRPyR3kRJSMLpriCWMAhM8dtf1j0iFg7UiryPUdp2eg1Nn+kqesRIx0rzAlcnFzpHjg3OIg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1277,8 +1277,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/nominal-types@6.2.0':
-    resolution: {integrity: sha512-HkrXkM8Ku4J0XYfh0XUEo67IyX1BAfI7m4MpJvnXh987YeiSwoyGTLBxQAWFIONxuTDTR/s5mfNXFB+6uAQTlA==}
+  '@solana/nominal-types@6.3.0':
+    resolution: {integrity: sha512-WJq6yD4quXtysPIuH/TRVHgQTjpgFpkQeXYr6xTBTHIsUsICeZA9H8J7Ajd97dU1mgCZBvs4yuul3lIOL1HdUA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1286,8 +1286,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/offchain-messages@6.2.0':
-    resolution: {integrity: sha512-Lx3yR2+t0uWULghEO7sMZR1xmPsZz/BvRPc9JiRjTd3jP54x346vecXZCIRdFXHZ79KVeCGaCx0GC8d41MGmSQ==}
+  '@solana/offchain-messages@6.3.0':
+    resolution: {integrity: sha512-7b2a2BEqX/bixcg5JhkUV7ntqFuhyJCvT+m8xecVhiEagCNkrZCfvKYbMslJaCQ/5ojFBGKlBHLHp25PcPYavQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1295,8 +1295,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/options@6.2.0':
-    resolution: {integrity: sha512-0He7qDNyFt61GwjLHdKM5uKsHYEKgiLljbysyZCBrr7dp42LkVmd59HA+bLBcnijcgJZ6JsNjxHTBOw+esulKQ==}
+  '@solana/options@6.3.0':
+    resolution: {integrity: sha512-nwUfBHB4WVhSAiZjlvjAGT+2swC+8T01BievMDTESeAnqB+j/cl7Ke/ncF3keCNhw9rTSUKCgSFLGdNPXBIPjg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1304,8 +1304,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/plugin-core@6.2.0':
-    resolution: {integrity: sha512-muQKHsFs2yp6w9keIDwv8b1mALHjHMUpBM1HRxKZML9o4BLIj89gsvrCT5QaHVjIcScOWvtf8D/EQ2SUHwIpMg==}
+  '@solana/plugin-core@6.3.0':
+    resolution: {integrity: sha512-td/twT1TwPng2vZ26PU/zIpFC8Hv43tNXQft09Bo+9AY7VIcd+zyO9fdcZJ80pJzq2vNGcrNKBR741c9x2OSVg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1313,8 +1313,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/plugin-interfaces@6.2.0':
-    resolution: {integrity: sha512-yh5RflQPE67ub30ssNuOXUGWk0rzkuI3ybjF5AX6p49BJWfUmx3j8GCYcTjRb9tCzsCzONlP73U9uGrY0zzFvQ==}
+  '@solana/plugin-interfaces@6.3.0':
+    resolution: {integrity: sha512-D+74BQCtSDbluPzVp7Ll/05LHQChjsBs0W6dDj62Rt1hiGnNIfeNfomSOBCEBhiauL9+qMP5KkwHwebb9/ySeQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1327,8 +1327,8 @@ packages:
     peerDependencies:
       prettier: ^3.7.4
 
-  '@solana/program-client-core@6.2.0':
-    resolution: {integrity: sha512-B044ZU02akGs1AtggEUvg6fsNKL970UJVRDDKBvQ6M9GX7c7R6sbNPFQoAuKUW3dAa9KSI5w2vOJDJTLzn1B+Q==}
+  '@solana/program-client-core@6.3.0':
+    resolution: {integrity: sha512-gFv6TqlMwbNdrxZ3PECB700uXqpSAyG67LxsjYFfPT0S8F7y5TgbDbjCtNv1cCc2WC4d6uOIdEqXm7PL4DBI1Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1336,8 +1336,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/programs@6.2.0':
-    resolution: {integrity: sha512-8GEmlY3d20UI3ncHvu2IDk5U+lvdMD8888oRYqK4YOlsumDGgIjN6RFHL+0KvkMx7k1yU7dpUl9/WpUj2CioEQ==}
+  '@solana/programs@6.3.0':
+    resolution: {integrity: sha512-Hkh7o63ddK2cQYJAoNHYn2WhuZDAM8Vx5sOs82Qt7khVWFN0UCLvhzf6ChNRdP9SiGofJOF/1yA96Tsfzer9aw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1345,8 +1345,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/promises@6.2.0':
-    resolution: {integrity: sha512-m4JJtbnd13ifYQn7Dx3ZqMmV8/yJ59QeGb9hDdQRWAtJs40JocnlanKGZ0yX0FxYq5mHMWDR6P9Yz/Kh3XPQ+Q==}
+  '@solana/promises@6.3.0':
+    resolution: {integrity: sha512-RaKlDg6m1x8dK1z5Vlqg/OgEFrQx7qW6Sp8cVOScw10UskhKpUNCyjEeQ/LUmSXHEemXlI7lC+eDPOyzIeiZEA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1354,8 +1354,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-api@6.2.0':
-    resolution: {integrity: sha512-jl40NKwpHXkCje1HAyBr2iiIhYl3G5CuUhOZeD9uikBE0lIef2vrqj5qClUkrQgqYOCpb/Kh0QFdKM4PI+HYqg==}
+  '@solana/rpc-api@6.3.0':
+    resolution: {integrity: sha512-RyuiudvrRIEhn+l2k9Zc7pScrMvNdZNH0LHpNAQBYxYykwHvVfrWQn44NgxKSFpGfHcc+Sag1hO0fnkaP76MAg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1363,8 +1363,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-parsed-types@6.2.0':
-    resolution: {integrity: sha512-NzhrZ7ENoqtlw3Xy9gmaE6ByVC38BSTL752O7iXTZF0vUZY7aY+mMmjvnGR5PCPr1UM/GI29KD+gXQXk8NJOOA==}
+  '@solana/rpc-parsed-types@6.3.0':
+    resolution: {integrity: sha512-hhmBxVj9gVkv+Sc1h10qDYYFnXv8DKqklkC/SdbpR9lc7+w/f6rHGqzSUI6cZa4nrfZU5Ekjo38Dg60k8aX2lQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1372,8 +1372,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-spec-types@6.2.0':
-    resolution: {integrity: sha512-aWyv7BMayXwKHpxc70Y24AGouvvRcBPkgNGtcPbfxnlyJIdFhqkWyHyuSzKNJa6jKLxOfb7r9CB9YkkiNU7q2Q==}
+  '@solana/rpc-spec-types@6.3.0':
+    resolution: {integrity: sha512-FqSc9nLh+7FOC23STdZMylOP8o1fYdQ8AmkLgRyf+5tOhPGi313bChl/jreoKGtuqcGDzFWU49CFTJJvgIawnw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1381,8 +1381,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-spec@6.2.0':
-    resolution: {integrity: sha512-oITJE++fknwR4i1wfvkPlYs6U2NZoTOCLpKa7OBwOr/rHrStfgmvCA57pzEiBuepcWQW34oncCw2eOxMwl8paQ==}
+  '@solana/rpc-spec@6.3.0':
+    resolution: {integrity: sha512-tKJve38H96baAhLb2fMQv282gwe63C9gC3u0wi+RHLq9sB7ZkB8VJctUloqqo4ZGoYTjC7sHOqhGOQH7nyKgPQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1390,8 +1390,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-api@6.2.0':
-    resolution: {integrity: sha512-AVV970+DfqwgtQbTliZ6ab/P90OLrh/Pa2hTJ/lAIvyj9sdGYtWOcxOY5ql4/NM80vYPLS4Jgk/x1RKbcgXc+Q==}
+  '@solana/rpc-subscriptions-api@6.3.0':
+    resolution: {integrity: sha512-sU/tDbJLiWNVb2kSTiJrpDbTj3oM+7Guqxg5Vr3SSGTIQhfogAjwBOTTuAkrrdX6k+7kNM8I6WLGfiTOKj9AmA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1399,8 +1399,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-channel-websocket@6.2.0':
-    resolution: {integrity: sha512-e9elkohNqaz522/4GcF7i7OLVOn4hzzpQCdvQ6gkO2AkoG2v9AxbfnPz4OedSNG8JmciAQ9HpioubyVFGokoew==}
+  '@solana/rpc-subscriptions-channel-websocket@6.3.0':
+    resolution: {integrity: sha512-Q1rxzmE9v+vq5tk4qcJLqeNIhgrEZUOQW8KcXSgcBNs0merTFyw7jFbcGRnSIhUFELOUADbDoUF2Aq4iu58E5Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1408,8 +1408,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-spec@6.2.0':
-    resolution: {integrity: sha512-ggFjwQj9tqXBGnNaOHwt/cw1CXuo5JTuzBnIij6jVQq26MZ3+VDib6ELaR8zlRxwVitYQzRmDDcOyISTfEHlfw==}
+  '@solana/rpc-subscriptions-spec@6.3.0':
+    resolution: {integrity: sha512-2JVxx3IH9m04E5XONailQySXcwjCGvc98ItDVMQfaTp9/84kOmsD77IAopU2KxqpD79YpX+DBh2HNQ1h6O9hDQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1417,8 +1417,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions@6.2.0':
-    resolution: {integrity: sha512-it9q5XNQxAZCBkJU1I6Q6Cpf579pdymKeHJUAVTsGmtM+K3TvOJQxFt7TDqxa12bpCD3rxYH1UClnK0VbaSk5A==}
+  '@solana/rpc-subscriptions@6.3.0':
+    resolution: {integrity: sha512-qOmujPoimhDLSYcEwMULRPQ7lR1+Frydl56nNBv87b53skvLoS2525poec/ewnlklmymsAV6SoNbgZHbag2ZBQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1426,8 +1426,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-transformers@6.2.0':
-    resolution: {integrity: sha512-d6lrvaTDmKwkrWBUHJqwlisbTQ4akhGsCTO5F8NCgqEUADPKVnPrfvhsdtqYSw7JqB5LcEUawt6eZ1ZR/nJokA==}
+  '@solana/rpc-transformers@6.3.0':
+    resolution: {integrity: sha512-UMoZnO2BqYld8WW5vBaR+DDK/mkGLtDR23sra2zc/1XZl+jaTibpMmph9+Eh5hSsioM41TUgoElx8HwDxpofvA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1435,8 +1435,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-transport-http@6.2.0':
-    resolution: {integrity: sha512-jf1yJi1v1Zi+n8WaZbtqNqV/h/XOTdC1nEwwm0kfRQiqNGHoRQFd+8Id/jUO6CL3TVYy1B1aQgH6Wh/3cr9QJA==}
+  '@solana/rpc-transport-http@6.3.0':
+    resolution: {integrity: sha512-wcxvn4AFAve/9DGQOgaPyYPP8pFBFUbtW4mnRsio4d29bf/b6T7Jv6ViBfTrTu3XJ986EbOB7EWioezRc7hQEg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1444,8 +1444,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-types@6.2.0':
-    resolution: {integrity: sha512-T9Zm/a5wW8kMtA6+M73C2PBknnWtGESfiIkL5qIaWoUbMJVZTK+zlibbr0R+b1+3UcRZWzHz4aIceacAtZiioQ==}
+  '@solana/rpc-types@6.3.0':
+    resolution: {integrity: sha512-iUQuFi+k4CvO/xQfayhfG0Xoa6a+NOxSK4jIXusKHa5Ol3rmbJckf5QXKubTrQoe8+j9bPoai2pDT/qpYdzwlw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1453,8 +1453,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc@6.2.0':
-    resolution: {integrity: sha512-xvCdVzZuQOWRvLB7vsHyhuHpPjFqywyJmGT48y0m35VMKw9u5xEWhpXZ2zV4GypyGLUQztlCPN83YGkcUqCeHA==}
+  '@solana/rpc@6.3.0':
+    resolution: {integrity: sha512-F8ROr7yJjwi8ISJv+rZmVScKXtD8up6MiixBrsmbfS0Em1UJkyalJkM27rGVJj6N8Nzm7Y0FwCgm4HjDFbfLvw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1462,8 +1462,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/signers@6.2.0':
-    resolution: {integrity: sha512-1HSa7qlbpjIcb7uhYcOwJzlH4niUu5W4X167nVeNbLA6yaqBABAM8su6iqdetnenv2Vyx2jB32WGbECKRB9NGQ==}
+  '@solana/signers@6.3.0':
+    resolution: {integrity: sha512-zeoASFELXFlWkbiza9ZIDPmyRn8i2Ze4j83u9XIBGRm6Fne89qFxaBkcMGebfhXwRVr9jjfb0fWvm3LlSF7PTA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1471,8 +1471,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/subscribable@6.2.0':
-    resolution: {integrity: sha512-HnQmydL541gGu6wbwH3KMdd17FxDSKp04yMPwzpYKZtOGGA4yF5F8xT2yKRmy9oL6Ib1esYHUF2Fkh+EinjgmQ==}
+  '@solana/subscribable@6.3.0':
+    resolution: {integrity: sha512-x4dTuvimHrgeYfsr3UDgWhT99a70ODOHrT4X8gpiq/AFKC2DBsqIevUBMaSf9xVR5JBa8XnVkBC5NiId7dHgXA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1480,8 +1480,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/sysvars@6.2.0':
-    resolution: {integrity: sha512-Rug/KbW+vSMtKeMmC7EK/PAigb1IX9V6sWj4M6VDV+VhVek5LbFQu1breckKwDaHdsQWQQSzLYggBMBFyirRLQ==}
+  '@solana/sysvars@6.3.0':
+    resolution: {integrity: sha512-kUYY766Ct9HSmLiXWZqKkkZsiH5BDLm7FtejY7eCG5OBOrT/v0cCRsxFQhQvozwJK//exQWhsWhX9Vdcc1ZbxQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1489,8 +1489,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/transaction-confirmation@6.2.0':
-    resolution: {integrity: sha512-HyqXUZt5RU2MNAC/odxxK73Q4hibXErY+oLaF5hIPVbKeuZ6smfuDmz2b66Hcwlveko9he5MtmLhuL8j8e4QnQ==}
+  '@solana/transaction-confirmation@6.3.0':
+    resolution: {integrity: sha512-HNlS1BVWPSawHfQkoNkS1dFrZHypPlSoh65CEqfbwnnKKU6AuhSmGSMjz3qdm8rK9nxCuHNNUJuXxGYeI4vNCQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1498,8 +1498,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/transaction-messages@6.2.0':
-    resolution: {integrity: sha512-ccKLHoNWU/ZknOqTAAbvd9LJDQfHnT5SZfPbrYNlpYnjK7ILaUlqq2FG/PUK2Y4SWStAyub0myDy4P0s21G9mg==}
+  '@solana/transaction-messages@6.3.0':
+    resolution: {integrity: sha512-zcohnwHiZxogc7GpWeDdc4/Q7tZvuYSIabq9dKduQz5y/LCcMMpbvOB7bpWR+P+0S5RamgTxUnAPKMnA/hXmwA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -1507,8 +1507,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/transactions@6.2.0':
-    resolution: {integrity: sha512-ItOgWG5F34lp44C9N+njj77pOFcnV82NZnt42l6VW03sfgMr3Pquj7uyYpmKeZ+hN1J+s8jDR1OxhQv7TMrEUg==}
+  '@solana/transactions@6.3.0':
+    resolution: {integrity: sha512-jxUIEbzxqdEvAdg/FpX3gu8lcNaKqeq/GKdXkBFapzpqaHftnMro3e4F0k/heNglO0M8umOZ4+LN6rNHxpHI8g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: ^5.0.0
@@ -4292,9 +4292,9 @@ snapshots:
 
   '@loris-sandbox/litesvm-kit@0.5.0(typescript@5.9.3)':
     dependencies:
-      '@solana-program/system': 0.10.0(@solana/kit@6.2.0(typescript@5.9.3))
-      '@solana-program/token': 0.9.0(@solana/kit@6.2.0(typescript@5.9.3))
-      '@solana/kit': 6.2.0(typescript@5.9.3)
+      '@solana-program/system': 0.10.0(@solana/kit@6.3.0(typescript@5.9.3))
+      '@solana-program/token': 0.9.0(@solana/kit@6.3.0(typescript@5.9.3))
+      '@solana/kit': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       '@loris-sandbox/litesvm-kit-darwin-arm64': 0.5.0
       '@loris-sandbox/litesvm-kit-darwin-x64': 0.5.0
@@ -4503,100 +4503,100 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@solana-program/compute-budget@0.14.0(@solana/kit@6.2.0(typescript@5.9.3))':
+  '@solana-program/compute-budget@0.15.0(@solana/kit@6.3.0(typescript@5.9.3))':
     dependencies:
-      '@solana/kit': 6.2.0(typescript@5.9.3)
+      '@solana/kit': 6.3.0(typescript@5.9.3)
 
-  '@solana-program/system@0.10.0(@solana/kit@6.2.0(typescript@5.9.3))':
+  '@solana-program/system@0.10.0(@solana/kit@6.3.0(typescript@5.9.3))':
     dependencies:
-      '@solana/kit': 6.2.0(typescript@5.9.3)
+      '@solana/kit': 6.3.0(typescript@5.9.3)
 
-  '@solana-program/system@0.12.0(@solana/kit@6.2.0(typescript@5.9.3))':
+  '@solana-program/system@0.12.0(@solana/kit@6.3.0(typescript@5.9.3))':
     dependencies:
-      '@solana/kit': 6.2.0(typescript@5.9.3)
+      '@solana/kit': 6.3.0(typescript@5.9.3)
 
-  '@solana-program/token@0.12.0(@solana/kit@6.2.0(typescript@5.9.3))':
+  '@solana-program/token@0.12.0(@solana/kit@6.3.0(typescript@5.9.3))':
     dependencies:
-      '@solana-program/system': 0.12.0(@solana/kit@6.2.0(typescript@5.9.3))
-      '@solana/kit': 6.2.0(typescript@5.9.3)
+      '@solana-program/system': 0.12.0(@solana/kit@6.3.0(typescript@5.9.3))
+      '@solana/kit': 6.3.0(typescript@5.9.3)
 
-  '@solana-program/token@0.9.0(@solana/kit@6.2.0(typescript@5.9.3))':
+  '@solana-program/token@0.9.0(@solana/kit@6.3.0(typescript@5.9.3))':
     dependencies:
-      '@solana/kit': 6.2.0(typescript@5.9.3)
+      '@solana/kit': 6.3.0(typescript@5.9.3)
 
-  '@solana/accounts@6.2.0(typescript@5.9.3)':
+  '@solana/accounts@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-spec': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.2.0(typescript@5.9.3)
+      '@solana/addresses': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@6.2.0(typescript@5.9.3)':
+  '@solana/addresses@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/assertions': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.2.0(typescript@5.9.3)
+      '@solana/assertions': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/assertions@6.2.0(typescript@5.9.3)':
+  '@solana/assertions@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.2.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-core@6.2.0(typescript@5.9.3)':
+  '@solana/codecs-core@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.2.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-data-structures@6.2.0(typescript@5.9.3)':
+  '@solana/codecs-data-structures@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-numbers@6.2.0(typescript@5.9.3)':
+  '@solana/codecs-numbers@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-strings@6.2.0(typescript@5.9.3)':
+  '@solana/codecs-strings@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs@6.2.0(typescript@5.9.3)':
+  '@solana/codecs@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.2.0(typescript@5.9.3)
-      '@solana/options': 6.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.3.0(typescript@5.9.3)
+      '@solana/options': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/errors@6.2.0(typescript@5.9.3)':
+  '@solana/errors@6.3.0(typescript@5.9.3)':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
@@ -4619,72 +4619,72 @@ snapshots:
       typescript: 5.9.3
       typescript-eslint: 8.50.0(eslint@9.39.2)(typescript@5.9.3)
 
-  '@solana/fast-stable-stringify@6.2.0(typescript@5.9.3)':
+  '@solana/fast-stable-stringify@6.3.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/functional@6.2.0(typescript@5.9.3)':
+  '@solana/functional@6.3.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/instruction-plans@6.2.0(typescript@5.9.3)':
+  '@solana/instruction-plans@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/instructions': 6.2.0(typescript@5.9.3)
-      '@solana/keys': 6.2.0(typescript@5.9.3)
-      '@solana/promises': 6.2.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.2.0(typescript@5.9.3)
-      '@solana/transactions': 6.2.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/instructions': 6.3.0(typescript@5.9.3)
+      '@solana/keys': 6.3.0(typescript@5.9.3)
+      '@solana/promises': 6.3.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.3.0(typescript@5.9.3)
+      '@solana/transactions': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/instructions@6.2.0(typescript@5.9.3)':
+  '@solana/instructions@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/keys@6.2.0(typescript@5.9.3)':
+  '@solana/keys@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/assertions': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.2.0(typescript@5.9.3)
+      '@solana/assertions': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@6.2.0(typescript@5.9.3)':
+  '@solana/kit@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/accounts': 6.2.0(typescript@5.9.3)
-      '@solana/addresses': 6.2.0(typescript@5.9.3)
-      '@solana/codecs': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/functional': 6.2.0(typescript@5.9.3)
-      '@solana/instruction-plans': 6.2.0(typescript@5.9.3)
-      '@solana/instructions': 6.2.0(typescript@5.9.3)
-      '@solana/keys': 6.2.0(typescript@5.9.3)
-      '@solana/offchain-messages': 6.2.0(typescript@5.9.3)
-      '@solana/plugin-core': 6.2.0(typescript@5.9.3)
-      '@solana/plugin-interfaces': 6.2.0(typescript@5.9.3)
-      '@solana/program-client-core': 6.2.0(typescript@5.9.3)
-      '@solana/programs': 6.2.0(typescript@5.9.3)
-      '@solana/rpc': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-api': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-parsed-types': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.2.0(typescript@5.9.3)
-      '@solana/signers': 6.2.0(typescript@5.9.3)
-      '@solana/sysvars': 6.2.0(typescript@5.9.3)
-      '@solana/transaction-confirmation': 6.2.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.2.0(typescript@5.9.3)
-      '@solana/transactions': 6.2.0(typescript@5.9.3)
+      '@solana/accounts': 6.3.0(typescript@5.9.3)
+      '@solana/addresses': 6.3.0(typescript@5.9.3)
+      '@solana/codecs': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/functional': 6.3.0(typescript@5.9.3)
+      '@solana/instruction-plans': 6.3.0(typescript@5.9.3)
+      '@solana/instructions': 6.3.0(typescript@5.9.3)
+      '@solana/keys': 6.3.0(typescript@5.9.3)
+      '@solana/offchain-messages': 6.3.0(typescript@5.9.3)
+      '@solana/plugin-core': 6.3.0(typescript@5.9.3)
+      '@solana/plugin-interfaces': 6.3.0(typescript@5.9.3)
+      '@solana/program-client-core': 6.3.0(typescript@5.9.3)
+      '@solana/programs': 6.3.0(typescript@5.9.3)
+      '@solana/rpc': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-api': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.3.0(typescript@5.9.3)
+      '@solana/signers': 6.3.0(typescript@5.9.3)
+      '@solana/sysvars': 6.3.0(typescript@5.9.3)
+      '@solana/transaction-confirmation': 6.3.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.3.0(typescript@5.9.3)
+      '@solana/transactions': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4692,50 +4692,50 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/nominal-types@6.2.0(typescript@5.9.3)':
+  '@solana/nominal-types@6.3.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/offchain-messages@6.2.0(typescript@5.9.3)':
+  '@solana/offchain-messages@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/keys': 6.2.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.2.0(typescript@5.9.3)
+      '@solana/addresses': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/keys': 6.3.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/options@6.2.0(typescript@5.9.3)':
+  '@solana/options@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/plugin-core@6.2.0(typescript@5.9.3)':
+  '@solana/plugin-core@6.3.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/plugin-interfaces@6.2.0(typescript@5.9.3)':
+  '@solana/plugin-interfaces@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.2.0(typescript@5.9.3)
-      '@solana/instruction-plans': 6.2.0(typescript@5.9.3)
-      '@solana/keys': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-spec': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-spec': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.2.0(typescript@5.9.3)
-      '@solana/signers': 6.2.0(typescript@5.9.3)
+      '@solana/addresses': 6.3.0(typescript@5.9.3)
+      '@solana/instruction-plans': 6.3.0(typescript@5.9.3)
+      '@solana/keys': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.3.0(typescript@5.9.3)
+      '@solana/signers': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4745,88 +4745,88 @@ snapshots:
     dependencies:
       prettier: 3.8.1
 
-  '@solana/program-client-core@6.2.0(typescript@5.9.3)':
+  '@solana/program-client-core@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/accounts': 6.2.0(typescript@5.9.3)
-      '@solana/addresses': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/instruction-plans': 6.2.0(typescript@5.9.3)
-      '@solana/instructions': 6.2.0(typescript@5.9.3)
-      '@solana/plugin-interfaces': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-api': 6.2.0(typescript@5.9.3)
-      '@solana/signers': 6.2.0(typescript@5.9.3)
+      '@solana/accounts': 6.3.0(typescript@5.9.3)
+      '@solana/addresses': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/instruction-plans': 6.3.0(typescript@5.9.3)
+      '@solana/instructions': 6.3.0(typescript@5.9.3)
+      '@solana/plugin-interfaces': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-api': 6.3.0(typescript@5.9.3)
+      '@solana/signers': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/programs@6.2.0(typescript@5.9.3)':
+  '@solana/programs@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
+      '@solana/addresses': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/promises@6.2.0(typescript@5.9.3)':
+  '@solana/promises@6.3.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-api@6.2.0(typescript@5.9.3)':
+  '@solana/rpc-api@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/keys': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-parsed-types': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-spec': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-transformers': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.2.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.2.0(typescript@5.9.3)
-      '@solana/transactions': 6.2.0(typescript@5.9.3)
+      '@solana/addresses': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/keys': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.3.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.3.0(typescript@5.9.3)
+      '@solana/transactions': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-parsed-types@6.2.0(typescript@5.9.3)':
+  '@solana/rpc-parsed-types@6.3.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-spec-types@6.2.0(typescript@5.9.3)':
+  '@solana/rpc-spec-types@6.3.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-spec@6.2.0(typescript@5.9.3)':
+  '@solana/rpc-spec@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.2.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-subscriptions-api@6.2.0(typescript@5.9.3)':
+  '@solana/rpc-subscriptions-api@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.2.0(typescript@5.9.3)
-      '@solana/keys': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-spec': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-transformers': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.2.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.2.0(typescript@5.9.3)
-      '@solana/transactions': 6.2.0(typescript@5.9.3)
+      '@solana/addresses': 6.3.0(typescript@5.9.3)
+      '@solana/keys': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.3.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.3.0(typescript@5.9.3)
+      '@solana/transactions': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@6.2.0(typescript@5.9.3)':
+  '@solana/rpc-subscriptions-channel-websocket@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/functional': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-spec': 6.2.0(typescript@5.9.3)
-      '@solana/subscribable': 6.2.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/functional': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.3.0(typescript@5.9.3)
+      '@solana/subscribable': 6.3.0(typescript@5.9.3)
       ws: 8.19.0
     optionalDependencies:
       typescript: 5.9.3
@@ -4834,28 +4834,28 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@solana/rpc-subscriptions-spec@6.2.0(typescript@5.9.3)':
+  '@solana/rpc-subscriptions-spec@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/promises': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.2.0(typescript@5.9.3)
-      '@solana/subscribable': 6.2.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/promises': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.3.0(typescript@5.9.3)
+      '@solana/subscribable': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-subscriptions@6.2.0(typescript@5.9.3)':
+  '@solana/rpc-subscriptions@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/fast-stable-stringify': 6.2.0(typescript@5.9.3)
-      '@solana/functional': 6.2.0(typescript@5.9.3)
-      '@solana/promises': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-api': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-channel-websocket': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-spec': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-transformers': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.2.0(typescript@5.9.3)
-      '@solana/subscribable': 6.2.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 6.3.0(typescript@5.9.3)
+      '@solana/functional': 6.3.0(typescript@5.9.3)
+      '@solana/promises': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-api': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-channel-websocket': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.3.0(typescript@5.9.3)
+      '@solana/subscribable': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4863,103 +4863,103 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/rpc-transformers@6.2.0(typescript@5.9.3)':
+  '@solana/rpc-transformers@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/functional': 6.2.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.2.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/functional': 6.3.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-transport-http@6.2.0(typescript@5.9.3)':
+  '@solana/rpc-transport-http@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-spec': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.2.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.3.0(typescript@5.9.3)
       undici-types: 7.22.0
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-types@6.2.0(typescript@5.9.3)':
+  '@solana/rpc-types@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.2.0(typescript@5.9.3)
+      '@solana/addresses': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc@6.2.0(typescript@5.9.3)':
+  '@solana/rpc@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/fast-stable-stringify': 6.2.0(typescript@5.9.3)
-      '@solana/functional': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-api': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-spec': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-transformers': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-transport-http': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.2.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 6.3.0(typescript@5.9.3)
+      '@solana/functional': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-api': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-transport-http': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@6.2.0(typescript@5.9.3)':
+  '@solana/signers@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/instructions': 6.2.0(typescript@5.9.3)
-      '@solana/keys': 6.2.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.2.0(typescript@5.9.3)
-      '@solana/offchain-messages': 6.2.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.2.0(typescript@5.9.3)
-      '@solana/transactions': 6.2.0(typescript@5.9.3)
+      '@solana/addresses': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/instructions': 6.3.0(typescript@5.9.3)
+      '@solana/keys': 6.3.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.3.0(typescript@5.9.3)
+      '@solana/offchain-messages': 6.3.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.3.0(typescript@5.9.3)
+      '@solana/transactions': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/subscribable@6.2.0(typescript@5.9.3)':
+  '@solana/subscribable@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.2.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/sysvars@6.2.0(typescript@5.9.3)':
+  '@solana/sysvars@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/accounts': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.2.0(typescript@5.9.3)
+      '@solana/accounts': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@6.2.0(typescript@5.9.3)':
+  '@solana/transaction-confirmation@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/keys': 6.2.0(typescript@5.9.3)
-      '@solana/promises': 6.2.0(typescript@5.9.3)
-      '@solana/rpc': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.2.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.2.0(typescript@5.9.3)
-      '@solana/transactions': 6.2.0(typescript@5.9.3)
+      '@solana/addresses': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/keys': 6.3.0(typescript@5.9.3)
+      '@solana/promises': 6.3.0(typescript@5.9.3)
+      '@solana/rpc': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.3.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.3.0(typescript@5.9.3)
+      '@solana/transactions': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4967,36 +4967,36 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/transaction-messages@6.2.0(typescript@5.9.3)':
+  '@solana/transaction-messages@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/functional': 6.2.0(typescript@5.9.3)
-      '@solana/instructions': 6.2.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.2.0(typescript@5.9.3)
+      '@solana/addresses': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/functional': 6.3.0(typescript@5.9.3)
+      '@solana/instructions': 6.3.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@6.2.0(typescript@5.9.3)':
+  '@solana/transactions@6.3.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.2.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.2.0(typescript@5.9.3)
-      '@solana/errors': 6.2.0(typescript@5.9.3)
-      '@solana/functional': 6.2.0(typescript@5.9.3)
-      '@solana/instructions': 6.2.0(typescript@5.9.3)
-      '@solana/keys': 6.2.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.2.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.2.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.2.0(typescript@5.9.3)
+      '@solana/addresses': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.3.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.3.0(typescript@5.9.3)
+      '@solana/errors': 6.3.0(typescript@5.9.3)
+      '@solana/functional': 6.3.0(typescript@5.9.3)
+      '@solana/instructions': 6.3.0(typescript@5.9.3)
+      '@solana/keys': 6.3.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.3.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.3.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.3.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:


### PR DESCRIPTION
This updates `@solana-program/compute-budget` from ^0.14.0 to ^0.15.0, which includes full simulation data in the compute limit estimation error context (solana-program/compute-budget#27). The new version requires `@solana/kit` ^6.3.0 as a peer dependency, so all `@solana/kit` references across the monorepo are bumped accordingly.

The error context for `SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT` now contains `Omit<RpcSimulateTransactionResult, 'err'>` instead of just `{ unitsConsumed: number }`. The `unitsConsumed` field is now a raw `bigint` from the RPC response rather than a downcast `number`. The RPC executor's skip-preflight recovery path is updated to downcast the bigint to a u32 number, matching the downcast logic on the success path.