### PR TITLE
fix: include source files in published packages for IDE navigation

### DIFF
--- a/.changeset/light-humans-nail.md
+++ b/.changeset/light-humans-nail.md
@@ -1,0 +1,12 @@
+---
+"@solana/kit-client-litesvm": patch
+"@solana/kit-client-rpc": patch
+"@solana/kit-plugin-airdrop": patch
+"@solana/kit-plugin-instruction-plan": patch
+"@solana/kit-plugin-litesvm": patch
+"@solana/kit-plugin-payer": patch
+"@solana/kit-plugin-rpc": patch
+"@solana/kit-plugins": patch
+---
+
+Include source files in published packages so IDE "Go to Definition" navigates to TypeScript source instead of .d.ts type declarations

--- a/packages/kit-client-litesvm/package.json
+++ b/packages/kit-client-litesvm/package.json
@@ -25,7 +25,8 @@
     "type": "commonjs",
     "files": [
         "./dist/types",
-        "./dist/index.*"
+        "./dist/index.*",
+        "./src/"
     ],
     "sideEffects": false,
     "keywords": [

--- a/packages/kit-client-rpc/package.json
+++ b/packages/kit-client-rpc/package.json
@@ -25,7 +25,8 @@
     "type": "commonjs",
     "files": [
         "./dist/types",
-        "./dist/index.*"
+        "./dist/index.*",
+        "./src/"
     ],
     "sideEffects": false,
     "keywords": [

--- a/packages/kit-plugin-airdrop/package.json
+++ b/packages/kit-plugin-airdrop/package.json
@@ -25,7 +25,8 @@
     "type": "commonjs",
     "files": [
         "./dist/types",
-        "./dist/index.*"
+        "./dist/index.*",
+        "./src/"
     ],
     "sideEffects": false,
     "keywords": [

--- a/packages/kit-plugin-instruction-plan/package.json
+++ b/packages/kit-plugin-instruction-plan/package.json
@@ -25,7 +25,8 @@
     "type": "commonjs",
     "files": [
         "./dist/types",
-        "./dist/index.*"
+        "./dist/index.*",
+        "./src/"
     ],
     "sideEffects": false,
     "keywords": [

--- a/packages/kit-plugin-litesvm/package.json
+++ b/packages/kit-plugin-litesvm/package.json
@@ -25,7 +25,8 @@
     "type": "commonjs",
     "files": [
         "./dist/types",
-        "./dist/index.*"
+        "./dist/index.*",
+        "./src/"
     ],
     "sideEffects": false,
     "keywords": [

--- a/packages/kit-plugin-payer/package.json
+++ b/packages/kit-plugin-payer/package.json
@@ -25,7 +25,8 @@
     "type": "commonjs",
     "files": [
         "./dist/types",
-        "./dist/index.*"
+        "./dist/index.*",
+        "./src/"
     ],
     "sideEffects": false,
     "keywords": [

--- a/packages/kit-plugin-rpc/package.json
+++ b/packages/kit-plugin-rpc/package.json
@@ -25,7 +25,8 @@
     "type": "commonjs",
     "files": [
         "./dist/types",
-        "./dist/index.*"
+        "./dist/index.*",
+        "./src/"
     ],
     "sideEffects": false,
     "keywords": [

--- a/packages/kit-plugins/package.json
+++ b/packages/kit-plugins/package.json
@@ -25,7 +25,8 @@
     "type": "commonjs",
     "files": [
         "./dist/types",
-        "./dist/index.*"
+        "./dist/index.*",
+        "./src/"
     ],
     "sideEffects": false,
     "keywords": [


### PR DESCRIPTION


## Problem

"Go to Definition" (Cmd+Click / F12) on any kit-plugins import takes you to `.d.ts` type declarations instead of actual source code.

**Before** — what you see when you Cmd+Click `createLocalClient`:
```typescript
// dist/types/index.d.ts
export declare function createLocalClient(config?: Omit<ClientConfig<string>, 'payer' | 'url'> & {
    payer?: TransactionSigner;
    url?: string;
}): ...
```

**After** — same Cmd+Click, now you land in the actual source:
```typescript
// src/index.ts
export function createLocalClient(config = {}) {
    return createEmptyClient()
        .use(localhostRpc(config.url, config.rpcSubscriptionsConfig))
        .use(rpcAirdrop())
        .use(payerOrGeneratedPayer(config.payer))
        .use(rpcTransactionPlanner({ priorityFees: config.priorityFees }))
        .use(rpcTransactionPlanExecutor({ maxConcurrency: config.maxConcurrency, skipPreflight: config.skipPreflight }))
        .use(planAndSendTransactions());
}
```

## Why this was broken

Same issue as anza-xyz/kit#1468:
- `declarationMap: true` is set in tsconfig 
- `.d.ts.map` files are generated with correct source paths like `"sources":["../../src/index.ts"]` 
- Source files included in published npm packages — `"files"` only includes `./dist/types` and `./dist/index.*`
- Source files included in published npm packages — `"files"` only includes `./dist/types` and `./dist/index.*`

Declaration maps point to `../../src/index.ts` but that path doesn't exist in `node_modules`. IDE can't follow the map, falls back to `.d.ts`.

## Fix

- Add `"./src/"` to the `files` array in all 8 publishable `package.json` files
- No `.npmignore` needed — no test/benchmark/mock dirs exist in `src/`
- No build system, tsconfig, or code changes

## Size impact

- **npm install**: small increase per package (source files only)
- **Your app's bundle size**: no impact. Bundlers resolve imports to compiled JS in `dist/` via `exports`/`main`/`module`. The `src/` files are only used by the IDE to follow declaration maps

## Test it locally

```bash
cd packages/kit-client-rpc
npm pack

# In a separate project
bun add /path/to/solana-kit-client-rpc-0.7.0.tgz

# Open in your IDE, import something, Cmd+Click it
# → navigates to src/*.ts instead of dist/types/*.d.ts
```

cc @mcintyre94 @lorisleiva @Woody4618