### PR TITLE
Bump `@solana/kit` peer dependency to ^6.8.0

### DIFF
--- a/.changeset/sunny-squids-juggle.md
+++ b/.changeset/sunny-squids-juggle.md
@@ -1,0 +1,12 @@
+---
+'@solana/kit-client-litesvm': minor
+'@solana/kit-client-rpc': minor
+'@solana/kit-plugin-airdrop': minor
+'@solana/kit-plugin-instruction-plan': minor
+'@solana/kit-plugin-litesvm': minor
+'@solana/kit-plugin-payer': minor
+'@solana/kit-plugin-rpc': minor
+'@solana/kit-plugins': minor
+---
+
+Bump `@solana/kit` peer dependency to ^6.8.0.

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ await client.sendTransaction([myInstruction]);
 None of the ready-to-use clients fit your needs? No worries! You can **build your own custom clients** by combining individual plugins like so.
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { rpc, rpcAirdrop, rpcTransactionPlanner, rpcTransactionPlanExecutor } from '@solana/kit-plugin-rpc';
 import { payerFromFile } from '@solana/kit-plugin-payer';
 import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
 
-const client = await createEmptyClient() // An empty client with a `use` method to install plugins.
+const client = await createClient() // An empty client with a `use` method to install plugins.
     .use(rpc('https://api.devnet.solana.com')) // Adds `client.rpc` and `client.rpcSubscriptions`.
     .use(payerFromFile('path/to/keypair.json')) // Adds `client.payer` using a local keypair file.
     .use(rpcAirdrop()) // Adds `client.airdrop` to request SOL from faucets.
@@ -119,12 +119,12 @@ _Do you know any? Please open a PR to add them here!_
 
 This repo provides the following individual plugin packages. You can learn more about each package by following the links to their READMEs below.
 
-| Package                                                                         | Version                                                                                                                                                      | Description                        | Plugins                                                                                    |
-| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- | ------------------------------------------------------------------------------------------ |
-| [`@solana/kit-plugin-rpc`](./packages/kit-plugin-rpc)                           | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-rpc.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-rpc)                           | Connect to Solana clusters         | `rpc`, `localhostRpc`, `rpcAirdrop`, `rpcGetMinimumBalance`, `rpcTransactionPlanner`, `rpcTransactionPlanExecutor` |
-| [`@solana/kit-plugin-payer`](./packages/kit-plugin-payer)                       | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-payer.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-payer)                       | Manage transaction fee payers      | `payer`, `payerFromFile`, `generatedPayer`, `generatedPayerWithSol`                        |
+| Package                                                                         | Version                                                                                                                                                      | Description                        | Plugins                                                                                                                |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| [`@solana/kit-plugin-rpc`](./packages/kit-plugin-rpc)                           | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-rpc.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-rpc)                           | Connect to Solana clusters         | `rpc`, `localhostRpc`, `rpcAirdrop`, `rpcGetMinimumBalance`, `rpcTransactionPlanner`, `rpcTransactionPlanExecutor`     |
+| [`@solana/kit-plugin-payer`](./packages/kit-plugin-payer)                       | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-payer.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-payer)                       | Manage transaction fee payers      | `payer`, `payerFromFile`, `generatedPayer`, `generatedPayerWithSol`                                                    |
 | [`@solana/kit-plugin-litesvm`](./packages/kit-plugin-litesvm)                   | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-litesvm.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-litesvm)                   | LiteSVM support                    | `litesvm`, `litesvmAirdrop`, `litesvmGetMinimumBalance`, `litesvmTransactionPlanner`, `litesvmTransactionPlanExecutor` |
-| [`@solana/kit-plugin-instruction-plan`](./packages/kit-plugin-instruction-plan) | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-instruction-plan.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-instruction-plan) | Transaction planning and execution | `transactionPlanner`, `transactionPlanExecutor`, `planAndSendTransactions`                 |
+| [`@solana/kit-plugin-instruction-plan`](./packages/kit-plugin-instruction-plan) | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-instruction-plan.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-instruction-plan) | Transaction planning and execution | `transactionPlanner`, `transactionPlanExecutor`, `planAndSendTransactions`                                             |
 
 ## Community Plugins
 
@@ -169,8 +169,8 @@ function appleTart() {
     return <T extends { fruit: 'apple' }>(client: T) => extendClient(client, { dessert: 'appleTart' as const });
 }
 
-createEmptyClient().use(apple()).use(appleTart()); // Ok
-createEmptyClient().use(appleTart()); // TypeScript error
+createClient().use(apple()).use(appleTart()); // Ok
+createClient().use(appleTart()); // TypeScript error
 ```
 
 Plugins can also be asynchronous if required and return promises that resolve to clients.
@@ -187,5 +187,5 @@ function magicFruit() {
 The `use` function on the client takes care of awaiting asynchronous plugins automatically, so you can use them seamlessly alongside synchronous ones and simply await the final client when required.
 
 ```ts
-const client = await createEmptyClient().use(magicFruit()).use(apple());
+const client = await createClient().use(magicFruit()).use(apple());
 ```

--- a/examples/token-airdrop/package.json
+++ b/examples/token-airdrop/package.json
@@ -4,7 +4,7 @@
     "dependencies": {
         "@solana-program/system": "^0.12.0",
         "@solana-program/token": "^0.13.0",
-        "@solana/kit": "^6.7.0",
+        "@solana/kit": "^6.8.0",
         "@solana/kit-client-rpc": "workspace:*"
     },
     "type": "module",

--- a/examples/transfer-lamports/package.json
+++ b/examples/transfer-lamports/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "dependencies": {
         "@solana-program/system": "^0.12.0",
-        "@solana/kit": "^6.7.0",
+        "@solana/kit": "^6.8.0",
         "@solana/kit-client-rpc": "workspace:*"
     },
     "type": "module",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "@changesets/changelog-github": "^0.6.0",
         "@changesets/cli": "^2.30.0",
         "@solana/eslint-config-solana": "^6.0.0",
-        "@solana/kit": "^6.7.0",
+        "@solana/kit": "^6.8.0",
         "@solana/prettier-config-solana": "0.0.6",
         "@types/node": "^25",
         "agadoo": "^3.0.0",

--- a/packages/kit-client-litesvm/package.json
+++ b/packages/kit-client-litesvm/package.json
@@ -46,7 +46,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.5.0"
+        "@solana/kit": "^6.8.0"
     },
     "dependencies": {
         "@solana/kit-plugin-instruction-plan": "workspace:*",

--- a/packages/kit-client-litesvm/src/index.ts
+++ b/packages/kit-client-litesvm/src/index.ts
@@ -1,4 +1,4 @@
-import { createEmptyClient, TransactionSigner } from '@solana/kit';
+import { createClient as createEmptyClient, TransactionSigner } from '@solana/kit';
 import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
 import {
     litesvm,

--- a/packages/kit-client-rpc/package.json
+++ b/packages/kit-client-rpc/package.json
@@ -46,7 +46,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.5.0"
+        "@solana/kit": "^6.8.0"
     },
     "dependencies": {
         "@solana/kit-plugin-instruction-plan": "workspace:*",

--- a/packages/kit-client-rpc/src/index.ts
+++ b/packages/kit-client-rpc/src/index.ts
@@ -1,6 +1,6 @@
 import {
     ClusterUrl,
-    createEmptyClient,
+    createClient as createEmptyClient,
     DefaultRpcSubscriptionsChannelConfig,
     MicroLamports,
     TransactionSigner,

--- a/packages/kit-plugin-airdrop/README.md
+++ b/packages/kit-plugin-airdrop/README.md
@@ -15,11 +15,11 @@
 ### RPC-based airdrop
 
 ```diff
-  import { createEmptyClient } from '@solana/kit';
+  import { createClient } from '@solana/kit';
 - import { airdrop, localhostRpc } from '@solana/kit-plugins';
 + import { localhostRpc, rpcAirdrop } from '@solana/kit-plugin-rpc';
 
-  const client = createEmptyClient()
+  const client = createClient()
       .use(localhostRpc())
 -     .use(airdrop());
 +     .use(rpcAirdrop());
@@ -28,11 +28,11 @@
 ### LiteSVM-based airdrop
 
 ```diff
-  import { createEmptyClient } from '@solana/kit';
+  import { createClient } from '@solana/kit';
 - import { airdrop, litesvm } from '@solana/kit-plugins';
 + import { litesvm, litesvmAirdrop } from '@solana/kit-plugin-litesvm';
 
-  const client = createEmptyClient()
+  const client = createClient()
       .use(litesvm())
 -     .use(airdrop());
 +     .use(litesvmAirdrop());

--- a/packages/kit-plugin-airdrop/package.json
+++ b/packages/kit-plugin-airdrop/package.json
@@ -46,7 +46,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.5.0"
+        "@solana/kit": "^6.8.0"
     },
     "devDependencies": {
         "@solana/kit-plugin-litesvm": "workspace:*",

--- a/packages/kit-plugin-airdrop/src/index.ts
+++ b/packages/kit-plugin-airdrop/src/index.ts
@@ -21,10 +21,10 @@ type RpcClient = {
  * @example
  * RPC-based airdrop.
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { localhostRpc, rpcAirdrop } from '@solana/kit-plugin-rpc';
  *
- * const client = createEmptyClient()
+ * const client = createClient()
  *     .use(localhostRpc())
  *     .use(rpcAirdrop());
  * ```
@@ -32,10 +32,10 @@ type RpcClient = {
  * @example
  * LiteSVM-based airdrop.
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { litesvm, litesvmAirdrop } from '@solana/kit-plugin-litesvm';
  *
- * const client = createEmptyClient()
+ * const client = createClient()
  *     .use(litesvm())
  *     .use(litesvmAirdrop());
  * ```

--- a/packages/kit-plugin-airdrop/test/index.test.ts
+++ b/packages/kit-plugin-airdrop/test/index.test.ts
@@ -1,4 +1,4 @@
-import { address, createEmptyClient, lamports, mainnet } from '@solana/kit';
+import { address, createClient, lamports, mainnet } from '@solana/kit';
 import { litesvm } from '@solana/kit-plugin-litesvm';
 import { localhostRpc, rpc } from '@solana/kit-plugin-rpc';
 import { describe, expect, it, vi } from 'vitest';
@@ -10,7 +10,7 @@ describe('airdrop', () => {
         const getSignatureStatuses = vi.fn();
         const requestAirdrop = vi.fn();
         const signatureNotifications = vi.fn();
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({
                 rpc: { getSignatureStatuses, requestAirdrop },
                 rpcSubscriptions: { signatureNotifications },
@@ -22,7 +22,7 @@ describe('airdrop', () => {
 
     it('provides an airdrop function that relies on a LiteSVM instance', async () => {
         const svm = { airdrop: vi.fn() };
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ svm }))
             .use(airdrop());
         expect(client).toHaveProperty('airdrop');
@@ -35,17 +35,17 @@ describe('airdrop', () => {
     });
 
     it('works with an arbitrary RPC', () => {
-        const client = createEmptyClient().use(rpc('https://my-rpc.com')).use(airdrop());
+        const client = createClient().use(rpc('https://my-rpc.com')).use(airdrop());
         expect(client).toHaveProperty('airdrop');
     });
 
     it('works with a localhost RPC', () => {
-        const client = createEmptyClient().use(localhostRpc()).use(airdrop());
+        const client = createClient().use(localhostRpc()).use(airdrop());
         expect(client).toHaveProperty('airdrop');
     });
 
     it('throws a TypeScript error with a mainnet RPC', () => {
-        const client = createEmptyClient()
+        const client = createClient()
             .use(rpc(mainnet('https://my-rpc.com')))
             // @ts-expect-error Airdrop RPC methods are not available on mainnet.
             .use(airdrop());
@@ -54,7 +54,7 @@ describe('airdrop', () => {
 
     if (__NODEJS__) {
         it('works with a LiteSVM instance', () => {
-            const client = createEmptyClient().use(litesvm()).use(airdrop());
+            const client = createClient().use(litesvm()).use(airdrop());
             expect(client).toHaveProperty('airdrop');
         });
     }

--- a/packages/kit-plugin-instruction-plan/README.md
+++ b/packages/kit-plugin-instruction-plan/README.md
@@ -22,11 +22,11 @@ The `transactionPlanner` plugin sets a custom transaction planner on the client.
 ### Installation
 
 ```ts
-import { createEmptyClient, createTransactionPlanner } from '@solana/kit';
+import { createClient, createTransactionPlanner } from '@solana/kit';
 import { transactionPlanner } from '@solana/kit-plugin-instruction-plan';
 
 const myTransactionPlanner = createTransactionPlanner(/* ... */);
-const client = createEmptyClient().use(transactionPlanner(myTransactionPlanner));
+const client = createClient().use(transactionPlanner(myTransactionPlanner));
 ```
 
 ### Features
@@ -43,11 +43,11 @@ The `transactionPlanExecutor` plugin sets a custom transaction plan executor on 
 ### Installation
 
 ```ts
-import { createEmptyClient, createTransactionPlanExecutor } from '@solana/kit';
+import { createClient, createTransactionPlanExecutor } from '@solana/kit';
 import { transactionPlanExecutor } from '@solana/kit-plugin-instruction-plan';
 
 const myTransactionPlanExecutor = createTransactionPlanExecutor(/* ... */);
-const client = createEmptyClient().use(transactionPlanExecutor(myTransactionPlanExecutor));
+const client = createClient().use(transactionPlanExecutor(myTransactionPlanExecutor));
 ```
 
 ### Features
@@ -66,14 +66,14 @@ The `planAndSendTransactions` plugin adds helper functions for planning and send
 This plugin requires both `transactionPlanner` and `transactionPlanExecutor` to be installed on the client.
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import {
     transactionPlanner,
     transactionPlanExecutor,
     planAndSendTransactions,
 } from '@solana/kit-plugin-instruction-plan';
 
-const client = createEmptyClient()
+const client = createClient()
     .use(transactionPlanner(myTransactionPlanner))
     .use(transactionPlanExecutor(myTransactionPlanExecutor))
     .use(planAndSendTransactions());

--- a/packages/kit-plugin-instruction-plan/package.json
+++ b/packages/kit-plugin-instruction-plan/package.json
@@ -47,7 +47,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.5.0"
+        "@solana/kit": "^6.8.0"
     },
     "license": "MIT",
     "repository": {

--- a/packages/kit-plugin-instruction-plan/src/core.ts
+++ b/packages/kit-plugin-instruction-plan/src/core.ts
@@ -25,11 +25,11 @@ import {
  *
  * @example
  * ```ts
- * import { createEmptyClient, createTransactionPlanner } from '@solana/kit';
+ * import { createClient, createTransactionPlanner } from '@solana/kit';
  * import { transactionPlanner } from '@solana/kit-plugin-instruction-plan';
  *
  * // Install the transactionPlanner plugin using a custom transaction planner.
- * const client = createEmptyClient()
+ * const client = createClient()
  *     .use(transactionPlanner(createTransactionPlanner(...)));
  *
  * // Use the transaction planner.
@@ -45,11 +45,11 @@ export function transactionPlanner(transactionPlanner: TransactionPlanner) {
  *
  * @example
  * ```ts
- * import { createEmptyClient, createTransactionPlanExecutor } from '@solana/kit';
+ * import { createClient, createTransactionPlanExecutor } from '@solana/kit';
  * import { transactionPlanExecutor } from '@solana/kit-plugin-instruction-plan';
  *
  * // Install the transactionPlanExecutor plugin using a custom transaction plan executor.
- * const client = createEmptyClient()
+ * const client = createClient()
  *     .use(transactionPlanExecutor(createTransactionPlanExecutor(...)));
  *
  * // Use the transaction plan executor.
@@ -79,11 +79,11 @@ export function transactionPlanExecutor(transactionPlanExecutor: TransactionPlan
  *
  * @example
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { transactionPlanner, transactionPlanExecutor, planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
  *
  * // Install the planAndSendTransactions plugin and its requirements.
- * const client = createEmptyClient()
+ * const client = createClient()
  *     .use(transactionPlanner(myTransactionPlanner))
  *     .use(transactionPlanExecutor(myTransactionPlanExecutor))
  *     .use(planAndSendTransactions());

--- a/packages/kit-plugin-instruction-plan/test/core.test.ts
+++ b/packages/kit-plugin-instruction-plan/test/core.test.ts
@@ -1,7 +1,7 @@
 import {
     Address,
     canceledSingleTransactionPlanResult,
-    createEmptyClient,
+    createClient,
     createFailedToExecuteTransactionPlanError,
     createTransactionMessage,
     failedSingleTransactionPlanResult,
@@ -35,7 +35,7 @@ import { planAndSendTransactions, transactionPlanExecutor, transactionPlanner } 
 describe('transactionPlanner', () => {
     it('sets the provided transactionPlanner on the client', () => {
         const customTransactionPlanner = vi.fn();
-        const client = createEmptyClient().use(transactionPlanner(customTransactionPlanner));
+        const client = createClient().use(transactionPlanner(customTransactionPlanner));
         expect(client).toHaveProperty('transactionPlanner');
         expect(client.transactionPlanner).toBe(customTransactionPlanner);
     });
@@ -44,7 +44,7 @@ describe('transactionPlanner', () => {
 describe('transactionPlanExecutor', () => {
     it('sets the provided transactionPlanExecutor on the client', () => {
         const customTransactionPlanExecutor = vi.fn();
-        const client = createEmptyClient().use(transactionPlanExecutor(customTransactionPlanExecutor));
+        const client = createClient().use(transactionPlanExecutor(customTransactionPlanExecutor));
         expect(client).toHaveProperty('transactionPlanExecutor');
         expect(client.transactionPlanExecutor).toBe(customTransactionPlanExecutor);
     });
@@ -58,7 +58,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -82,7 +82,7 @@ describe('planAndSendTransactions', () => {
             ]);
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -101,7 +101,7 @@ describe('planAndSendTransactions', () => {
             const transactionPlan = singleTransactionPlan({} as TransactionMessage & TransactionMessageWithFeePayer);
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -115,7 +115,7 @@ describe('planAndSendTransactions', () => {
         it('does not call the planner if the abort signal is already triggered', async () => {
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -132,7 +132,7 @@ describe('planAndSendTransactions', () => {
             const transactionPlan = singleTransactionPlan({} as TransactionMessage & TransactionMessageWithFeePayer);
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -155,7 +155,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -175,7 +175,7 @@ describe('planAndSendTransactions', () => {
             const transactionPlan = singleTransactionPlan({} as TransactionMessage & TransactionMessageWithFeePayer);
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -189,7 +189,7 @@ describe('planAndSendTransactions', () => {
         it('does not call the planner if the abort signal is already triggered', async () => {
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -209,7 +209,7 @@ describe('planAndSendTransactions', () => {
             ]);
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -233,7 +233,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -258,7 +258,7 @@ describe('planAndSendTransactions', () => {
             ]);
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -283,7 +283,7 @@ describe('planAndSendTransactions', () => {
             ]);
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -306,7 +306,7 @@ describe('planAndSendTransactions', () => {
             );
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -329,7 +329,7 @@ describe('planAndSendTransactions', () => {
             );
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -343,7 +343,7 @@ describe('planAndSendTransactions', () => {
         it('does not call the planner if the abort signal is already triggered', async () => {
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -363,7 +363,7 @@ describe('planAndSendTransactions', () => {
             });
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -385,7 +385,7 @@ describe('planAndSendTransactions', () => {
             });
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -407,7 +407,7 @@ describe('planAndSendTransactions', () => {
             });
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -428,7 +428,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
             const customTransactionPlanExecutor = vi.fn().mockRejectedValue(executionError);
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -460,7 +460,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
             const customTransactionPlanExecutor = vi.fn().mockRejectedValue(executionError);
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -479,7 +479,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
             const customTransactionPlanExecutor = vi.fn().mockRejectedValue(genericError);
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -497,7 +497,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -516,7 +516,7 @@ describe('planAndSendTransactions', () => {
         it('passes the abort signal through the planner and executor', async () => {
             const customTransactionPlanner = vi.fn().mockResolvedValue({});
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue({});
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -530,7 +530,7 @@ describe('planAndSendTransactions', () => {
         it('does not call the planner if the abort signal is already triggered', async () => {
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -550,7 +550,7 @@ describe('planAndSendTransactions', () => {
             ]);
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -569,7 +569,7 @@ describe('planAndSendTransactions', () => {
             const transaction = setTransactionMessageFeePayer(payer, createTransactionMessage({ version: 0 }));
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -592,7 +592,7 @@ describe('planAndSendTransactions', () => {
             );
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -612,7 +612,7 @@ describe('planAndSendTransactions', () => {
             ]);
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -633,7 +633,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
             const customTransactionPlanExecutor = vi.fn().mockRejectedValue(executionError);
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -665,7 +665,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
             const customTransactionPlanExecutor = vi.fn().mockRejectedValue(executionError);
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());
@@ -685,7 +685,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
             const customTransactionPlanExecutor = vi.fn().mockRejectedValue(genericError);
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(transactionPlanner(customTransactionPlanner))
                 .use(transactionPlanExecutor(customTransactionPlanExecutor))
                 .use(planAndSendTransactions());

--- a/packages/kit-plugin-litesvm/README.md
+++ b/packages/kit-plugin-litesvm/README.md
@@ -25,10 +25,10 @@ The LiteSVM plugin starts a new LiteSVM instance within your Kit client, allowin
 ### Installation
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { litesvm } from '@solana/kit-plugin-litesvm';
 
-const client = createEmptyClient().use(litesvm());
+const client = createClient().use(litesvm());
 ```
 
 ### Features
@@ -52,10 +52,10 @@ This plugin adds an `airdrop` method to your Kit client that airdrops SOL using 
 The client must have the `litesvm` plugin installed before applying this plugin.
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { litesvm, litesvmAirdrop } from '@solana/kit-plugin-litesvm';
 
-const client = createEmptyClient().use(litesvm()).use(litesvmAirdrop());
+const client = createClient().use(litesvm()).use(litesvmAirdrop());
 ```
 
 ### Features
@@ -74,10 +74,10 @@ This plugin adds a `getMinimumBalance` method to your Kit client that computes t
 The client must have the `litesvm` plugin installed before applying this plugin.
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { litesvm, litesvmGetMinimumBalance } from '@solana/kit-plugin-litesvm';
 
-const client = createEmptyClient().use(litesvm()).use(litesvmGetMinimumBalance());
+const client = createClient().use(litesvm()).use(litesvmGetMinimumBalance());
 ```
 
 ### Features
@@ -101,11 +101,11 @@ This plugin provides a default transaction planner that creates transaction mess
 This plugin requires a payer to be set on the client or passed as an option.
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { litesvm, litesvmTransactionPlanner, litesvmTransactionPlanExecutor } from '@solana/kit-plugin-litesvm';
 import { generatedPayer } from '@solana/kit-plugin-payer';
 
-const client = await createEmptyClient()
+const client = await createClient()
     .use(litesvm())
     .use(generatedPayer())
     .use(litesvmTransactionPlanner())
@@ -133,11 +133,11 @@ This plugin provides a default transaction plan executor that signs and sends tr
 This plugin requires an `svm` instance to be configured on the client.
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { litesvm, litesvmTransactionPlanner, litesvmTransactionPlanExecutor } from '@solana/kit-plugin-litesvm';
 import { generatedPayer } from '@solana/kit-plugin-payer';
 
-const client = await createEmptyClient()
+const client = await createClient()
     .use(litesvm())
     .use(generatedPayer())
     .use(litesvmTransactionPlanner())

--- a/packages/kit-plugin-litesvm/package.json
+++ b/packages/kit-plugin-litesvm/package.json
@@ -46,7 +46,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.5.0"
+        "@solana/kit": "^6.8.0"
     },
     "dependencies": {
         "litesvm": "^1.0.0"

--- a/packages/kit-plugin-litesvm/src/airdrop.ts
+++ b/packages/kit-plugin-litesvm/src/airdrop.ts
@@ -24,10 +24,10 @@ type LiteSVMClient = {
  *
  * @example
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { litesvm, litesvmAirdrop } from '@solana/kit-plugin-litesvm';
  *
- * const client = createEmptyClient()
+ * const client = createClient()
  *     .use(litesvm())
  *     .use(litesvmAirdrop());
  *

--- a/packages/kit-plugin-litesvm/src/get-minimum-balance.ts
+++ b/packages/kit-plugin-litesvm/src/get-minimum-balance.ts
@@ -20,10 +20,10 @@ type LiteSVMClient = {
  *
  * @example
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { litesvm, litesvmGetMinimumBalance } from '@solana/kit-plugin-litesvm';
  *
- * const client = createEmptyClient()
+ * const client = createClient()
  *     .use(litesvm())
  *     .use(litesvmGetMinimumBalance());
  *

--- a/packages/kit-plugin-litesvm/src/litesvm.ts
+++ b/packages/kit-plugin-litesvm/src/litesvm.ts
@@ -16,11 +16,11 @@ export type { LiteSVM } from 'litesvm';
  *
  * @example
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { litesvm } from '@solana/kit-plugin-litesvm';
  *
  * // Install the LiteSVM plugin.
- * const client = createEmptyClient().use(litesvm());
+ * const client = createClient().use(litesvm());
  *
  * // Use LiteSVM to set up accounts and programs.
  * client.svm.setAccount(myAccount);

--- a/packages/kit-plugin-litesvm/src/transaction-plan-executor.ts
+++ b/packages/kit-plugin-litesvm/src/transaction-plan-executor.ts
@@ -21,11 +21,11 @@ import { getSolanaErrorFromLiteSvmFailure, isFailedTransaction } from './transac
  *
  * @example
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { litesvm, litesvmTransactionPlanner, litesvmTransactionPlanExecutor } from '@solana/kit-plugin-litesvm';
  * import { generatedPayer } from '@solana/kit-plugin-payer';
  *
- * const client = await createEmptyClient()
+ * const client = await createClient()
  *     .use(litesvm())
  *     .use(generatedPayer())
  *     .use(litesvmTransactionPlanner())

--- a/packages/kit-plugin-litesvm/src/transaction-planner.ts
+++ b/packages/kit-plugin-litesvm/src/transaction-planner.ts
@@ -22,11 +22,11 @@ import {
  *
  * @example
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { litesvm, litesvmTransactionPlanner, litesvmTransactionPlanExecutor } from '@solana/kit-plugin-litesvm';
  * import { generatedPayer } from '@solana/kit-plugin-payer';
  *
- * const client = await createEmptyClient()
+ * const client = await createClient()
  *     .use(litesvm())
  *     .use(generatedPayer())
  *     .use(litesvmTransactionPlanner())

--- a/packages/kit-plugin-litesvm/test/airdrop.test.ts
+++ b/packages/kit-plugin-litesvm/test/airdrop.test.ts
@@ -1,4 +1,4 @@
-import { address, createEmptyClient, lamports } from '@solana/kit';
+import { address, createClient, lamports } from '@solana/kit';
 import { describe, expect, it, vi } from 'vitest';
 
 import { litesvm, litesvmAirdrop } from '../src';
@@ -11,7 +11,7 @@ describe('litesvmAirdrop', () => {
                 signature: () => mockSignature,
             }),
         };
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ svm }))
             .use(litesvmAirdrop());
         expect(client).toHaveProperty('airdrop');
@@ -26,7 +26,7 @@ describe('litesvmAirdrop', () => {
 
     it('throws when the airdrop returns null', () => {
         const svm = { airdrop: vi.fn().mockReturnValue(null) };
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ svm }))
             .use(litesvmAirdrop());
 
@@ -40,7 +40,7 @@ describe('litesvmAirdrop', () => {
                 err: () => 2, // AccountNotFound
             }),
         };
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ svm }))
             .use(litesvmAirdrop());
 
@@ -50,7 +50,7 @@ describe('litesvmAirdrop', () => {
 
     if (__NODEJS__) {
         it('works with a LiteSVM instance', async () => {
-            const client = createEmptyClient().use(litesvm()).use(litesvmAirdrop());
+            const client = createClient().use(litesvm()).use(litesvmAirdrop());
             expect(client).toHaveProperty('airdrop');
 
             const receiver = address('HQVxiMVDoV9jzG4tpoxmDZsNfWvaHXm8DGGv93Gka75v');

--- a/packages/kit-plugin-litesvm/test/get-minimum-balance.test.ts
+++ b/packages/kit-plugin-litesvm/test/get-minimum-balance.test.ts
@@ -1,4 +1,4 @@
-import { BASE_ACCOUNT_SIZE, createEmptyClient, lamports } from '@solana/kit';
+import { BASE_ACCOUNT_SIZE, createClient, lamports } from '@solana/kit';
 import { describe, expect, it, vi } from 'vitest';
 
 import { litesvm, litesvmGetMinimumBalance } from '../src';
@@ -9,7 +9,7 @@ const LAMPORTS_PER_BYTE = 6_960n;
 describe('litesvmGetMinimumBalance', () => {
     it('provides a getMinimumBalance function that relies on a LiteSVM instance', () => {
         const minimumBalanceForRentExemption = vi.fn();
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ svm: { minimumBalanceForRentExemption } }))
             .use(litesvmGetMinimumBalance());
         expect(client).toHaveProperty('getMinimumBalance');
@@ -18,7 +18,7 @@ describe('litesvmGetMinimumBalance', () => {
 
     it('calls svm with the space as data length by default', async () => {
         const minimumBalanceForRentExemption = vi.fn().mockReturnValue(42n);
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ svm: { minimumBalanceForRentExemption } }))
             .use(litesvmGetMinimumBalance());
 
@@ -30,7 +30,7 @@ describe('litesvmGetMinimumBalance', () => {
     it('computes the per-byte rate when withoutHeader is true', async () => {
         const headerBalance = LAMPORTS_PER_BYTE * BigInt(BASE_ACCOUNT_SIZE);
         const minimumBalanceForRentExemption = vi.fn().mockReturnValue(headerBalance);
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ svm: { minimumBalanceForRentExemption } }))
             .use(litesvmGetMinimumBalance());
 
@@ -42,7 +42,7 @@ describe('litesvmGetMinimumBalance', () => {
 
     if (__NODEJS__) {
         it('works with a LiteSVM instance', async () => {
-            const client = createEmptyClient().use(litesvm()).use(litesvmGetMinimumBalance());
+            const client = createClient().use(litesvm()).use(litesvmGetMinimumBalance());
             expect(client).toHaveProperty('getMinimumBalance');
 
             const balance = await client.getMinimumBalance(100);

--- a/packages/kit-plugin-litesvm/test/index.test.ts
+++ b/packages/kit-plugin-litesvm/test/index.test.ts
@@ -1,5 +1,5 @@
 import {
-    createEmptyClient,
+    createClient,
     GetAccountInfoApi,
     GetBalanceApi,
     GetEpochScheduleApi,
@@ -26,13 +26,13 @@ describe('litesvm', () => {
     }
 
     it('instantiates and attaches a new LiteSVM client', () => {
-        const client = createEmptyClient().use(litesvm());
+        const client = createClient().use(litesvm());
         expect(client).toHaveProperty('svm');
         expect(client.svm).toBeInstanceOf(LiteSVM);
     });
 
     it('derives a small RPC from the LiteSVM client', () => {
-        const client = createEmptyClient().use(litesvm());
+        const client = createClient().use(litesvm());
         expect(client).toHaveProperty('rpc');
         expect(client.rpc).toBeTypeOf('object');
         expect(client.rpc.getAccountInfo).toBeTypeOf('function');

--- a/packages/kit-plugin-litesvm/test/litesvm-to-rpc.test.ts
+++ b/packages/kit-plugin-litesvm/test/litesvm-to-rpc.test.ts
@@ -1,4 +1,4 @@
-import { address, createEmptyClient, generateKeyPairSigner, lamports, Rpc } from '@solana/kit';
+import { address, createClient, generateKeyPairSigner, lamports, Rpc } from '@solana/kit';
 import { describe, expect, it } from 'vitest';
 
 import { litesvm as nodeLitesvm } from '../src/index';
@@ -14,7 +14,7 @@ describe('createRpcFromSvm', () => {
     }
 
     it('can fetch an account set on the svm', async () => {
-        const client = createEmptyClient().use(litesvm());
+        const client = createClient().use(litesvm());
         const accountAddress = await generateKeyPairSigner().then(signer => signer.address);
 
         client.svm.setAccount({
@@ -37,7 +37,7 @@ describe('createRpcFromSvm', () => {
     });
 
     it('can fetch a missing account on the svm', async () => {
-        const client = createEmptyClient().use(litesvm());
+        const client = createClient().use(litesvm());
         const missingAddress = await generateKeyPairSigner().then(signer => signer.address);
 
         const { value } = await client.rpc.getAccountInfo(missingAddress).send();
@@ -45,7 +45,7 @@ describe('createRpcFromSvm', () => {
     });
 
     it('can fetch multiple accounts set on the svm', async () => {
-        const client = createEmptyClient().use(litesvm());
+        const client = createClient().use(litesvm());
 
         const [addressA, addressB, missingAddressC] = await Promise.all([
             generateKeyPairSigner().then(signer => signer.address),
@@ -91,7 +91,7 @@ describe('createRpcFromSvm', () => {
     });
 
     it('can fetch the balance of an account set on the svm', async () => {
-        const client = createEmptyClient().use(litesvm());
+        const client = createClient().use(litesvm());
         const accountAddress = await generateKeyPairSigner().then(signer => signer.address);
 
         client.svm.setAccount({
@@ -108,7 +108,7 @@ describe('createRpcFromSvm', () => {
     });
 
     it('returns zero balance for a missing account', async () => {
-        const client = createEmptyClient().use(litesvm());
+        const client = createClient().use(litesvm());
         const missingAddress = await generateKeyPairSigner().then(signer => signer.address);
 
         const { value } = await client.rpc.getBalance(missingAddress).send();
@@ -116,7 +116,7 @@ describe('createRpcFromSvm', () => {
     });
 
     it('can fetch the epoch schedule', async () => {
-        const client = createEmptyClient().use(litesvm());
+        const client = createClient().use(litesvm());
 
         const response = await client.rpc.getEpochSchedule().send();
         expect(typeof response.firstNormalEpoch).toBe('bigint');
@@ -127,7 +127,7 @@ describe('createRpcFromSvm', () => {
     });
 
     it('can fetch the latest blockhash', async () => {
-        const client = createEmptyClient().use(litesvm());
+        const client = createClient().use(litesvm());
 
         const { value } = await client.rpc.getLatestBlockhash({ commitment: 'finalized' }).send();
         expect(value).toStrictEqual({
@@ -137,7 +137,7 @@ describe('createRpcFromSvm', () => {
     });
 
     it('can fetch the minimum balance for rent exemption', async () => {
-        const client = createEmptyClient().use(litesvm());
+        const client = createClient().use(litesvm());
 
         const response = await client.rpc.getMinimumBalanceForRentExemption(100n).send();
         expect(response).toBeGreaterThan(0n);
@@ -145,7 +145,7 @@ describe('createRpcFromSvm', () => {
     });
 
     it('can fetch the current slot', async () => {
-        const client = createEmptyClient().use(litesvm());
+        const client = createClient().use(litesvm());
 
         const slot = await client.rpc.getSlot().send();
         expect(typeof slot).toBe('bigint');
@@ -153,7 +153,7 @@ describe('createRpcFromSvm', () => {
     });
 
     it('can request an airdrop', async () => {
-        const client = createEmptyClient().use(litesvm());
+        const client = createClient().use(litesvm());
         const recipientAddress = await generateKeyPairSigner().then(signer => signer.address);
 
         const signature = await client.rpc.requestAirdrop(recipientAddress, lamports(1_000_000_000n)).send();
@@ -166,7 +166,7 @@ describe('createRpcFromSvm', () => {
     });
 
     it('throws when calling an unsupported RPC method', async () => {
-        const client = createEmptyClient().use(litesvm());
+        const client = createClient().use(litesvm());
         const rpc = client.rpc as unknown as Rpc<{ unsupportedMethod: () => unknown }>;
         const promise = rpc.unsupportedMethod().send();
         await expect(promise).rejects.toThrow('Unsupported RPC method for LiteSVM client: unsupportedMethod');

--- a/packages/kit-plugin-litesvm/test/transaction-plan-executor.test.ts
+++ b/packages/kit-plugin-litesvm/test/transaction-plan-executor.test.ts
@@ -1,7 +1,7 @@
 import {
     Address,
     appendTransactionMessageInstruction,
-    createEmptyClient,
+    createClient,
     createTransactionMessage,
     extendClient,
     generateKeyPairSigner,
@@ -29,7 +29,7 @@ describe('litesvmTransactionPlanExecutor', () => {
     describe('with mocks', () => {
         it('provides a transactionPlanExecutor on the client', () => {
             const svm = {} as LiteSVM;
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(() => ({ svm }))
                 .use(litesvmTransactionPlanExecutor());
             expect(client).toHaveProperty('transactionPlanExecutor');
@@ -41,7 +41,7 @@ describe('litesvmTransactionPlanExecutor', () => {
             // Return a success result (no `.err` property).
             const sendTransaction = vi.fn().mockReturnValue({ signature: () => new Uint8Array(64) });
             const svm = { sendTransaction, setTransactionMessageLifetimeUsingLatestBlockhash } as unknown as LiteSVM;
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(() => ({ payer, svm }))
                 .use(litesvmTransactionPlanner())
                 .use(litesvmTransactionPlanExecutor());
@@ -62,7 +62,7 @@ describe('litesvmTransactionPlanExecutor', () => {
             const mockMetadata = { logs: () => ['log1'], signature: () => new Uint8Array(64) };
             const sendTransaction = vi.fn().mockReturnValue(mockMetadata);
             const svm = { sendTransaction, setTransactionMessageLifetimeUsingLatestBlockhash } as unknown as LiteSVM;
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(() => ({ payer, svm }))
                 .use(litesvmTransactionPlanner())
                 .use(litesvmTransactionPlanExecutor());
@@ -79,7 +79,7 @@ describe('litesvmTransactionPlanExecutor', () => {
             const mockMetadata = { err: () => 2 };
             const sendTransaction = vi.fn().mockReturnValue(mockMetadata);
             const svm = { sendTransaction, setTransactionMessageLifetimeUsingLatestBlockhash } as unknown as LiteSVM;
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(() => ({ payer, svm }))
                 .use(litesvmTransactionPlanExecutor());
 
@@ -99,7 +99,7 @@ describe('litesvmTransactionPlanExecutor', () => {
             // Return a failed result with a fieldless error (AccountNotFound = 2).
             const sendTransaction = vi.fn().mockReturnValue({ err: () => 2 });
             const svm = { sendTransaction, setTransactionMessageLifetimeUsingLatestBlockhash } as unknown as LiteSVM;
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(() => ({ payer, svm }))
                 .use(litesvmTransactionPlanExecutor());
 
@@ -130,7 +130,7 @@ describe('litesvmTransactionPlanExecutor', () => {
             };
             const sendTransaction = vi.fn().mockReturnValue({ err: () => instructionError });
             const svm = { sendTransaction, setTransactionMessageLifetimeUsingLatestBlockhash } as unknown as LiteSVM;
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(() => ({ payer, svm }))
                 .use(litesvmTransactionPlanExecutor());
 
@@ -155,7 +155,7 @@ describe('litesvmTransactionPlanExecutor', () => {
 
         it('requires an svm instance on the client', () => {
             // @ts-expect-error Missing svm instance on the client.
-            expect(() => createEmptyClient().use(litesvmTransactionPlanExecutor())).toThrow();
+            expect(() => createClient().use(litesvmTransactionPlanExecutor())).toThrow();
         });
     });
 
@@ -169,7 +169,7 @@ describe('litesvmTransactionPlanExecutor', () => {
 
         it('sends a real transaction successfully', async () => {
             const payer = await generateKeyPairSigner();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(litesvm())
                 .use(client => extendClient(client, { payer }))
                 .use(litesvmTransactionPlanner())
@@ -186,7 +186,7 @@ describe('litesvmTransactionPlanExecutor', () => {
         it('successfully executes a planned instruction plan', async () => {
             const payer = await generateKeyPairSigner();
             const destination = await generateKeyPairSigner();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(litesvm())
                 .use(client => extendClient(client, { payer }))
                 .use(litesvmTransactionPlanner())
@@ -206,7 +206,7 @@ describe('litesvmTransactionPlanExecutor', () => {
 
         it('throws a SolanaError when a real transaction fails with an instruction error', async () => {
             const payer = await generateKeyPairSigner();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(litesvm())
                 .use(client => extendClient(client, { payer }))
                 .use(litesvmTransactionPlanner())
@@ -241,7 +241,7 @@ describe('litesvmTransactionPlanExecutor', () => {
 
         it('throws a SolanaError when the payer has no account', async () => {
             const payer = await generateKeyPairSigner();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(litesvm())
                 .use(client => extendClient(client, { payer }))
                 .use(litesvmTransactionPlanner())
@@ -266,7 +266,7 @@ describe('litesvmTransactionPlanExecutor', () => {
 
         it('includes transactionMetadata with expected methods on success', async () => {
             const payer = await generateKeyPairSigner();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(litesvm())
                 .use(client => extendClient(client, { payer }))
                 .use(litesvmTransactionPlanner())
@@ -288,7 +288,7 @@ describe('litesvmTransactionPlanExecutor', () => {
 
         it('includes transactionMetadata in the result context on failure', async () => {
             const payer = await generateKeyPairSigner();
-            const client = createEmptyClient()
+            const client = createClient()
                 .use(litesvm())
                 .use(client => extendClient(client, { payer }))
                 .use(litesvmTransactionPlanner())

--- a/packages/kit-plugin-litesvm/test/transaction-planner.test.ts
+++ b/packages/kit-plugin-litesvm/test/transaction-planner.test.ts
@@ -1,6 +1,6 @@
 import {
     Address,
-    createEmptyClient,
+    createClient,
     generateKeyPairSigner,
     singleInstructionPlan,
     SingleTransactionPlan,
@@ -17,7 +17,7 @@ const MOCK_INSTRUCTION = {
 describe('litesvmTransactionPlanner', () => {
     it('provides a transactionPlanner on the client', () => {
         const payer = {} as TransactionSigner;
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ payer }))
             .use(litesvmTransactionPlanner());
         expect(client).toHaveProperty('transactionPlanner');
@@ -25,7 +25,7 @@ describe('litesvmTransactionPlanner', () => {
 
     it('uses the provided payer as fee payer when planning transactions', async () => {
         const payer = await generateKeyPairSigner();
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ payer }))
             .use(litesvmTransactionPlanner());
 
@@ -36,17 +36,17 @@ describe('litesvmTransactionPlanner', () => {
     });
 
     it('requires a payer on the client by default', () => {
-        expect(() => createEmptyClient().use(litesvmTransactionPlanner())).toThrow();
+        expect(() => createClient().use(litesvmTransactionPlanner())).toThrow();
     });
 
     it('also accepts a payer directly', () => {
         const payer = {} as TransactionSigner;
-        expect(() => createEmptyClient().use(litesvmTransactionPlanner({ payer }))).not.toThrow();
+        expect(() => createClient().use(litesvmTransactionPlanner({ payer }))).not.toThrow();
     });
 
     it('uses the provided payer over the one set on the client', async () => {
         const [clientPayer, explicitPayer] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ payer: clientPayer }))
             .use(litesvmTransactionPlanner({ payer: explicitPayer }));
 

--- a/packages/kit-plugin-payer/README.md
+++ b/packages/kit-plugin-payer/README.md
@@ -22,10 +22,10 @@ This plugin simply accepts a `TransactionSigner` and sets it as the `payer` prop
 ### Installation
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { payer } from '@solana/kit-plugin-payer';
 
-const client = createEmptyClient().use(payer(mySigner));
+const client = createClient().use(payer(mySigner));
 ```
 
 ### Features
@@ -47,10 +47,10 @@ This asynchronous plugin generates a new random `KeyPairSigner` to be used as th
 ### Installation
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { generatedPayer } from '@solana/kit-plugin-payer';
 
-const client = await createEmptyClient().use(generatedPayer());
+const client = await createClient().use(generatedPayer());
 ```
 
 ### Features
@@ -66,11 +66,11 @@ This asynchronous plugin generates a new random `KeyPairSigner`, airdrops some S
 Note that this plugin requires an airdrop plugin to be installed on the client beforehand (e.g. `rpcAirdrop` or `litesvmAirdrop`) which itself either requires an RPC connection or a LiteSVM instance.
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { localhostRpc, rpcAirdrop } from '@solana/kit-plugin-rpc';
 import { generatedPayerWithSol } from '@solana/kit-plugin-payer';
 
-const client = await createEmptyClient()
+const client = await createClient()
     .use(localhostRpc()) // or .use(litesvm()).use(litesvmAirdrop())
     .use(rpcAirdrop())
     .use(generatedPayerWithSol(lamports(10_000_000_000n))); // 10 SOL
@@ -89,15 +89,15 @@ This asynchronous plugin uses the provided `TransactionSigner` as the payer if o
 When no explicit payer is given, this plugin requires an airdrop plugin to be installed on the client beforehand (e.g. `rpcAirdrop` or `litesvmAirdrop`) which itself either requires an RPC connection or a LiteSVM instance.
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { localhostRpc, rpcAirdrop } from '@solana/kit-plugin-rpc';
 import { payerOrGeneratedPayer } from '@solana/kit-plugin-payer';
 
 // With an explicit payer — no airdrop needed.
-const client = await createEmptyClient().use(payerOrGeneratedPayer(mySigner));
+const client = await createClient().use(payerOrGeneratedPayer(mySigner));
 
 // Without a payer — generates one and airdrops 100 SOL.
-const client = await createEmptyClient()
+const client = await createClient()
     .use(localhostRpc()) // or .use(litesvm()).use(litesvmAirdrop())
     .use(rpcAirdrop())
     .use(payerOrGeneratedPayer(undefined));
@@ -116,10 +116,10 @@ This plugin loads a `KeyPairSigner` from a local file and sets it as the `payer`
 Note that this plugin requires access to the local filesystem and therefore can only work in Node.js environments. Other environments (like browsers) will throw an error when trying to use this plugin.
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { payerFromFile } from '@solana/kit-plugin-payer';
 
-const client = createEmptyClient().use(payerFromFile('path/to/keypair.json'));
+const client = createClient().use(payerFromFile('path/to/keypair.json'));
 ```
 
 ### Features

--- a/packages/kit-plugin-payer/package.json
+++ b/packages/kit-plugin-payer/package.json
@@ -47,7 +47,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.5.0"
+        "@solana/kit": "^6.8.0"
     },
     "license": "MIT",
     "repository": {

--- a/packages/kit-plugin-payer/src/index.ts
+++ b/packages/kit-plugin-payer/src/index.ts
@@ -18,11 +18,11 @@ import {
  *
  * @example
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { payer } from '@solana/kit-plugin-payer';
  *
  * // Install the payer plugin with your signer.
- * const client = createEmptyClient().use(payer(mySigner));
+ * const client = createClient().use(payer(mySigner));
  *
  * // Use the payer in your client.
  * console.log(client.payer.address);
@@ -38,11 +38,11 @@ export function payer(payer: TransactionSigner) {
  *
  * @example
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { generatedPayer } from '@solana/kit-plugin-payer';
  *
  * // Install the generatedPayer plugin.
- * const client = await createEmptyClient().use(generatedPayer());
+ * const client = await createClient().use(generatedPayer());
  *
  * // Use the payer in your client.
  * console.log(client.payer.address);
@@ -62,12 +62,12 @@ export function generatedPayer() {
  *
  * @example
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { generatedPayerWithSol } from '@solana/kit-plugin-payer';
  *
  * // Install the generatedPayerWithSol plugin.
  * const amount = lamports(10_000_000_000n); // 10 SOL.
- * const client = await createEmptyClient().use(generatedPayerWithSol(amount));
+ * const client = await createClient().use(generatedPayerWithSol(amount));
  *
  * // Use the payer in your client.
  * console.log(client.payer.address);
@@ -95,11 +95,11 @@ export function generatedPayerWithSol(amount: Lamports) {
  *
  * @example
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { payerFromFile } from '@solana/kit-plugin-payer';
  *
  * // Install the payerFromFile plugin.
- * const client = createEmptyClient().use(payerFromFile('path/to/keypair.json'));
+ * const client = createClient().use(payerFromFile('path/to/keypair.json'));
  *
  * // Use the payer in your client.
  * console.log(client.payer.address);
@@ -132,15 +132,15 @@ export function payerFromFile(path: string) {
  *
  * @example
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { localhostRpc, rpcAirdrop } from '@solana/kit-plugin-rpc';
  * import { payerOrGeneratedPayer } from '@solana/kit-plugin-payer';
  *
  * // With an explicit payer.
- * const client = await createEmptyClient().use(payerOrGeneratedPayer(mySigner));
+ * const client = await createClient().use(payerOrGeneratedPayer(mySigner));
  *
  * // Without a payer — generates one and airdrops 100 SOL.
- * const client = await createEmptyClient()
+ * const client = await createClient()
  *     .use(localhostRpc())
  *     .use(rpcAirdrop())
  *     .use(payerOrGeneratedPayer(undefined));

--- a/packages/kit-plugin-payer/test/index.test.ts
+++ b/packages/kit-plugin-payer/test/index.test.ts
@@ -1,4 +1,4 @@
-import { createEmptyClient, generateKeyPairSigner, KeyPairSigner, lamports, TransactionSigner } from '@solana/kit';
+import { createClient, generateKeyPairSigner, KeyPairSigner, lamports, TransactionSigner } from '@solana/kit';
 import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import { generatedPayer, generatedPayerWithSol, payer, payerFromFile, payerOrGeneratedPayer } from '../src';
@@ -6,7 +6,7 @@ import { generatedPayer, generatedPayerWithSol, payer, payerFromFile, payerOrGen
 describe('payer', () => {
     it('sets the payer attribute with the provided signer', async () => {
         const signer = await generateKeyPairSigner();
-        const client = createEmptyClient().use(payer(signer));
+        const client = createClient().use(payer(signer));
         expect(client).toHaveProperty('payer');
         expect(client.payer).toBe(signer);
     });
@@ -14,7 +14,7 @@ describe('payer', () => {
 
 describe('generatedPayer', () => {
     it('generates a new payer and set it on the client', async () => {
-        const client = await createEmptyClient().use(generatedPayer());
+        const client = await createClient().use(generatedPayer());
         expect(client).toHaveProperty('payer');
         expect(client.payer).toBeTypeOf('object');
         expectTypeOf(client.payer).toEqualTypeOf<KeyPairSigner>();
@@ -25,7 +25,7 @@ describe('generatedPayerWithSol', () => {
     it('generates a new payer with some initial SOL using the airdrop plugin', async () => {
         const amount = lamports(1_000_000_000n);
         const airdrop = vi.fn();
-        const client = await createEmptyClient()
+        const client = await createClient()
             .use(() => ({ airdrop }))
             .use(generatedPayerWithSol(amount));
 
@@ -40,7 +40,7 @@ describe('payerOrGeneratedPayer', () => {
     it('uses the provided payer when one is given', async () => {
         const signer = await generateKeyPairSigner();
         const airdrop = vi.fn();
-        const client = await createEmptyClient()
+        const client = await createClient()
             .use(() => ({ airdrop }))
             .use(payerOrGeneratedPayer(signer));
 
@@ -50,7 +50,7 @@ describe('payerOrGeneratedPayer', () => {
 
     it('generates a new payer and airdrops 100 SOL when no payer is given', async () => {
         const airdrop = vi.fn();
-        const client = await createEmptyClient()
+        const client = await createClient()
             .use(() => ({ airdrop }))
             .use(payerOrGeneratedPayer(undefined));
 
@@ -64,7 +64,7 @@ describe('payerOrGeneratedPayer', () => {
 describe('payerFromFile', () => {
     if (__NODEJS__) {
         it('generates a new payer and set it on the client', async () => {
-            const client = await createEmptyClient().use(payerFromFile('test/mock_payer.json'));
+            const client = await createClient().use(payerFromFile('test/mock_payer.json'));
             expect(client).toHaveProperty('payer');
             expect(client.payer).toBeTypeOf('object');
             expectTypeOf(client.payer).toEqualTypeOf<KeyPairSigner>();

--- a/packages/kit-plugin-rpc/README.md
+++ b/packages/kit-plugin-rpc/README.md
@@ -24,10 +24,10 @@ The RPC plugin adds `rpc` and `rpcSubscriptions` objects to your Kit client, all
 To use the `rpc` plugin, you must provide the URL of your desired Solana RPC endpoint.
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { rpc } from '@solana/kit-plugin-rpc';
 
-const client = createEmptyClient().use(rpc('https://api.mainnet-beta.solana.com'));
+const client = createClient().use(rpc('https://api.mainnet-beta.solana.com'));
 ```
 
 Note that you may wrap your RPC URL using the `mainnet`, `devnet`, or `testnet` helpers from `@solana/kit`. When you do, the returned RPC API will be adjusted to match the selected cluster since some RPC features are not available on all clusters.
@@ -35,13 +35,13 @@ Note that you may wrap your RPC URL using the `mainnet`, `devnet`, or `testnet` 
 ```ts
 import { mainnet } from '@solana/kit';
 
-const client = createEmptyClient().use(rpc(mainnet('https://api.mainnet-beta.solana.com')));
+const client = createClient().use(rpc(mainnet('https://api.mainnet-beta.solana.com')));
 ```
 
 By default, the WebSocket URL is derived from the RPC's HTTP URL but you may configure it explicitly using the second parameter. This config object can also be used to customize other aspects of RPC Subscriptions behavior.
 
 ```ts
-const client = createEmptyClient().use(
+const client = createClient().use(
     rpc('https://my-rpc-url.com', {
         url: 'wss://my-rpc-ws-url.com',
         minChannels: 5,
@@ -71,10 +71,10 @@ This plugin is an alias for the `rpc` plugin pre-configured to connect to a loca
 ### Installation
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { localhostRpc } from '@solana/kit-plugin-rpc';
 
-const client = createEmptyClient().use(localhostRpc());
+const client = createClient().use(localhostRpc());
 ```
 
 ### Features
@@ -93,10 +93,10 @@ This plugin adds an `airdrop` method to your Kit client that requests SOL airdro
 The client must have `rpc` and `rpcSubscriptions` installed before applying this plugin.
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { localhostRpc, rpcAirdrop } from '@solana/kit-plugin-rpc';
 
-const client = createEmptyClient().use(localhostRpc()).use(rpcAirdrop());
+const client = createClient().use(localhostRpc()).use(rpcAirdrop());
 ```
 
 ### Features
@@ -115,10 +115,10 @@ This plugin adds a `getMinimumBalance` method to your Kit client that computes t
 The client must have `rpc` installed before applying this plugin.
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { rpc, rpcGetMinimumBalance } from '@solana/kit-plugin-rpc';
 
-const client = createEmptyClient().use(rpc('https://api.mainnet-beta.solana.com')).use(rpcGetMinimumBalance());
+const client = createClient().use(rpc('https://api.mainnet-beta.solana.com')).use(rpcGetMinimumBalance());
 ```
 
 ### Features
@@ -142,11 +142,11 @@ This plugin provides a default transaction planner that creates transaction mess
 This plugin requires a payer to be set on the client or passed as an option.
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { rpc, rpcTransactionPlanner, rpcTransactionPlanExecutor } from '@solana/kit-plugin-rpc';
 import { generatedPayer } from '@solana/kit-plugin-payer';
 
-const client = await createEmptyClient()
+const client = await createClient()
     .use(rpc('https://api.mainnet-beta.solana.com'))
     .use(generatedPayer())
     .use(rpcTransactionPlanner())
@@ -174,11 +174,11 @@ This plugin provides a default transaction plan executor that estimates compute 
 This plugin requires `rpc` and `rpcSubscriptions` to be configured on the client.
 
 ```ts
-import { createEmptyClient } from '@solana/kit';
+import { createClient } from '@solana/kit';
 import { rpc, rpcTransactionPlanner, rpcTransactionPlanExecutor } from '@solana/kit-plugin-rpc';
 import { generatedPayer } from '@solana/kit-plugin-payer';
 
-const client = await createEmptyClient()
+const client = await createClient()
     .use(rpc('https://api.mainnet-beta.solana.com'))
     .use(generatedPayer())
     .use(rpcTransactionPlanner())

--- a/packages/kit-plugin-rpc/package.json
+++ b/packages/kit-plugin-rpc/package.json
@@ -46,7 +46,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.5.0"
+        "@solana/kit": "^6.8.0"
     },
     "license": "MIT",
     "repository": {

--- a/packages/kit-plugin-rpc/src/airdrop.ts
+++ b/packages/kit-plugin-rpc/src/airdrop.ts
@@ -16,10 +16,10 @@ type RpcClient = {
  *
  * @example
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { localhostRpc, rpcAirdrop } from '@solana/kit-plugin-rpc';
  *
- * const client = createEmptyClient()
+ * const client = createClient()
  *     .use(localhostRpc())
  *     .use(rpcAirdrop());
  *

--- a/packages/kit-plugin-rpc/src/get-minimum-balance.ts
+++ b/packages/kit-plugin-rpc/src/get-minimum-balance.ts
@@ -17,10 +17,10 @@ import {
  *
  * @example
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { rpc, rpcGetMinimumBalance } from '@solana/kit-plugin-rpc';
  *
- * const client = createEmptyClient()
+ * const client = createClient()
  *     .use(rpc('https://api.mainnet-beta.solana.com'))
  *     .use(rpcGetMinimumBalance());
  *

--- a/packages/kit-plugin-rpc/src/rpc.ts
+++ b/packages/kit-plugin-rpc/src/rpc.ts
@@ -14,11 +14,11 @@ import {
  *
  * @example
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { rpc } from '@solana/kit-plugin-rpc';
  *
  * // Install the RPC plugin.
- * const client = createEmptyClient().use(rpc('https://api.mainnet-beta.solana.com'));
+ * const client = createClient().use(rpc('https://api.mainnet-beta.solana.com'));
  *
  * // Make RPC calls.
  * const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send();
@@ -51,11 +51,11 @@ export function rpc<TClusterUrl extends ClusterUrl>(
  *
  * @example
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { localhostRpc } from '@solana/kit-plugin-rpc';
  *
  * // Install the Localhost RPC plugin.
- * const client = createEmptyClient().use(localhostRpc());
+ * const client = createClient().use(localhostRpc());
  *
  * // Make RPC calls.
  * const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send();

--- a/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
+++ b/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
@@ -37,11 +37,11 @@ const MAX_COMPUTE_UNIT_LIMIT = 1_400_000;
  *
  * @example
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { rpc, rpcTransactionPlanner, rpcTransactionPlanExecutor } from '@solana/kit-plugin-rpc';
  * import { generatedPayer } from '@solana/kit-plugin-payer';
  *
- * const client = await createEmptyClient()
+ * const client = await createClient()
  *     .use(rpc('https://api.mainnet-beta.solana.com'))
  *     .use(generatedPayer())
  *     .use(rpcTransactionPlanner())

--- a/packages/kit-plugin-rpc/src/transaction-planner.ts
+++ b/packages/kit-plugin-rpc/src/transaction-planner.ts
@@ -24,11 +24,11 @@ import {
  *
  * @example
  * ```ts
- * import { createEmptyClient } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
  * import { rpc, rpcTransactionPlanner, rpcTransactionPlanExecutor } from '@solana/kit-plugin-rpc';
  * import { generatedPayer } from '@solana/kit-plugin-payer';
  *
- * const client = await createEmptyClient()
+ * const client = await createClient()
  *     .use(rpc('https://api.mainnet-beta.solana.com'))
  *     .use(generatedPayer())
  *     .use(rpcTransactionPlanner())

--- a/packages/kit-plugin-rpc/test/airdrop.test.ts
+++ b/packages/kit-plugin-rpc/test/airdrop.test.ts
@@ -1,4 +1,4 @@
-import { createEmptyClient, mainnet } from '@solana/kit';
+import { createClient, mainnet } from '@solana/kit';
 import { describe, expect, it, vi } from 'vitest';
 
 import { localhostRpc, rpc, rpcAirdrop } from '../src';
@@ -8,7 +8,7 @@ describe('rpcAirdrop', () => {
         const getSignatureStatuses = vi.fn();
         const requestAirdrop = vi.fn();
         const signatureNotifications = vi.fn();
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({
                 rpc: { getSignatureStatuses, requestAirdrop },
                 rpcSubscriptions: { signatureNotifications },
@@ -19,17 +19,17 @@ describe('rpcAirdrop', () => {
     });
 
     it('works with an arbitrary RPC', () => {
-        const client = createEmptyClient().use(rpc('https://my-rpc.com')).use(rpcAirdrop());
+        const client = createClient().use(rpc('https://my-rpc.com')).use(rpcAirdrop());
         expect(client).toHaveProperty('airdrop');
     });
 
     it('works with a localhost RPC', () => {
-        const client = createEmptyClient().use(localhostRpc()).use(rpcAirdrop());
+        const client = createClient().use(localhostRpc()).use(rpcAirdrop());
         expect(client).toHaveProperty('airdrop');
     });
 
     it('throws a TypeScript error with a mainnet RPC', () => {
-        const client = createEmptyClient()
+        const client = createClient()
             .use(rpc(mainnet('https://my-rpc.com')))
             // @ts-expect-error Airdrop RPC methods are not available on mainnet.
             .use(rpcAirdrop());

--- a/packages/kit-plugin-rpc/test/get-minimum-balance.test.ts
+++ b/packages/kit-plugin-rpc/test/get-minimum-balance.test.ts
@@ -1,4 +1,4 @@
-import { BASE_ACCOUNT_SIZE, createEmptyClient, lamports } from '@solana/kit';
+import { BASE_ACCOUNT_SIZE, createClient, lamports } from '@solana/kit';
 import { describe, expect, it, vi } from 'vitest';
 
 import { localhostRpc, rpc, rpcGetMinimumBalance } from '../src';
@@ -9,7 +9,7 @@ const LAMPORTS_PER_BYTE = 6_960n;
 describe('rpcGetMinimumBalance', () => {
     it('provides a getMinimumBalance function that relies on RPCs', () => {
         const getMinimumBalanceForRentExemption = vi.fn();
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({
                 rpc: { getMinimumBalanceForRentExemption },
             }))
@@ -19,19 +19,19 @@ describe('rpcGetMinimumBalance', () => {
     });
 
     it('works with an arbitrary RPC', () => {
-        const client = createEmptyClient().use(rpc('https://my-rpc.com')).use(rpcGetMinimumBalance());
+        const client = createClient().use(rpc('https://my-rpc.com')).use(rpcGetMinimumBalance());
         expect(client).toHaveProperty('getMinimumBalance');
     });
 
     it('works with a localhost RPC', () => {
-        const client = createEmptyClient().use(localhostRpc()).use(rpcGetMinimumBalance());
+        const client = createClient().use(localhostRpc()).use(rpcGetMinimumBalance());
         expect(client).toHaveProperty('getMinimumBalance');
     });
 
     it('calls the RPC with the space as data length by default', async () => {
         const send = vi.fn().mockResolvedValue(lamports(42n));
         const getMinimumBalanceForRentExemption = vi.fn().mockReturnValue({ send });
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({
                 rpc: { getMinimumBalanceForRentExemption },
             }))
@@ -46,7 +46,7 @@ describe('rpcGetMinimumBalance', () => {
         const headerBalance = lamports(LAMPORTS_PER_BYTE * BigInt(BASE_ACCOUNT_SIZE));
         const send = vi.fn().mockResolvedValue(headerBalance);
         const getMinimumBalanceForRentExemption = vi.fn().mockReturnValue({ send });
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({
                 rpc: { getMinimumBalanceForRentExemption },
             }))

--- a/packages/kit-plugin-rpc/test/index.test.ts
+++ b/packages/kit-plugin-rpc/test/index.test.ts
@@ -1,11 +1,11 @@
-import { createEmptyClient, mainnet } from '@solana/kit';
+import { createClient, mainnet } from '@solana/kit';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { localhostRpc, rpc } from '../src';
 
 describe('rpc', () => {
     it('initializes the rpc and rpcSubscriptions properties', () => {
-        const client = createEmptyClient().use(rpc('https://api.mainnet-beta.solana.com'));
+        const client = createClient().use(rpc('https://api.mainnet-beta.solana.com'));
         expect(client).toHaveProperty('rpc');
         expect(client).toHaveProperty('rpcSubscriptions');
         expect(client.rpc.sendTransaction).toBeTypeOf('function');
@@ -13,14 +13,14 @@ describe('rpc', () => {
     });
 
     it('narrows the RPC API based on the cluster', () => {
-        const client = createEmptyClient().use(rpc(mainnet('https://api.mainnet-beta.solana.com')));
+        const client = createClient().use(rpc(mainnet('https://api.mainnet-beta.solana.com')));
         expectTypeOf(client.rpc).not.toHaveProperty('requestAirdrop');
     });
 });
 
 describe('localhostRpc', () => {
     it('initializes the rpc and rpcSubscriptions properties', () => {
-        const client = createEmptyClient().use(localhostRpc());
+        const client = createClient().use(localhostRpc());
         expect(client).toHaveProperty('rpc');
         expect(client).toHaveProperty('rpcSubscriptions');
         expect(client.rpc.sendTransaction).toBeTypeOf('function');
@@ -28,7 +28,7 @@ describe('localhostRpc', () => {
     });
 
     it('has access to airdrop methods', () => {
-        const client = createEmptyClient().use(localhostRpc());
+        const client = createClient().use(localhostRpc());
         expectTypeOf(client.rpc).toHaveProperty('requestAirdrop');
     });
 });

--- a/packages/kit-plugin-rpc/test/transaction-plan-executor.test.ts
+++ b/packages/kit-plugin-rpc/test/transaction-plan-executor.test.ts
@@ -1,6 +1,6 @@
 import {
     Address,
-    createEmptyClient,
+    createClient,
     createTransactionMessage,
     generateKeyPairSigner,
     parallelTransactionPlan,
@@ -38,7 +38,7 @@ describe('rpcTransactionPlanExecutor', () => {
     it('provides a transactionPlanExecutor on the client', () => {
         const rpc = {} as Rpc<SolanaRpcApi>;
         const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ rpc, rpcSubscriptions }))
             .use(rpcTransactionPlanExecutor());
         expect(client).toHaveProperty('transactionPlanExecutor');
@@ -56,7 +56,7 @@ describe('rpcTransactionPlanExecutor', () => {
         const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
         (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
 
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
             .use(rpcTransactionPlanner())
             .use(rpcTransactionPlanExecutor());
@@ -84,7 +84,7 @@ describe('rpcTransactionPlanExecutor', () => {
         const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
         (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
 
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
             .use(rpcTransactionPlanExecutor());
 
@@ -114,7 +114,7 @@ describe('rpcTransactionPlanExecutor', () => {
         const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
         (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
 
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
             .use(rpcTransactionPlanExecutor());
 
@@ -148,7 +148,7 @@ describe('rpcTransactionPlanExecutor', () => {
         const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
         (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
 
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
             .use(rpcTransactionPlanExecutor({ skipPreflight: true }));
 
@@ -184,7 +184,7 @@ describe('rpcTransactionPlanExecutor', () => {
         const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
         (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
 
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
             .use(rpcTransactionPlanExecutor());
 
@@ -212,7 +212,7 @@ describe('rpcTransactionPlanExecutor', () => {
         const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
         (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
 
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
             .use(rpcTransactionPlanExecutor({ skipPreflight: true }));
 
@@ -241,7 +241,7 @@ describe('rpcTransactionPlanExecutor', () => {
         });
         (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
 
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
             .use(rpcTransactionPlanner())
             .use(rpcTransactionPlanExecutor({ maxConcurrency: 2 }));
@@ -273,7 +273,7 @@ describe('rpcTransactionPlanExecutor', () => {
     it('requires an RPC API on the client', () => {
         const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
         expect(() =>
-            createEmptyClient()
+            createClient()
                 .use(() => ({ rpcSubscriptions }))
                 // @ts-expect-error Missing RPC on the client.
                 .use(rpcTransactionPlanExecutor()),
@@ -283,7 +283,7 @@ describe('rpcTransactionPlanExecutor', () => {
     it('requires an RPC Subscriptions API on the client', () => {
         const rpc = {} as Rpc<SolanaRpcApi>;
         expect(() =>
-            createEmptyClient()
+            createClient()
                 .use(() => ({ rpc }))
                 // @ts-expect-error Missing RPC Subscriptions on the client.
                 .use(rpcTransactionPlanExecutor()),

--- a/packages/kit-plugin-rpc/test/transaction-planner.test.ts
+++ b/packages/kit-plugin-rpc/test/transaction-planner.test.ts
@@ -1,6 +1,6 @@
 import {
     Address,
-    createEmptyClient,
+    createClient,
     generateKeyPairSigner,
     singleInstructionPlan,
     SingleTransactionPlan,
@@ -17,7 +17,7 @@ const MOCK_INSTRUCTION = {
 describe('rpcTransactionPlanner', () => {
     it('provides a transactionPlanner on the client', () => {
         const payer = {} as TransactionSigner;
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ payer }))
             .use(rpcTransactionPlanner());
         expect(client).toHaveProperty('transactionPlanner');
@@ -25,7 +25,7 @@ describe('rpcTransactionPlanner', () => {
 
     it('uses the provided payer as fee payer when planning transactions', async () => {
         const payer = await generateKeyPairSigner();
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ payer }))
             .use(rpcTransactionPlanner());
 
@@ -36,17 +36,17 @@ describe('rpcTransactionPlanner', () => {
     });
 
     it('requires a payer on the client by default', () => {
-        expect(() => createEmptyClient().use(rpcTransactionPlanner())).toThrow();
+        expect(() => createClient().use(rpcTransactionPlanner())).toThrow();
     });
 
     it('also accepts a payer directly', () => {
         const payer = {} as TransactionSigner;
-        expect(() => createEmptyClient().use(rpcTransactionPlanner({ payer }))).not.toThrow();
+        expect(() => createClient().use(rpcTransactionPlanner({ payer }))).not.toThrow();
     });
 
     it('uses the provided payer over the one set on the client', async () => {
         const [clientPayer, explicitPayer] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
-        const client = createEmptyClient()
+        const client = createClient()
             .use(() => ({ payer: clientPayer }))
             .use(rpcTransactionPlanner({ payer: explicitPayer }));
 

--- a/packages/kit-plugins/package.json
+++ b/packages/kit-plugins/package.json
@@ -45,7 +45,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.5.0"
+        "@solana/kit": "^6.8.0"
     },
     "dependencies": {
         "@solana/kit-client-litesvm": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@solana/kit': ^6.7.0
+  '@solana/kit': ^6.8.0
 
 importers:
 
@@ -16,19 +16,19 @@ importers:
         version: 0.6.0
       '@changesets/cli':
         specifier: ^2.30.0
-        version: 2.30.0(@types/node@25.5.2)
+        version: 2.30.0(@types/node@25.5.0)
       '@solana/eslint-config-solana':
         specifier: ^6.0.0
-        version: 6.0.0(@eslint/js@9.39.2)(@types/eslint@9.6.1)(@types/eslint__js@9.14.0)(eslint-plugin-jest@29.5.0(@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(jest@30.2.0(@types/node@25.5.2))(typescript@5.9.3))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.2))(eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.2))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(globals@14.0.0)(jest@30.2.0(@types/node@25.5.2))(typescript-eslint@8.50.0(eslint@9.39.2)(typescript@5.9.3))(typescript@5.9.3)
+        version: 6.0.0(@eslint/js@9.39.2)(@types/eslint@9.6.1)(@types/eslint__js@9.14.0)(eslint-plugin-jest@29.5.0(@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(jest@30.2.0(@types/node@25.5.0))(typescript@5.9.3))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.2))(eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.2))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(globals@14.0.0)(jest@30.2.0(@types/node@25.5.0))(typescript-eslint@8.50.0(eslint@9.39.2)(typescript@5.9.3))(typescript@5.9.3)
       '@solana/kit':
-        specifier: ^6.7.0
-        version: 6.7.0(typescript@5.9.3)
+        specifier: ^6.8.0
+        version: 6.8.0(typescript@5.9.3)
       '@solana/prettier-config-solana':
         specifier: 0.0.6
         version: 0.0.6(prettier@3.8.1)
       '@types/node':
         specifier: ^25
-        version: 25.5.2
+        version: 25.5.0
       agadoo:
         specifier: ^3.0.0
         version: 3.0.0
@@ -49,13 +49,13 @@ importers:
         version: 8.5.1(postcss@8.5.8)(typescript@5.9.3)
       turbo:
         specifier: ^2.9.4
-        version: 2.9.4
+        version: 2.9.6
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.2))
+        version: 4.1.2(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0))
       ws:
         specifier: ^8.20.0
         version: 8.20.0
@@ -64,13 +64,13 @@ importers:
     dependencies:
       '@solana-program/system':
         specifier: ^0.12.0
-        version: 0.12.0(@solana/kit@6.7.0(typescript@5.9.3))
+        version: 0.12.0(@solana/kit@6.8.0(typescript@5.9.3))
       '@solana-program/token':
         specifier: ^0.13.0
-        version: 0.13.0(@solana/kit@6.7.0(typescript@5.9.3))
+        version: 0.13.0(@solana/kit@6.8.0(typescript@5.9.3))
       '@solana/kit':
-        specifier: ^6.7.0
-        version: 6.7.0(typescript@5.9.3)
+        specifier: ^6.8.0
+        version: 6.8.0(typescript@5.9.3)
       '@solana/kit-client-rpc':
         specifier: workspace:*
         version: link:../../packages/kit-client-rpc
@@ -79,10 +79,10 @@ importers:
     dependencies:
       '@solana-program/system':
         specifier: ^0.12.0
-        version: 0.12.0(@solana/kit@6.7.0(typescript@5.9.3))
+        version: 0.12.0(@solana/kit@6.8.0(typescript@5.9.3))
       '@solana/kit':
-        specifier: ^6.7.0
-        version: 6.7.0(typescript@5.9.3)
+        specifier: ^6.8.0
+        version: 6.8.0(typescript@5.9.3)
       '@solana/kit-client-rpc':
         specifier: workspace:*
         version: link:../../packages/kit-client-rpc
@@ -90,8 +90,8 @@ importers:
   packages/kit-client-litesvm:
     dependencies:
       '@solana/kit':
-        specifier: ^6.7.0
-        version: 6.7.0(typescript@5.9.3)
+        specifier: ^6.8.0
+        version: 6.8.0(typescript@5.9.3)
       '@solana/kit-plugin-instruction-plan':
         specifier: workspace:*
         version: link:../kit-plugin-instruction-plan
@@ -105,8 +105,8 @@ importers:
   packages/kit-client-rpc:
     dependencies:
       '@solana/kit':
-        specifier: ^6.7.0
-        version: 6.7.0(typescript@5.9.3)
+        specifier: ^6.8.0
+        version: 6.8.0(typescript@5.9.3)
       '@solana/kit-plugin-instruction-plan':
         specifier: workspace:*
         version: link:../kit-plugin-instruction-plan
@@ -120,8 +120,8 @@ importers:
   packages/kit-plugin-airdrop:
     dependencies:
       '@solana/kit':
-        specifier: ^6.7.0
-        version: 6.7.0(typescript@5.9.3)
+        specifier: ^6.8.0
+        version: 6.8.0(typescript@5.9.3)
     devDependencies:
       '@solana/kit-plugin-litesvm':
         specifier: workspace:*
@@ -133,39 +133,39 @@ importers:
   packages/kit-plugin-instruction-plan:
     dependencies:
       '@solana/kit':
-        specifier: ^6.7.0
-        version: 6.7.0(typescript@5.9.3)
+        specifier: ^6.8.0
+        version: 6.8.0(typescript@5.9.3)
 
   packages/kit-plugin-litesvm:
     dependencies:
       '@solana/kit':
-        specifier: ^6.7.0
-        version: 6.7.0(typescript@5.9.3)
+        specifier: ^6.8.0
+        version: 6.8.0(typescript@5.9.3)
       litesvm:
         specifier: ^1.0.0
         version: 1.0.0(typescript@5.9.3)
     devDependencies:
       '@solana-program/system':
         specifier: ^0.12.0
-        version: 0.12.0(@solana/kit@6.7.0(typescript@5.9.3))
+        version: 0.12.0(@solana/kit@6.8.0(typescript@5.9.3))
 
   packages/kit-plugin-payer:
     dependencies:
       '@solana/kit':
-        specifier: ^6.7.0
-        version: 6.7.0(typescript@5.9.3)
+        specifier: ^6.8.0
+        version: 6.8.0(typescript@5.9.3)
 
   packages/kit-plugin-rpc:
     dependencies:
       '@solana/kit':
-        specifier: ^6.7.0
-        version: 6.7.0(typescript@5.9.3)
+        specifier: ^6.8.0
+        version: 6.8.0(typescript@5.9.3)
 
   packages/kit-plugins:
     dependencies:
       '@solana/kit':
-        specifier: ^6.7.0
-        version: 6.7.0(typescript@5.9.3)
+        specifier: ^6.8.0
+        version: 6.8.0(typescript@5.9.3)
       '@solana/kit-client-litesvm':
         specifier: workspace:*
         version: link:../kit-client-litesvm
@@ -1209,99 +1209,99 @@ packages:
   '@solana-program/system@0.12.0':
     resolution: {integrity: sha512-ZnAAWeGVMWNtJhw3GdifI2HnhZ0A0H0qs8tBkcFvxp/8wIavvO+GOM4Jd0N22u2+Lni2zcwvcrxrsxj6Mjphng==}
     peerDependencies:
-      '@solana/kit': ^6.7.0
+      '@solana/kit': ^6.8.0
 
   '@solana-program/token@0.12.0':
     resolution: {integrity: sha512-hnidRNuFhmqUdW5aWkKTJ+cdzuotVMNwLsTyAk0Nd8VjLDld+vQC0fugHWqm5GPrvYe0hCNAhtpJcZVnNp7rOA==}
     peerDependencies:
-      '@solana/kit': ^6.7.0
+      '@solana/kit': ^6.8.0
 
   '@solana-program/token@0.13.0':
     resolution: {integrity: sha512-/Apjrd5lwOJGrPB0J5Rv7EBeclvyEBQPAGA85Scm7wBH+GpkbdLDM9uK3TNg8jjFKyWQYai/JtPHbrx7VgFLSg==}
     peerDependencies:
-      '@solana/kit': ^6.7.0
+      '@solana/kit': ^6.8.0
 
-  '@solana/accounts@6.7.0':
-    resolution: {integrity: sha512-RNUJtnFKGjr4rdlnj5zUyhZolDl+EC2X5Sw0XAjXCsyp5A0TbymWA/XbyUGw9FYdv2TP1x10lD8TiH/IRo4dlA==}
+  '@solana/accounts@6.8.0':
+    resolution: {integrity: sha512-rXjFYVopaEw1H2PTBQbRjKr+0i4EFuBEhRT5E0dI4cMaabSb4KKypC2gaf47+6cjU3hMlM1AcsyIs72/MqAVBw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/addresses@6.7.0':
-    resolution: {integrity: sha512-jmzTxmEXXPDyh1vIJnxjGWxpX1p8DiS201M0yzPynlOf3XhQrk5nfVYw5O/U3+g64pEyOi/W6qbTVAVOov+oVw==}
+  '@solana/addresses@6.8.0':
+    resolution: {integrity: sha512-xVlA0DNX1LVfTueVsbhxDDoqr1VxeXvgJEh2GcIN/vcJPhY3GE3AYtjTbJJmTDgPrzOccI0t6ElVb1gelJH/PQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/assertions@6.7.0':
-    resolution: {integrity: sha512-/nv3tgZNYmIz2mezzfjQcAUl1QN70lGYqKtR+LWFlKt2Srv0V9ugyerniRInMpuPjb/loVA9UxdPne0hzFt4Uw==}
+  '@solana/assertions@6.8.0':
+    resolution: {integrity: sha512-OU6prCq39fSvGL8xY1C/9vhghasvAkMiRlituzJxzJpZRfpVRrwhzLd6P5NPAPoQ28qKcenA50kFdw9+ZyneJQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/codecs-core@6.7.0':
-    resolution: {integrity: sha512-IVBuoFyN8upzJJ/Qg3Wc/Go8XKusZXAjqsglgCLCTgOaS68kb9E9CC2N8cGkqFDb2zJuOqGm80ZBdQaL/T7qiA==}
+  '@solana/codecs-core@6.8.0':
+    resolution: {integrity: sha512-udFO8TrvzgROonwX3rY3E2SG675RehILNb4ZYcKlf1mL7vkDJ9bEJnBxi87AEwl8RWZFTl+MhT0MmrJnbpvdug==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/codecs-data-structures@6.7.0':
-    resolution: {integrity: sha512-n9SUQd5hGLAmYV4fJL6XEEdL5oZ+gfUxPe7rENPAXxw2gwjc4/axV3s251a3duKNJPW0CVwdmMM4tcUxJmmpGw==}
+  '@solana/codecs-data-structures@6.8.0':
+    resolution: {integrity: sha512-lHr0F+nNwgm9c+tWQX398yzYh1qDi7QSCJpY9MQ2azW4FfY2IyPSo7bqzTaWNnJh9pmJx3ZI6jHfXBnLD5k/SQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/codecs-numbers@6.7.0':
-    resolution: {integrity: sha512-bk5b+JXVGoU6AdITBSd48NrCA2RsS8jpbXlyCnDsHJrr84TMJfk1lvFYXnv6DYm8ObdgaqIoQCo8lpvITEFavQ==}
+  '@solana/codecs-numbers@6.8.0':
+    resolution: {integrity: sha512-ebf4f1D19EAe0uhdUYOCEYnn5+EellsBxbJ42tM2yYEoIBVz5FoBBC0gSsq+UTNbQHFa7XagyBT3LewxXttiTQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/codecs-strings@6.7.0':
-    resolution: {integrity: sha512-X+vmiHll/8ATjW1GCny5jP5odZXq2f6luUmyMsEuUvBugA8KqFUqb9FezdHDizuWU234im+0iDFMjvvFNt0ROw==}
+  '@solana/codecs-strings@6.8.0':
+    resolution: {integrity: sha512-Rpk5NVhbKYcPnE7wz3IpTp0GVNVs0IYKdmyzByiimgPTiII8eb8ay4wQiYHGHrpYh62hD14Qy3GiGDFgipRKqA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       fastestsmallesttextencoderdecoder:
         optional: true
       typescript:
         optional: true
 
-  '@solana/codecs@6.7.0':
-    resolution: {integrity: sha512-1LLDxHMDZj2OqPlSbgQY8uRw+AkvsdPQDJWkn783hzpBtU3oj7whehoqOETtTqbWtF1hK3T/cESz31LTL919pA==}
+  '@solana/codecs@6.8.0':
+    resolution: {integrity: sha512-qCSAaw1qszeQflavkIM7c21qJ3BHReP/qgDelZbhsEXpZc852CCZM00FOIWuxePr6X+JjSNqJquxwdDSoZe7Bw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/errors@6.7.0':
-    resolution: {integrity: sha512-wxxo56b2NHcXXXTr/tixpDCa8xzW8v4/gNnDPcctwof21/Jv8qNNyBNgu/xbREuN1SQNthDM5d5c7k/v67uQkw==}
+  '@solana/errors@6.8.0':
+    resolution: {integrity: sha512-HRTrLgTn0c99GKz4v4IKgz2+6soaRY1mh2tLW4sk1Fe4Zzv85Q6ZLK1mXrVGL73z1apyHDrr9/Sd/9ZhUsUvpA==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1323,101 +1323,101 @@ packages:
       typescript: ^5.9.3
       typescript-eslint: ^8.49.0
 
-  '@solana/fast-stable-stringify@6.7.0':
-    resolution: {integrity: sha512-1RAk+8PDrF1jDiZLbuPNsH6+g2XPR4jiN823ZqXaDcqgSjeCB59mkyH5KNuwhLFIBjxL+IApWdG+JL/H4WJu9g==}
+  '@solana/fast-stable-stringify@6.8.0':
+    resolution: {integrity: sha512-lZa3Qnsn+9ew6rHTXkPc+uqSa3i+AWqSBhV6oYxxBc+smvuxovItU4TPIs30cTfA7lAP+j+oYAQtUDu2dLy0hA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/functional@6.7.0':
-    resolution: {integrity: sha512-RcR+RRJKH43Ko98ru+LKDkjtcs3sHGz26HWL2IyPujni8RH3VsK2hg7HiLqO8Y4R53yzwsn2iZ3D+q8SkYbTpg==}
+  '@solana/functional@6.8.0':
+    resolution: {integrity: sha512-oMSAD/8w9ujx7OplvwRWwHHFnaaxi/Xrji1XH3xAB+gzxupUpBbOmgxQ+e84x+9VN8QWk5aU3L7gmCqdTAR6OA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/instruction-plans@6.7.0':
-    resolution: {integrity: sha512-JTCPahwY76ojHPW+P+xsT08pr7pZNPxQm6uuRBLRjQXmRaNu5ZENgJHGjm1C/gwOCq9qlzPTR3R2T9I5/88GOA==}
+  '@solana/instruction-plans@6.8.0':
+    resolution: {integrity: sha512-osAsY8ozqohrcTcHlG1EmO3i9flc0eESMIy9akTHyVvqk915gZgkaTmt4IjcYSwBGt7i+Rh8TmLj27RrTpCKvg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/instructions@6.7.0':
-    resolution: {integrity: sha512-VlDcmxWXsLPO3BXMxQrv/wHDWz2HZ47XAYIgEJlIvzGYm77GEpawyNQSoPUb6F6zTBuJmn02HW8gvmEBYPqs7w==}
+  '@solana/instructions@6.8.0':
+    resolution: {integrity: sha512-dTtykhS9IeN3npCfnd7wSS6KmKAh54+g90JRtLYy5/31L2Zvunf3AJz2QUk58vgsAGZ5fuoiMyhCxRJm4rHUBQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/keys@6.7.0':
-    resolution: {integrity: sha512-qyrBOLuluxkI+JamwpfsuwCIgFtapts+TcTeG4w0bxbE9TXJAJKb/CP9JhVt4XgNkW+awX4YTk0itpHOZL5y3Q==}
+  '@solana/keys@6.8.0':
+    resolution: {integrity: sha512-Wo8CnbrVfCP1Jbsb3ElMej/3dmMrl4ArPhI1mDcqIIz/O4j4HmxZYbn2BCWtnV9V/LPM638EMO2r1x6GzDNrPA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/kit@6.7.0':
-    resolution: {integrity: sha512-/N/lkkYSQ4frD2K61jBZenvU92GoETiraCoWlsWe3OzqeJABMToLG3fwTpG/tU5T+ErHNqjmRdAHAQXvSe5muw==}
+  '@solana/kit@6.8.0':
+    resolution: {integrity: sha512-+McC1aCgcUBdM7Cd7U6k2ZHJ9OKCy5mzpb0XWrhkrgsFxT0QoRr0AcWJc85o6tIDfG6Jz7vVhbS3l8ugYz2Vzw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/nominal-types@6.7.0':
-    resolution: {integrity: sha512-XY+6gF9TzonHiI6VBjtcrEfxT/0KlmF3KRFGSKM5JLEfhs3w+E26op3TOqHuOX7H6llZBgxybaZmXKrvo2rt/w==}
+  '@solana/nominal-types@6.8.0':
+    resolution: {integrity: sha512-mLmHr92pM4mEfe49GUmZ5Ry0RMqtMuFQqZYnxQqhDKMcl+Wtt820ezxYgwPhqcMxRzfqaQSO3ZxpSB0RlLBa/Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/offchain-messages@6.7.0':
-    resolution: {integrity: sha512-c9IDz6hrzkklq0y7fhPXiY973cDILLL3ZIGIZPofEg12s/VxvUIFYseN/syVAQSUkzeYrDywZQLlF6sptAxWdQ==}
+  '@solana/offchain-messages@6.8.0':
+    resolution: {integrity: sha512-HoniTs2uoCHGicD0dTTJ3YBhLZC9URxdXXUf0CHalLFwAidF9iNuB8dsuKk16Euu68L4/ERKKGfyC0QobBvahw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/options@6.7.0':
-    resolution: {integrity: sha512-B6nmUvfNpW+E6Oq9MtCzI6ExK5b3AJIRqjz+x1RBdA9rUCF6alM/4bjCSoADCZZVCTMts7FJF59r9XZrwONp2w==}
+  '@solana/options@6.8.0':
+    resolution: {integrity: sha512-T5441HHeucFaLtaMAJQJl79T7mX007oAFPunpPebBphRvCXGv+qQwQvqa4HkYct6Jf2O0aKLBL9GSe/kfdCk9A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/plugin-core@6.7.0':
-    resolution: {integrity: sha512-tO9PAa9nFxZdrlYYHuG8pP9WbO/Szo1rr2YT2Mpj8PKDDqLsrQ2cCC8GerHbdLOr1s+cE1O7fotbydGDqeC9yQ==}
+  '@solana/plugin-core@6.8.0':
+    resolution: {integrity: sha512-kdqFIhQvJP2BDUsMOIbor35esj8u78SO33Xv0Wmo+uTRg6yKONKVK53ghw235pWrinOT4f0VnVe6MN6ciYiQVA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/plugin-interfaces@6.7.0':
-    resolution: {integrity: sha512-RVlZEx3gqCsPZ2aQtxRc+8TX0m8LqPFakZn9ceq40WPuZwqE1khx4G82aYSxwJiiZ3HIepMPChRYSG+7tcoRRA==}
+  '@solana/plugin-interfaces@6.8.0':
+    resolution: {integrity: sha512-4olaMKGUVA7wG6BBWM5A31bQsUWBlfcL1pjhq6ZTqVEJ7vshHXGwHVlWYXYyYn9ixozGDpGSl553yaRY9jQwWw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1427,191 +1427,191 @@ packages:
     peerDependencies:
       prettier: ^3.7.4
 
-  '@solana/program-client-core@6.7.0':
-    resolution: {integrity: sha512-/ReQ26eOUjdL26smpv1732H+amGOCAB6dMnCCgaqCxS1pzY6bAfJoS6SU+z4ev8KzF7kAdlZG/f+LrtI74hFyA==}
+  '@solana/program-client-core@6.8.0':
+    resolution: {integrity: sha512-eOZtEnwl+vdiy9x/rFF89NDtnvt+Q3H04A/0u4GoHnt+fFkQG3JS+ChWG9c77izmpmRuz5C1GptOPDGNDnIUgQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/programs@6.7.0':
-    resolution: {integrity: sha512-RbJ9jWRaSGSQgyDyaN2FBXjqb5ussSjmIRgG5SsXehCQeJqb91qVGRpA55x7H6pbIPX5WDIiBgxZTK0nS4ja7Q==}
+  '@solana/programs@6.8.0':
+    resolution: {integrity: sha512-8hSKGfPTLX9Sm7KGV/UtiGCeSzptT/9vcjbodE+ZGHKFefo5vES4UAW+qD01LjL7IumGtMJvnfhCWt81qT/jbQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/promises@6.7.0':
-    resolution: {integrity: sha512-LKdYoYr6KXqSsJ39VjlZ15l+QuCx/bzoug62CShJqud41BUFUTPm7mD5sbV+rc8k0W1+MY8OKFA8G1i7zljw7w==}
+  '@solana/promises@6.8.0':
+    resolution: {integrity: sha512-kIypZG83ZbADbrAq9/LS7LuWlVxlgJSzIpic75+9IuAfC3k5/KSus8LrvggBkCzfAyIslrUh70iz4JcnzUZrOw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-api@6.7.0':
-    resolution: {integrity: sha512-Tzz1Mr2ejmLV2vKqPPru51u4EiwOUdMGHgby6j9XKMDBNcLIYPnAJKfIgbTZUJljM/MPFzZSzBGUzmoTo4pqTQ==}
+  '@solana/rpc-api@6.8.0':
+    resolution: {integrity: sha512-v8ZKWgPtKbF6HeJcfC4ciwI8mwDCizBtRLYYjjHOu+9S9IJYyefQzsQxL5P8OjJPpI4gFauT6gsjQLo76BoojA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-parsed-types@6.7.0':
-    resolution: {integrity: sha512-DwX4O918uAodrJyMh5TmsovOGeXRfF46Qwgbh57ZknFk3whrnahAHnPV9H5uR41hBExfZ/RE4u4IvLySca3Y8g==}
+  '@solana/rpc-parsed-types@6.8.0':
+    resolution: {integrity: sha512-jYddZviBSUYbuUKqvNthet7KbJVI7me6xfRH2znv1SjIpmvhSPJcGN5QrlHVOasHdzEWSpvZa5VYDfnqH3aYvA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-spec-types@6.7.0':
-    resolution: {integrity: sha512-ohameGNJmtjZm7bIIGSaRIRI2G6Ikx77MfCyi9egxZo+CSS6X8WYQyqibVFjq/5RuFz9KnQp6+o2wOn3UL78sg==}
+  '@solana/rpc-spec-types@6.8.0':
+    resolution: {integrity: sha512-ebCWgiQbIgFOehU7PdRFmYCzda3Azc/qa2Y3P8gexSHSsDAO27VwS4E05XSY+a7cIL5MYmvUa1vpDynl1Rkakw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-spec@6.7.0':
-    resolution: {integrity: sha512-dCCwZQdWW176fs7Db9qOrCGii7WnIhe+x5DM1p8TFov+4X/4APD4VD5/sgUcTEFKobawYaqrH2f7kk/kMSbE3w==}
+  '@solana/rpc-spec@6.8.0':
+    resolution: {integrity: sha512-kE5uOspxCVFJKNUu73hlebGiAFosjfYXbbTXAbGKfksPzy84u1oJFC2IVIobLRnqUCw1x7oJcvfnX00Zs0Itpg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-api@6.7.0':
-    resolution: {integrity: sha512-924U8fmFd+5ZkkK5023LWsR//qIkx7TinNxuFEnpbM4x/Yfi2O50xLelnx6hWV+dOJRQSJDzpMoPa3edQXUyQQ==}
+  '@solana/rpc-subscriptions-api@6.8.0':
+    resolution: {integrity: sha512-cPJOsydyoqkztW3msEH09wPDYqxJcMvO6DBlvrboq6wGu1UjeP66w2eApzQ8POoQHxhyw+CfEXl1Gbu6kKwuMQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-channel-websocket@6.7.0':
-    resolution: {integrity: sha512-QlyqG31WCZtHrRinxeysNpmWOUJ8dYVl6/IKDACSH8QwlTmKkeIi/U197RfZ24ul+nDQ/arrVBp3wBFWVK8MWg==}
+  '@solana/rpc-subscriptions-channel-websocket@6.8.0':
+    resolution: {integrity: sha512-c3PpkorYwhAz1iuUfM5sLpZQi8xtZFGbaPbaPRELVeDjFSRzoa12KFnuQs4i9fbVbLy5Cnt1t23tf0bL2snZCQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-spec@6.7.0':
-    resolution: {integrity: sha512-F+zK+l3INGGzrKN5+4VV8wemS18IvNYtr43h05VMwPF4qcibR+RnAxZ0Eq6FiCjQ+nF8dA5lE1eQxkkLoNxThQ==}
+  '@solana/rpc-subscriptions-spec@6.8.0':
+    resolution: {integrity: sha512-+t4L5q9qE6IVfunW3n1amA/3EswJr64pVqRF7234vCUuVUz4PgYfbqtEBV3KkA1o0NwEHHM3pXuofT63nBb8Bg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions@6.7.0':
-    resolution: {integrity: sha512-QocXnamF9fkgRMneApAepFZEX6sqjmFcmNX1h+fx05KKouQRgJ5fMEmV10Ga9DFtdc8CJtOPqYjyYRk2b/ygLQ==}
+  '@solana/rpc-subscriptions@6.8.0':
+    resolution: {integrity: sha512-9CotreNZmKAP2z07FY1I7TPPvylKLFF5p4mujB5ZFMHQPp5JVQFVCmMIhSj5voZHAeYx7jdwJ2Kf0RDeClqJzA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-transformers@6.7.0':
-    resolution: {integrity: sha512-0kKwDbvYRfc5jvppqdkgxI620qF/rxnfayR0XLvdu4W+mOKMNEbBccBzrMqwm0tjVWGRgRHtpQtZ7t9fKWDX8A==}
+  '@solana/rpc-transformers@6.8.0':
+    resolution: {integrity: sha512-GzcFkllym7eXbw7grdE41MCb15CjkibrXtr7EFsf4d6LD9DRvzFj2ZRYywS2FB2ibVP0LUXXGk3vmtkZJjfajA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-transport-http@6.7.0':
-    resolution: {integrity: sha512-FDj6y+LT+TY5cn4bgYjZss73vqqThc60P7CLSDUqYzTtqNE+IfEe7h6pmP4oJvOVWr6sWwYICHkgD3x2BFtPZA==}
+  '@solana/rpc-transport-http@6.8.0':
+    resolution: {integrity: sha512-jw/L0q2motGcx7yo6KvkKJd2HGVg9gvViXatFloLl1XmHbkwE7+97YYmG17WRuM5xauzI/UGYOXNW7cEB+Uaxw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc-types@6.7.0':
-    resolution: {integrity: sha512-M5F1ommNsp/aNWZIDUdboOHAftrPaUH6wcho71bIh3WaTVAtk2vYyyTaow+lX5sI3psVE/XB8f2WVcKH+p1TIA==}
+  '@solana/rpc-types@6.8.0':
+    resolution: {integrity: sha512-vACMV9VR2JsZGDcgaMOFN/dwLK57CsE+erassxxtF12sSPXJooz+Vu1vyY2Yp2EkCc7mDf7BNkTKvSXajbt+Qw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/rpc@6.7.0':
-    resolution: {integrity: sha512-Z2gE4U4ou8st8CwV1NjoVvVjeEfJi1Xnz5Rs5bd6vIneHyB3UjVk8hHmjNpaYCI/11zdFL1gp4D2tga38pNrHg==}
+  '@solana/rpc@6.8.0':
+    resolution: {integrity: sha512-+jW4n9TDmBttY3bO3PdUo54GAnwFrd7UJsyfXoMgl/lWGQq5uddYDgnzQLtHOBP5zKslkR8h0RKkic0GZhMZrQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/signers@6.7.0':
-    resolution: {integrity: sha512-r2cFkxJFf7AjxXkZL0aXbiipscis7xzs1acmZzD2pgy7w7Hz6bw1w3lWihYL/pgjprYafnpH7XG36jJzKF0+WA==}
+  '@solana/signers@6.8.0':
+    resolution: {integrity: sha512-7E1cAXBLOcz9kmHhzWdu5m3UJlJzxfwOl8irOMLJI6NnKB2EmU0B0h4I+Mlfs9w8Bfj0WQpUei21ammbNBq39g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/subscribable@6.7.0':
-    resolution: {integrity: sha512-cAEM3u8Z9qTjWwMEZ75tMRoFWArPnseP3INz0FM8FxsjD5uxZ5rH6H0uPfUBBiI/n+pqdkmQMX39hmdXE39hXQ==}
+  '@solana/subscribable@6.8.0':
+    resolution: {integrity: sha512-yj41Q97MiWrOmLj1iRFobvTdtU6H5wz5BlH5FHJg9lyapy1YQyaYF37MZx4LiUj4Ww0V3ReluIZTWWDBOJ53Jg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/sysvars@6.7.0':
-    resolution: {integrity: sha512-TDMmDh1Nq/F0B0IN6P/eujx96oLo9n794jn7ZAT+a7cSrMM9QtxPXvEaW8cqp0cB6lWWkKolPfPSOilZK74WcQ==}
+  '@solana/sysvars@6.8.0':
+    resolution: {integrity: sha512-pwfMpMNL6MSmm07eHQYdTdRdzmPOd+EuVCCaNLSYdWGpYcocVJiaLiNWRV3cXA5wPj/ZFkoUGtc1bo0v7H50lw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/transaction-confirmation@6.7.0':
-    resolution: {integrity: sha512-yalZYuOQDvLpRftcxdKYRbPkEjPRNZ1pFavdpj4TWPQryYbq86xgxJmvP2GW8UnCIBEp42PucbdHXuXM33Cx+A==}
+  '@solana/transaction-confirmation@6.8.0':
+    resolution: {integrity: sha512-R6rj8y/+kZqYJr8FR/fWxgi3Pw3eCiacUyjCPTVtdVe6i+hIiBApTGLzXrSRJmAMdpZrjYBZU1cG8C6oAb+B2A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/transaction-messages@6.7.0':
-    resolution: {integrity: sha512-sbr26okH0DNrufhMMegMyqL1z1+ISXn/NcIWeEh7xXiMUGZlWL1z045PrRdqD2qTkMh8c474DBEzfGWj8AiQOA==}
+  '@solana/transaction-messages@6.8.0':
+    resolution: {integrity: sha512-jsJu9mAcN1x7onKOeC4WEvYP04UVcnkOYu/9bMe+S9jqjL+3DMy9kFZpV5FBl+TPuTNJrtOqc6Gc28hUWyyp1A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@solana/transactions@6.7.0':
-    resolution: {integrity: sha512-4qiVyr2VfJdjmKg9aLA+nulHaoNLOEBr2f6+aWDQIuRMNiaYHLwXQ2BzfVROtou1TuUrdO9R6JGwI/C477bW4g==}
+  '@solana/transactions@6.8.0':
+    resolution: {integrity: sha512-Q46m+o3C1yL2EIZBAP5B8ou2VZwHN9wTi+muIS6/giCKO3jwUtnTEbWcZEDMj2vxUb7P2WfwTluZb/VAWxlx7Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1619,33 +1619,33 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@turbo/darwin-64@2.9.4':
-    resolution: {integrity: sha512-ZSlPqJ5Vqg/wgVw8P3AOVCIosnbBilOxLq7TMz3MN/9U46DUYfdG2jtfevNDufyxyrg98pcPs/GBgDRaaids6g==}
+  '@turbo/darwin-64@2.9.6':
+    resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.4':
-    resolution: {integrity: sha512-9cjTWe4OiNlFMSRggPNh+TJlRs7MS5FWrHc96MOzft5vESWjjpvaadYPv5ykDW7b45mVHOF2U/W+48LoX9USWw==}
+  '@turbo/darwin-arm64@2.9.6':
+    resolution: {integrity: sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.4':
-    resolution: {integrity: sha512-Cl1GjxqBXQ+r9KKowmXG+lhD1gclLp48/SE7NxL//66iaMytRw0uiphWGOkccD92iPiRjHLRUaA9lOTtgr5OCA==}
+  '@turbo/linux-64@2.9.6':
+    resolution: {integrity: sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.9.4':
-    resolution: {integrity: sha512-j2hPAKVmGNN2EsKigEWD+43y9m7zaPhNAs6ptsyfq0u7evHHBAXAwOfv86OEMg/gvC+pwGip0i1CIm1bR1vYug==}
+  '@turbo/linux-arm64@2.9.6':
+    resolution: {integrity: sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.9.4':
-    resolution: {integrity: sha512-1jWPjCe9ZRmsDTXE7uzqfySNQspnUx0g6caqvwps+k/sc+fm9hC/4zRQKlXZLbVmP3Xxp601Ju71boegHdnYGw==}
+  '@turbo/windows-64@2.9.6':
+    resolution: {integrity: sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.4':
-    resolution: {integrity: sha512-dlko15TQVu/BFYmIY018Y3covWMRQlUgAkD+OOk+Rokcfj6VY02Vv4mCfT/Zns6B4q8jGbOd6IZhnCFYsE8Viw==}
+  '@turbo/windows-arm64@2.9.6':
+    resolution: {integrity: sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A==}
     cpu: [arm64]
     os: [win32]
 
@@ -1695,11 +1695,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@25.5.2':
-    resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
-
-  '@types/node@25.5.2':
-    resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
+  '@types/node@25.5.0':
+    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
@@ -2082,8 +2079,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.10.15:
-    resolution: {integrity: sha512-1nfKCq9wuAZFTkA2ey/3OXXx7GzFjLdkTiFVNwlJ9WqdI706CZRIhEqjuwanjMIja+84jDLa9rcyZDPDiVkASQ==}
+  baseline-browser-mapping@2.10.13:
+    resolution: {integrity: sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2145,8 +2142,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001786:
-    resolution: {integrity: sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==}
+  caniuse-lite@1.0.30001784:
+    resolution: {integrity: sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -3477,8 +3474,8 @@ packages:
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
 
-  turbo@2.9.4:
-    resolution: {integrity: sha512-wZ/kMcZCuK5oEp7sXSSo/5fzKjP9I2EhoiarZjyCm2Ixk0WxFrC/h0gF3686eHHINoFQOOSWgB/pGfvkR8rkgQ==}
+  turbo@2.9.6:
+    resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
     hasBin: true
 
   type-check@0.4.0:
@@ -3511,8 +3508,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici-types@7.24.7:
-    resolution: {integrity: sha512-XA+gOBkzYD3C74sZowtCLTpgtaCdqZhqCvR6y9LXvrKTt/IVU6bz49T4D+BPi475scshCCkb0IklJRw6T1ZlgQ==}
+  undici-types@8.0.2:
+    resolution: {integrity: sha512-5AfRgQ8gcBaQW8pKd/zYRGGspwSCjFaMEq2oLKKt8T2bgnML0MH+SzIIn0B0xJ9qx7UADB8weRiNxdADJgLZ7A==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -3921,7 +3918,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.30.0(@types/node@25.5.2)':
+  '@changesets/cli@2.30.0(@types/node@25.5.0)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.0
       '@changesets/assemble-release-plan': 6.0.9
@@ -3937,7 +3934,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@25.5.2)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.5.0)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -4276,12 +4273,12 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/external-editor@1.0.3(@types/node@25.5.2)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.5.0)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -4307,7 +4304,7 @@ snapshots:
   '@jest/console@30.2.0':
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       chalk: 4.1.2
       jest-message-util: 30.2.0
       jest-util: 30.2.0
@@ -4321,14 +4318,14 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.2.0
-      jest-config: 30.2.0(@types/node@25.5.2)
+      jest-config: 30.2.0(@types/node@25.5.0)
       jest-haste-map: 30.2.0
       jest-message-util: 30.2.0
       jest-regex-util: 30.0.1
@@ -4355,7 +4352,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       jest-mock: 30.2.0
 
   '@jest/expect-utils@30.2.0':
@@ -4373,7 +4370,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.2.0
       '@sinonjs/fake-timers': 13.0.5
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       jest-message-util: 30.2.0
       jest-mock: 30.2.0
       jest-util: 30.2.0
@@ -4391,7 +4388,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       jest-regex-util: 30.0.1
 
   '@jest/reporters@30.2.0':
@@ -4402,7 +4399,7 @@ snapshots:
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -4479,7 +4476,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -4697,181 +4694,183 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@solana-program/system@0.12.0(@solana/kit@6.7.0(typescript@5.9.3))':
+  '@solana-program/system@0.12.0(@solana/kit@6.8.0(typescript@5.9.3))':
     dependencies:
-      '@solana/kit': 6.7.0(typescript@5.9.3)
+      '@solana/kit': 6.8.0(typescript@5.9.3)
 
-  '@solana-program/token@0.12.0(@solana/kit@6.7.0(typescript@5.9.3))':
+  '@solana-program/token@0.12.0(@solana/kit@6.8.0(typescript@5.9.3))':
     dependencies:
-      '@solana-program/system': 0.12.0(@solana/kit@6.7.0(typescript@5.9.3))
-      '@solana/kit': 6.7.0(typescript@5.9.3)
+      '@solana-program/system': 0.12.0(@solana/kit@6.8.0(typescript@5.9.3))
+      '@solana/kit': 6.8.0(typescript@5.9.3)
 
-  '@solana-program/token@0.13.0(@solana/kit@6.7.0(typescript@5.9.3))':
+  '@solana-program/token@0.13.0(@solana/kit@6.8.0(typescript@5.9.3))':
     dependencies:
-      '@solana-program/system': 0.12.0(@solana/kit@6.7.0(typescript@5.9.3))
-      '@solana/kit': 6.7.0(typescript@5.9.3)
+      '@solana-program/system': 0.12.0(@solana/kit@6.8.0(typescript@5.9.3))
+      '@solana/kit': 6.8.0(typescript@5.9.3)
 
-  '@solana/accounts@6.7.0(typescript@5.9.3)':
+  '@solana/accounts@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-spec': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.7.0(typescript@5.9.3)
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@6.7.0(typescript@5.9.3)':
+  '@solana/addresses@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/assertions': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.7.0(typescript@5.9.3)
+      '@solana/assertions': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/assertions@6.7.0(typescript@5.9.3)':
+  '@solana/assertions@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.7.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-core@6.7.0(typescript@5.9.3)':
+  '@solana/codecs-core@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.7.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-data-structures@6.7.0(typescript@5.9.3)':
+  '@solana/codecs-data-structures@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-numbers@6.7.0(typescript@5.9.3)':
+  '@solana/codecs-numbers@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-strings@6.7.0(typescript@5.9.3)':
+  '@solana/codecs-strings@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs@6.7.0(typescript@5.9.3)':
+  '@solana/codecs@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.7.0(typescript@5.9.3)
-      '@solana/options': 6.7.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/options': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/errors@6.7.0(typescript@5.9.3)':
+  '@solana/errors@6.8.0(typescript@5.9.3)':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/eslint-config-solana@6.0.0(@eslint/js@9.39.2)(@types/eslint@9.6.1)(@types/eslint__js@9.14.0)(eslint-plugin-jest@29.5.0(@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(jest@30.2.0(@types/node@25.5.2))(typescript@5.9.3))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.2))(eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.2))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(globals@14.0.0)(jest@30.2.0(@types/node@25.5.2))(typescript-eslint@8.50.0(eslint@9.39.2)(typescript@5.9.3))(typescript@5.9.3)':
+  '@solana/eslint-config-solana@6.0.0(@eslint/js@9.39.2)(@types/eslint@9.6.1)(@types/eslint__js@9.14.0)(eslint-plugin-jest@29.5.0(@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(jest@30.2.0(@types/node@25.5.0))(typescript@5.9.3))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.2))(eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.2))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(globals@14.0.0)(jest@30.2.0(@types/node@25.5.0))(typescript-eslint@8.50.0(eslint@9.39.2)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@eslint/js': 9.39.2
       '@types/eslint': 9.6.1
       '@types/eslint__js': 9.14.0
       eslint: 9.39.2
-      eslint-plugin-jest: 29.5.0(@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(jest@30.2.0(@types/node@25.5.2))(typescript@5.9.3)
+      eslint-plugin-jest: 29.5.0(@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(jest@30.2.0(@types/node@25.5.0))(typescript@5.9.3)
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.39.2)
       eslint-plugin-sort-keys-fix: 1.1.2
       eslint-plugin-typescript-sort-keys: 3.3.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)
       globals: 14.0.0
-      jest: 30.2.0(@types/node@25.5.2)
+      jest: 30.2.0(@types/node@25.5.0)
       typescript: 5.9.3
       typescript-eslint: 8.50.0(eslint@9.39.2)(typescript@5.9.3)
 
-  '@solana/fast-stable-stringify@6.7.0(typescript@5.9.3)':
+  '@solana/fast-stable-stringify@6.8.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/functional@6.7.0(typescript@5.9.3)':
+  '@solana/functional@6.8.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/instruction-plans@6.7.0(typescript@5.9.3)':
+  '@solana/instruction-plans@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/instructions': 6.7.0(typescript@5.9.3)
-      '@solana/keys': 6.7.0(typescript@5.9.3)
-      '@solana/promises': 6.7.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.7.0(typescript@5.9.3)
-      '@solana/transactions': 6.7.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/instructions': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/promises': 6.8.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.8.0(typescript@5.9.3)
+      '@solana/transactions': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/instructions@6.7.0(typescript@5.9.3)':
+  '@solana/instructions@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/keys@6.7.0(typescript@5.9.3)':
+  '@solana/keys@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/assertions': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.7.0(typescript@5.9.3)
+      '@solana/assertions': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.8.0(typescript@5.9.3)
+      '@solana/promises': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@6.7.0(typescript@5.9.3)':
+  '@solana/kit@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/accounts': 6.7.0(typescript@5.9.3)
-      '@solana/addresses': 6.7.0(typescript@5.9.3)
-      '@solana/codecs': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/functional': 6.7.0(typescript@5.9.3)
-      '@solana/instruction-plans': 6.7.0(typescript@5.9.3)
-      '@solana/instructions': 6.7.0(typescript@5.9.3)
-      '@solana/keys': 6.7.0(typescript@5.9.3)
-      '@solana/offchain-messages': 6.7.0(typescript@5.9.3)
-      '@solana/plugin-core': 6.7.0(typescript@5.9.3)
-      '@solana/plugin-interfaces': 6.7.0(typescript@5.9.3)
-      '@solana/program-client-core': 6.7.0(typescript@5.9.3)
-      '@solana/programs': 6.7.0(typescript@5.9.3)
-      '@solana/rpc': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-api': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-parsed-types': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.7.0(typescript@5.9.3)
-      '@solana/signers': 6.7.0(typescript@5.9.3)
-      '@solana/sysvars': 6.7.0(typescript@5.9.3)
-      '@solana/transaction-confirmation': 6.7.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.7.0(typescript@5.9.3)
-      '@solana/transactions': 6.7.0(typescript@5.9.3)
+      '@solana/accounts': 6.8.0(typescript@5.9.3)
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/functional': 6.8.0(typescript@5.9.3)
+      '@solana/instruction-plans': 6.8.0(typescript@5.9.3)
+      '@solana/instructions': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/offchain-messages': 6.8.0(typescript@5.9.3)
+      '@solana/plugin-core': 6.8.0(typescript@5.9.3)
+      '@solana/plugin-interfaces': 6.8.0(typescript@5.9.3)
+      '@solana/program-client-core': 6.8.0(typescript@5.9.3)
+      '@solana/programs': 6.8.0(typescript@5.9.3)
+      '@solana/rpc': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-api': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+      '@solana/signers': 6.8.0(typescript@5.9.3)
+      '@solana/subscribable': 6.8.0(typescript@5.9.3)
+      '@solana/sysvars': 6.8.0(typescript@5.9.3)
+      '@solana/transaction-confirmation': 6.8.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.8.0(typescript@5.9.3)
+      '@solana/transactions': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4879,50 +4878,50 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/nominal-types@6.7.0(typescript@5.9.3)':
+  '@solana/nominal-types@6.8.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/offchain-messages@6.7.0(typescript@5.9.3)':
+  '@solana/offchain-messages@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/keys': 6.7.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.7.0(typescript@5.9.3)
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/options@6.7.0(typescript@5.9.3)':
+  '@solana/options@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/plugin-core@6.7.0(typescript@5.9.3)':
+  '@solana/plugin-core@6.8.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/plugin-interfaces@6.7.0(typescript@5.9.3)':
+  '@solana/plugin-interfaces@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.7.0(typescript@5.9.3)
-      '@solana/instruction-plans': 6.7.0(typescript@5.9.3)
-      '@solana/keys': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-spec': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-spec': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.7.0(typescript@5.9.3)
-      '@solana/signers': 6.7.0(typescript@5.9.3)
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/instruction-plans': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+      '@solana/signers': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4932,88 +4931,88 @@ snapshots:
     dependencies:
       prettier: 3.8.1
 
-  '@solana/program-client-core@6.7.0(typescript@5.9.3)':
+  '@solana/program-client-core@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/accounts': 6.7.0(typescript@5.9.3)
-      '@solana/addresses': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/instruction-plans': 6.7.0(typescript@5.9.3)
-      '@solana/instructions': 6.7.0(typescript@5.9.3)
-      '@solana/plugin-interfaces': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-api': 6.7.0(typescript@5.9.3)
-      '@solana/signers': 6.7.0(typescript@5.9.3)
+      '@solana/accounts': 6.8.0(typescript@5.9.3)
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/instruction-plans': 6.8.0(typescript@5.9.3)
+      '@solana/instructions': 6.8.0(typescript@5.9.3)
+      '@solana/plugin-interfaces': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-api': 6.8.0(typescript@5.9.3)
+      '@solana/signers': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/programs@6.7.0(typescript@5.9.3)':
+  '@solana/programs@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/promises@6.7.0(typescript@5.9.3)':
+  '@solana/promises@6.8.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-api@6.7.0(typescript@5.9.3)':
+  '@solana/rpc-api@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/keys': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-parsed-types': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-spec': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-transformers': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.7.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.7.0(typescript@5.9.3)
-      '@solana/transactions': 6.7.0(typescript@5.9.3)
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.8.0(typescript@5.9.3)
+      '@solana/transactions': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-parsed-types@6.7.0(typescript@5.9.3)':
+  '@solana/rpc-parsed-types@6.8.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-spec-types@6.7.0(typescript@5.9.3)':
+  '@solana/rpc-spec-types@6.8.0(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-spec@6.7.0(typescript@5.9.3)':
+  '@solana/rpc-spec@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.7.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-subscriptions-api@6.7.0(typescript@5.9.3)':
+  '@solana/rpc-subscriptions-api@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.7.0(typescript@5.9.3)
-      '@solana/keys': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-spec': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-transformers': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.7.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.7.0(typescript@5.9.3)
-      '@solana/transactions': 6.7.0(typescript@5.9.3)
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.8.0(typescript@5.9.3)
+      '@solana/transactions': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@6.7.0(typescript@5.9.3)':
+  '@solana/rpc-subscriptions-channel-websocket@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/functional': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-spec': 6.7.0(typescript@5.9.3)
-      '@solana/subscribable': 6.7.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/functional': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.8.0(typescript@5.9.3)
+      '@solana/subscribable': 6.8.0(typescript@5.9.3)
       ws: 8.20.0
     optionalDependencies:
       typescript: 5.9.3
@@ -5021,132 +5020,28 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@solana/rpc-subscriptions-spec@6.7.0(typescript@5.9.3)':
+  '@solana/rpc-subscriptions-spec@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/promises': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.7.0(typescript@5.9.3)
-      '@solana/subscribable': 6.7.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/promises': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.8.0(typescript@5.9.3)
+      '@solana/subscribable': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-subscriptions@6.7.0(typescript@5.9.3)':
+  '@solana/rpc-subscriptions@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/fast-stable-stringify': 6.7.0(typescript@5.9.3)
-      '@solana/functional': 6.7.0(typescript@5.9.3)
-      '@solana/promises': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-api': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-channel-websocket': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions-spec': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-transformers': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.7.0(typescript@5.9.3)
-      '@solana/subscribable': 6.7.0(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - bufferutil
-      - fastestsmallesttextencoderdecoder
-      - utf-8-validate
-
-  '@solana/rpc-transformers@6.7.0(typescript@5.9.3)':
-    dependencies:
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/functional': 6.7.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.7.0(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/rpc-transport-http@6.7.0(typescript@5.9.3)':
-    dependencies:
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-spec': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.7.0(typescript@5.9.3)
-      undici-types: 7.24.7
-    optionalDependencies:
-      typescript: 5.9.3
-
-  '@solana/rpc-types@6.7.0(typescript@5.9.3)':
-    dependencies:
-      '@solana/addresses': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.7.0(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/rpc@6.7.0(typescript@5.9.3)':
-    dependencies:
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/fast-stable-stringify': 6.7.0(typescript@5.9.3)
-      '@solana/functional': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-api': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-spec': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-spec-types': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-transformers': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-transport-http': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.7.0(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/signers@6.7.0(typescript@5.9.3)':
-    dependencies:
-      '@solana/addresses': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/instructions': 6.7.0(typescript@5.9.3)
-      '@solana/keys': 6.7.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.7.0(typescript@5.9.3)
-      '@solana/offchain-messages': 6.7.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.7.0(typescript@5.9.3)
-      '@solana/transactions': 6.7.0(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/subscribable@6.7.0(typescript@5.9.3)':
-    dependencies:
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-
-  '@solana/sysvars@6.7.0(typescript@5.9.3)':
-    dependencies:
-      '@solana/accounts': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.7.0(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/transaction-confirmation@6.7.0(typescript@5.9.3)':
-    dependencies:
-      '@solana/addresses': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/keys': 6.7.0(typescript@5.9.3)
-      '@solana/promises': 6.7.0(typescript@5.9.3)
-      '@solana/rpc': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.7.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.7.0(typescript@5.9.3)
-      '@solana/transactions': 6.7.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 6.8.0(typescript@5.9.3)
+      '@solana/functional': 6.8.0(typescript@5.9.3)
+      '@solana/promises': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-api': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-channel-websocket': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+      '@solana/subscribable': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5154,36 +5049,140 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/transaction-messages@6.7.0(typescript@5.9.3)':
+  '@solana/rpc-transformers@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/functional': 6.7.0(typescript@5.9.3)
-      '@solana/instructions': 6.7.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.7.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/functional': 6.8.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@6.7.0(typescript@5.9.3)':
+  '@solana/rpc-transport-http@6.8.0(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-core': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-data-structures': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.7.0(typescript@5.9.3)
-      '@solana/codecs-strings': 6.7.0(typescript@5.9.3)
-      '@solana/errors': 6.7.0(typescript@5.9.3)
-      '@solana/functional': 6.7.0(typescript@5.9.3)
-      '@solana/instructions': 6.7.0(typescript@5.9.3)
-      '@solana/keys': 6.7.0(typescript@5.9.3)
-      '@solana/nominal-types': 6.7.0(typescript@5.9.3)
-      '@solana/rpc-types': 6.7.0(typescript@5.9.3)
-      '@solana/transaction-messages': 6.7.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.8.0(typescript@5.9.3)
+      undici-types: 8.0.2
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-types@6.8.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.8.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/rpc@6.8.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 6.8.0(typescript@5.9.3)
+      '@solana/functional': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-api': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-transport-http': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/signers@6.8.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/instructions': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.8.0(typescript@5.9.3)
+      '@solana/offchain-messages': 6.8.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.8.0(typescript@5.9.3)
+      '@solana/transactions': 6.8.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/subscribable@6.8.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/sysvars@6.8.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transaction-confirmation@6.8.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/promises': 6.8.0(typescript@5.9.3)
+      '@solana/rpc': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.8.0(typescript@5.9.3)
+      '@solana/transactions': 6.8.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+
+  '@solana/transaction-messages@6.8.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/functional': 6.8.0(typescript@5.9.3)
+      '@solana/instructions': 6.8.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@6.8.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-core': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.8.0(typescript@5.9.3)
+      '@solana/codecs-strings': 6.8.0(typescript@5.9.3)
+      '@solana/errors': 6.8.0(typescript@5.9.3)
+      '@solana/functional': 6.8.0(typescript@5.9.3)
+      '@solana/instructions': 6.8.0(typescript@5.9.3)
+      '@solana/keys': 6.8.0(typescript@5.9.3)
+      '@solana/nominal-types': 6.8.0(typescript@5.9.3)
+      '@solana/rpc-types': 6.8.0(typescript@5.9.3)
+      '@solana/transaction-messages': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5191,22 +5190,22 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@turbo/darwin-64@2.9.4':
+  '@turbo/darwin-64@2.9.6':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.4':
+  '@turbo/darwin-arm64@2.9.6':
     optional: true
 
-  '@turbo/linux-64@2.9.4':
+  '@turbo/linux-64@2.9.6':
     optional: true
 
-  '@turbo/linux-arm64@2.9.4':
+  '@turbo/linux-arm64@2.9.6':
     optional: true
 
-  '@turbo/windows-64@2.9.4':
+  '@turbo/windows-64@2.9.6':
     optional: true
 
-  '@turbo/windows-arm64@2.9.4':
+  '@turbo/windows-arm64@2.9.6':
     optional: true
 
   '@tybys/wasm-util@0.10.1':
@@ -5267,11 +5266,7 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@25.5.2':
-    dependencies:
-      undici-types: 7.18.2
-
-  '@types/node@25.5.2':
+  '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
 
@@ -5283,7 +5278,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -5329,8 +5324,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.50.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.50.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.50.0
+      '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.0
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5552,13 +5547,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@7.3.1(@types/node@25.5.2))':
+  '@vitest/mocker@4.1.2(vite@7.3.1(@types/node@25.5.0))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.2)
+      vite: 7.3.1(@types/node@25.5.0)
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -5704,7 +5699,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.10.15: {}
+  baseline-browser-mapping@2.10.13: {}
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -5738,8 +5733,8 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.15
-      caniuse-lite: 1.0.30001786
+      baseline-browser-mapping: 2.10.13
+      caniuse-lite: 1.0.30001784
       electron-to-chromium: 1.5.331
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
@@ -5763,7 +5758,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001786: {}
+  caniuse-lite@1.0.30001784: {}
 
   chai@6.2.2: {}
 
@@ -5929,13 +5924,13 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-jest@29.5.0(@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(jest@30.2.0(@types/node@25.5.2))(typescript@5.9.3):
+  eslint-plugin-jest@29.5.0(@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(jest@30.2.0(@types/node@25.5.0))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.58.0(eslint@9.39.2)(typescript@5.9.3)
       eslint: 9.39.2
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)
-      jest: 30.2.0(@types/node@25.5.2)
+      jest: 30.2.0(@types/node@25.5.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -6223,7 +6218,7 @@ snapshots:
 
   happy-dom@20.8.9:
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       entities: 7.0.1
@@ -6351,7 +6346,7 @@ snapshots:
       '@jest/expect': 30.2.0
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -6371,7 +6366,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.2.0(@types/node@25.5.2):
+  jest-cli@30.2.0(@types/node@25.5.0):
     dependencies:
       '@jest/core': 30.2.0
       '@jest/test-result': 30.2.0
@@ -6379,7 +6374,7 @@ snapshots:
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.2.0(@types/node@25.5.2)
+      jest-config: 30.2.0(@types/node@25.5.0)
       jest-util: 30.2.0
       jest-validate: 30.2.0
       yargs: 17.7.2
@@ -6390,7 +6385,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.2.0(@types/node@25.5.2):
+  jest-config@30.2.0(@types/node@25.5.0):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -6417,39 +6412,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 25.5.2
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.2.0(@types/node@25.5.2):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.2.0
-      '@jest/types': 30.2.0
-      babel-jest: 30.2.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.2.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.2.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.2.0
-      jest-runner: 30.2.0
-      jest-util: 30.2.0
-      jest-validate: 30.2.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 30.2.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -6478,7 +6441,7 @@ snapshots:
       '@jest/environment': 30.2.0
       '@jest/fake-timers': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       jest-mock: 30.2.0
       jest-util: 30.2.0
       jest-validate: 30.2.0
@@ -6486,7 +6449,7 @@ snapshots:
   jest-haste-map@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -6525,7 +6488,7 @@ snapshots:
   jest-mock@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       jest-util: 30.2.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.2.0):
@@ -6559,7 +6522,7 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -6588,7 +6551,7 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -6635,7 +6598,7 @@ snapshots:
   jest-util@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -6654,7 +6617,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -6663,18 +6626,18 @@ snapshots:
 
   jest-worker@30.2.0:
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.2.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.2.0(@types/node@25.5.2):
+  jest@30.2.0(@types/node@25.5.0):
     dependencies:
       '@jest/core': 30.2.0
       '@jest/types': 30.2.0
       import-local: 3.2.0
-      jest-cli: 30.2.0(@types/node@25.5.2)
+      jest-cli: 30.2.0(@types/node@25.5.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -6748,9 +6711,9 @@ snapshots:
 
   litesvm@1.0.0(typescript@5.9.3):
     dependencies:
-      '@solana-program/system': 0.12.0(@solana/kit@6.7.0(typescript@5.9.3))
-      '@solana-program/token': 0.12.0(@solana/kit@6.7.0(typescript@5.9.3))
-      '@solana/kit': 6.7.0(typescript@5.9.3)
+      '@solana-program/system': 0.12.0(@solana/kit@6.8.0(typescript@5.9.3))
+      '@solana-program/token': 0.12.0(@solana/kit@6.8.0(typescript@5.9.3))
+      '@solana/kit': 6.8.0(typescript@5.9.3)
     optionalDependencies:
       litesvm-darwin-arm64: 1.0.0
       litesvm-darwin-x64: 1.0.0
@@ -7289,14 +7252,14 @@ snapshots:
       tslib: 1.14.1
       typescript: 5.9.3
 
-  turbo@2.9.4:
+  turbo@2.9.6:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.4
-      '@turbo/darwin-arm64': 2.9.4
-      '@turbo/linux-64': 2.9.4
-      '@turbo/linux-arm64': 2.9.4
-      '@turbo/windows-64': 2.9.4
-      '@turbo/windows-arm64': 2.9.4
+      '@turbo/darwin-64': 2.9.6
+      '@turbo/darwin-arm64': 2.9.6
+      '@turbo/linux-64': 2.9.6
+      '@turbo/linux-arm64': 2.9.6
+      '@turbo/windows-64': 2.9.6
+      '@turbo/windows-arm64': 2.9.6
 
   type-check@0.4.0:
     dependencies:
@@ -7323,7 +7286,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici-types@7.24.7: {}
+  undici-types@8.0.2: {}
 
   universalify@0.1.2: {}
 
@@ -7367,7 +7330,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vite@7.3.1(@types/node@25.5.2):
+  vite@7.3.1(@types/node@25.5.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -7376,13 +7339,13 @@ snapshots:
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       fsevents: 2.3.3
 
-  vitest@4.1.2(@types/node@25.5.2)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.2)):
+  vitest@4.1.2(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@7.3.1(@types/node@25.5.2))
+      '@vitest/mocker': 4.1.2(vite@7.3.1(@types/node@25.5.0))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -7399,10 +7362,10 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.5.2)
+      vite: 7.3.1(@types/node@25.5.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.5.0
       happy-dom: 20.8.9
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
This PR bumps the `@solana/kit` peer dependency to ^6.8.0 across all packages and updates all references to the renamed `createEmptyClient` API in source files, tests, docblocks, and READMEs. No behavioral changes.