### PR TITLE
Deprecate client packages in favor of all-in-one plugins

### DIFF
--- a/.changeset/itchy-garlics-chew.md
+++ b/.changeset/itchy-garlics-chew.md
@@ -1,0 +1,6 @@
+---
+'@solana/kit-client-rpc': patch
+'@solana/kit-client-litesvm': patch
+---
+
+Deprecate client packages in favor of all-in-one plugins.

--- a/README.md
+++ b/README.md
@@ -5,73 +5,80 @@
 [ci-image]: https://img.shields.io/github/actions/workflow/status/anza-xyz/kit-plugins/main.yml?logo=GitHub
 [ci-url]: https://github.com/anza-xyz/kit-plugins/actions/workflows/main.yml
 
-A plugin library for [Solana Kit](https://github.com/anza-xyz/kit) that provides **ready-to-use clients** for your Solana applications!
+A library for [Solana Kit](https://github.com/anza-xyz/kit) that helps you **build composable Solana clients** with a modular plugin system.
 
 ## Features
 
-- ✨ **Ready-to-use clients** for production, local development, and local testing.
-- ✨ **Modular plugin system** to build custom clients by combining individual plugins.
+- ✨ **All-in-one bundle plugins** for production, local development, and local testing.
+- ✨ **Modular plugin system** to compose custom clients by combining granular plugins.
 - ✨ Default **transaction planning and execution** logic built-in, just call `client.sendTransaction(myInstructions)`.
 - ✨ Various **useful plugins** for RPC connectivity, payer management, SOL airdrops, LiteSVM support and more.
 
 ## Quick Start
 
-Choose from the following three ready-to-use clients!
+### Production
 
-### Production (Mainnet/Devnet/Testnet)
-
-Pre-configured client for production use with real Solana clusters.
+Use the `solanaRpc` bundle plugin to set up a full Solana RPC client with transaction planning and execution.
 
 ```sh
-pnpm install @solana/kit @solana/kit-client-rpc
+pnpm install @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-payer
 ```
 
 ```ts
-import { generateKeyPairSigner } from '@solana/kit';
-import { createClient } from '@solana/kit-client-rpc';
+import { createClient } from '@solana/kit';
+import { solanaRpc } from '@solana/kit-plugin-rpc';
+import { payer } from '@solana/kit-plugin-payer';
 
-const payer = await generateKeyPairSigner();
-const client = createClient({ payer, url: 'https://api.devnet.solana.com' });
+const client = createClient()
+    .use(payer(myProductionSigner))
+    .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
 
-// Send transactions
 await client.sendTransaction([myInstruction]);
 ```
 
-[See all features and configuration options](./packages/kit-client-rpc/README.md#createclient).
+For mainnet type safety (preventing accidental use of devnet-only features like airdrops), use `solanaMainnetRpc` instead.
+
+[See all features and configuration options](./packages/kit-plugin-rpc/README.md#solanarpc-plugin).
 
 ### Local Development
 
-Pre-configured client for localhost development with automatic payer funding.
+Use `solanaLocalRpc` which defaults to `http://127.0.0.1:8899` and includes airdrop support.
 
 ```sh
-pnpm install @solana/kit @solana/kit-client-rpc
+pnpm install @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-payer
 ```
 
 ```ts
-import { createLocalClient } from '@solana/kit-client-rpc';
-import { lamports } from '@solana/kit';
+import { createClient } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { payerFromFile } from '@solana/kit-plugin-payer';
 
-const client = await createLocalClient();
+const client = createClient().use(payerFromFile('~/.config/solana/id.json')).use(solanaLocalRpc());
 
-// Payer is auto-generated and funded with SOL
-console.log('Payer address:', client.payer.address);
 await client.sendTransaction([myInstruction]);
 ```
 
-[See all features and configuration options](./packages/kit-client-rpc/README.md#createlocalclient).
+For devnet, use `solanaDevnetRpc` which defaults to `https://api.devnet.solana.com` and also includes airdrop support.
+
+[See all features and configuration options](./packages/kit-plugin-rpc/README.md#solanalocalrpc-plugin).
 
 ### Local Testing with LiteSVM
 
-Pre-configured client using LiteSVM for testing without an RPC connection.
+Use the `litesvm` bundle plugin for fast local blockchain simulation without a network connection.
 
 ```sh
-pnpm install @solana/kit @solana/kit-client-litesvm
+pnpm install @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-payer
 ```
 
 ```ts
-import { createClient } from '@solana/kit-client-litesvm';
+import { createClient, lamports } from '@solana/kit';
+import { litesvm } from '@solana/kit-plugin-litesvm';
+import { generatedPayer } from '@solana/kit-plugin-payer';
 
-const client = await createClient();
+const client = await createClient().use(generatedPayer()).use(litesvm());
+
+// Fund the payer
+await client.airdrop(client.payer.address, lamports(10_000_000_000n));
 
 // Set up test environment
 client.svm.setAccount(myTestAccount);
@@ -81,11 +88,11 @@ client.svm.addProgramFromFile(myProgramAddress, 'program.so');
 await client.sendTransaction([myInstruction]);
 ```
 
-[See all features and configuration options](./packages/kit-client-litesvm/README.md#createclient).
+[See all features and configuration options](./packages/kit-plugin-litesvm/README.md#litesvm-plugin).
 
-## Build Your Own Client
+## Compose Granular Plugins
 
-None of the ready-to-use clients fit your needs? No worries! You can **build your own custom clients** by combining individual plugins like so.
+The bundle plugins above are built from smaller, granular plugins. You can compose these granular plugins directly to build a custom setup tailored to your needs.
 
 ```ts
 import { createClient } from '@solana/kit';
@@ -99,28 +106,17 @@ import {
 import { payerFromFile } from '@solana/kit-plugin-payer';
 import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
 
-const client = await createClient() // An empty client with a `use` method to install plugins.
+const client = await createClient()
+    .use(payerFromFile('path/to/keypair.json')) // Adds `client.payer` using a local keypair file.
     .use(solanaRpcConnection('https://api.devnet.solana.com')) // Adds `client.rpc`.
     .use(solanaRpcSubscriptionsConnection('wss://api.devnet.solana.com')) // Adds `client.rpcSubscriptions`.
-    .use(payerFromFile('path/to/keypair.json')) // Adds `client.payer` using a local keypair file.
     .use(rpcAirdrop()) // Adds `client.airdrop` to request SOL from faucets.
     .use(rpcTransactionPlanner()) // Adds `client.transactionPlanner`.
     .use(rpcTransactionPlanExecutor()) // Adds `client.transactionPlanExecutor`.
     .use(planAndSendTransactions()); // Adds `client.planTransaction(s)` and `client.sendTransaction(s)`.
 ```
 
-Note that since plugins are defined in `@solana/kit` itself, you're not limited to the plugins in this repo! You can use [community plugins](#community-plugins) or even [create your own](#create-your-own-plugins).
-
-## Available Clients
-
-| Package                                                       | Version                                                                                                                                    | Description                   | Exports                             |
-| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------- | ----------------------------------- |
-| [`@solana/kit-client-rpc`](./packages/kit-client-rpc)         | [![npm](https://img.shields.io/npm/v/@solana/kit-client-rpc.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-client-rpc)         | Pre-configured RPC client     | `createClient`, `createLocalClient` |
-| [`@solana/kit-client-litesvm`](./packages/kit-client-litesvm) | [![npm](https://img.shields.io/npm/v/@solana/kit-client-litesvm.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-client-litesvm) | Pre-configured LiteSVM client | `createClient`                      |
-
-## Community Clients
-
-_Do you know any? Please open a PR to add them here!_
+Note that since core plugin interfaces are defined in `@solana/kit` itself, you're not limited to the plugins in this repo! You can use [community plugins](#community-plugins) or even [create your own](#create-your-own-plugins).
 
 ## Available Plugins
 

--- a/packages/kit-client-litesvm/README.md
+++ b/packages/kit-client-litesvm/README.md
@@ -1,4 +1,4 @@
-# Kit Plugins ➤ LiteSVM Client
+# Kit Plugins ➤ LiteSVM Client (deprecated)
 
 [![npm][npm-image]][npm-url]
 [![npm-downloads][npm-downloads-image]][npm-url]
@@ -7,50 +7,21 @@
 [npm-image]: https://img.shields.io/npm/v/@solana/kit-client-litesvm.svg?style=flat&label=%40solana%2Fkit-client-litesvm
 [npm-url]: https://www.npmjs.com/package/@solana/kit-client-litesvm
 
-This package provides a pre-configured LiteSVM client for Solana Kit. It bundles several plugins together so you can get started with a single function call.
+> [!WARNING]
+> This package is deprecated. Add a payer to your client using any payer plugin from [`@solana/kit-plugin-payer`](../kit-plugin-payer), then use the `litesvm` all-in-one plugin from [`@solana/kit-plugin-litesvm`](../kit-plugin-litesvm) instead.
+>
+> | Deprecated export | Use instead                                                            |
+> | ----------------- | ---------------------------------------------------------------------- |
+> | `createClient()`  | `litesvm()` from [`@solana/kit-plugin-litesvm`](../kit-plugin-litesvm) |
 
-> [!NOTE]
-> This package is only available in Node.js environments. LiteSVM relies on Node.js APIs and cannot run in browsers or React Native.
+## Migration
 
-## Installation
+```diff
+- import { createClient } from '@solana/kit-client-litesvm';
++ import { createClient } from '@solana/kit';
++ import { litesvm } from '@solana/kit-plugin-litesvm';
++ import { payer } from '@solana/kit-plugin-payer';
 
-```sh
-pnpm install @solana/kit-client-litesvm
+- const client = await createClient({ payer: myPayer });
++ const client = createClient().use(payer(myPayer)).use(litesvm());
 ```
-
-## `createClient`
-
-Pre-configured client using LiteSVM for testing without an RPC connection.
-
-```ts
-import { createClient } from '@solana/kit-client-litesvm';
-
-const client = await createClient();
-
-// Set up test environment
-client.svm.setAccount(myTestAccount);
-client.svm.addProgramFromFile(myProgramAddress, 'program.so');
-
-// Execute transactions locally
-await client.sendTransaction([myInstruction]);
-```
-
-### Features
-
-- `client.svm`: Embedded LiteSVM instance for local blockchain simulation.
-- `client.rpc`: Subset of RPC methods that delegate to the LiteSVM instance.
-- `client.payer`: The main payer signer for transactions.
-- `client.airdrop`: Function to request SOL from the LiteSVM instance.
-- `client.getMinimumBalance`: Computes the minimum lamports required for an account with a given data size.
-- `client.transactionPlanner`: Plans instructions into transaction messages.
-- `client.transactionPlanExecutor`: Executes planned transaction messages.
-- `client.planTransactions`: Plans transaction messages, instructions or instruction plans into a transaction plan without executing it.
-- `client.planTransaction`: Same as `client.planTransactions` but asserts a single transaction message is returned.
-- `client.sendTransactions`: Sends transaction messages, instructions or instruction plans to the cluster by using the client's transaction planner and executor.
-- `client.sendTransaction`: Same as `client.sendTransactions` but ensuring only a single transaction is sent.
-
-### Configuration
-
-| Option  | Type                | Description                                                                                                     |
-| ------- | ------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `payer` | `TransactionSigner` | Signer used to pay for transaction fees and on-chain account storage. Defaults to a generated and funded payer. |

--- a/packages/kit-client-litesvm/src/index.ts
+++ b/packages/kit-client-litesvm/src/index.ts
@@ -20,37 +20,17 @@ export type {
 /**
  * Creates a default LiteSVM client for local blockchain simulation.
  *
- * This function sets up a client with an embedded LiteSVM instance for fast
- * local blockchain simulation, airdrop functionality, automatic payer generation
- * (if not provided), and all essential transaction capabilities. Ideal for testing
- * and development without requiring a live network connection.
- *
- * @param config - Optional configuration object with an optional payer.
- * @returns A fully configured client ready for local blockchain simulation.
- *
- * @example
+ * @deprecated Add a payer to your client using any payer plugin from
+ * `@solana/kit-plugin-payer`, then use `litesvm` from `@solana/kit-plugin-litesvm`.
  * ```ts
- * import { createClient } from '@solana/kit-client-litesvm';
+ * import { createClient, lamports } from '@solana/kit';
+ * import { litesvm } from '@solana/kit-plugin-litesvm';
+ * import { generatedPayer } from '@solana/kit-plugin-payer';
  *
- * // Creates a client with auto-generated and funded payer
- * const client = await createClient();
- *
- * // Set up accounts and programs
- * client.svm.setAccount(myAccount);
- * client.svm.addProgramFromFile(myProgramAddress, 'program.so');
- *
- * // Use the client
- * const result = await client.sendTransaction([myInstruction]);
- * ```
- *
- * @example
- * Using a custom payer.
- * ```ts
- * import { createClient } from '@solana/kit-client-litesvm';
- * import { generateKeyPairSigner } from '@solana/kit';
- *
- * const customPayer = await generateKeyPairSigner();
- * const client = await createClient({ payer: customPayer });
+ * const client = await createClient()
+ *     .use(generatedPayer())
+ *     .use(litesvm());
+ * await client.airdrop(client.payer.address, lamports(10_000_000_000n));
  * ```
  */
 export function createClient(config: { payer?: TransactionSigner } = {}) {

--- a/packages/kit-client-rpc/README.md
+++ b/packages/kit-client-rpc/README.md
@@ -1,4 +1,4 @@
-# Kit Plugins ➤ RPC Client
+# Kit Plugins ➤ RPC Client (deprecated)
 
 [![npm][npm-image]][npm-url]
 [![npm-downloads][npm-downloads-image]][npm-url]
@@ -7,94 +7,24 @@
 [npm-image]: https://img.shields.io/npm/v/@solana/kit-client-rpc.svg?style=flat&label=%40solana%2Fkit-client-rpc
 [npm-url]: https://www.npmjs.com/package/@solana/kit-client-rpc
 
-This package provides pre-configured RPC clients for Solana Kit. It bundles several plugins together so you can get started with a single function call.
+> [!WARNING]
+> This package is deprecated. Add a payer to your client using any payer plugin from [`@solana/kit-plugin-payer`](../kit-plugin-payer), then use the all-in-one plugins from [`@solana/kit-plugin-rpc`](../kit-plugin-rpc) instead.
+>
+> | Deprecated export            | Use instead                                                                     |
+> | ---------------------------- | ------------------------------------------------------------------------------- |
+> | `createClient({ url, ... })` | `solanaRpc({ rpcUrl, ... })` from [`@solana/kit-plugin-rpc`](../kit-plugin-rpc) |
+> | `createLocalClient()`        | `solanaLocalRpc()` from [`@solana/kit-plugin-rpc`](../kit-plugin-rpc)           |
 
-## Installation
+## Migration
 
-```sh
-pnpm install @solana/kit-client-rpc
+```diff
+- import { createClient } from '@solana/kit-client-rpc';
++ import { createClient } from '@solana/kit';
++ import { solanaRpc } from '@solana/kit-plugin-rpc';
++ import { payer } from '@solana/kit-plugin-payer';
+
+- const client = createClient({ url: 'https://api.mainnet-beta.solana.com', payer: myPayer });
++ const client = createClient()
++     .use(payer(myPayer))
++     .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
 ```
-
-## `createClient`
-
-Pre-configured client for production use with real Solana clusters.
-
-```ts
-import { createClient } from '@solana/kit-client-rpc';
-import { generateKeyPairSigner } from '@solana/kit';
-
-const payer = await generateKeyPairSigner();
-const client = createClient({
-    url: 'https://api.devnet.solana.com',
-    payer,
-});
-
-await client.sendTransaction([myInstruction]);
-```
-
-### Features
-
-- `client.rpc`: RPC methods for interacting with the Solana cluster.
-- `client.rpcSubscriptions`: Subscription methods for real-time updates.
-- `client.payer`: The main payer signer for transactions.
-- `client.getMinimumBalance`: Computes the minimum lamports required for an account with a given data size.
-- `client.transactionPlanner`: Plans instructions into transaction messages.
-- `client.transactionPlanExecutor`: Executes planned transaction messages.
-- `client.planTransactions`: Plans transaction messages, instructions or instruction plans into a transaction plan without executing it.
-- `client.planTransaction`: Same as `client.planTransactions` but asserts a single transaction message is returned.
-- `client.sendTransactions`: Sends transaction messages, instructions or instruction plans to the cluster by using the client's transaction planner and executor.
-- `client.sendTransaction`: Same as `client.sendTransactions` but ensuring only a single transaction is sent.
-
-### Configuration
-
-| Option                   | Type                     | Description                                                                                    |
-| ------------------------ | ------------------------ | ---------------------------------------------------------------------------------------------- |
-| `url` (required)         | `string`                 | URL of the Solana RPC endpoint.                                                                |
-| `payer` (required)       | `TransactionSigner`      | Signer used to pay for transaction fees and on-chain account storage.                          |
-| `rpcSubscriptionsConfig` | `RpcSubscriptionsConfig` | Configuration for RPC subscriptions. Use `rpcSubscriptionsConfig.url` to specify its endpoint. |
-| `priorityFees`           | `MicroLamports`          | Priority fees in micro-lamports per compute unit. Defaults to no priority fees.                |
-| `maxConcurrency`         | `number`                 | Maximum number of concurrent transaction executions. Defaults to `10`.                         |
-| `skipPreflight`          | `boolean`                | Whether to skip preflight simulation when sending transactions. Defaults to `false`.           |
-
-## `createLocalClient`
-
-Pre-configured client for localhost development with automatic payer funding.
-
-```ts
-import { createLocalClient } from '@solana/kit-client-rpc';
-import { lamports } from '@solana/kit';
-
-const client = await createLocalClient();
-
-// Payer is automatically generated and funded
-console.log('Payer address:', client.payer.address);
-await client.sendTransaction([myInstruction]);
-
-// Request additional funding
-await client.airdrop(client.payer.address, lamports(5_000_000_000n));
-```
-
-### Features
-
-- `client.rpc`: RPC methods for interacting with the local validator (i.e. `http://127.0.0.1:8899`).
-- `client.rpcSubscriptions`: Subscription methods for real-time updates from the local validator (i.e. `ws://127.0.0.1:8900`).
-- `client.payer`: The main payer signer for transactions.
-- `client.airdrop`: Function to request SOL from the local faucet.
-- `client.getMinimumBalance`: Computes the minimum lamports required for an account with a given data size.
-- `client.transactionPlanner`: Plans instructions into transaction messages.
-- `client.transactionPlanExecutor`: Executes planned transaction messages.
-- `client.planTransactions`: Plans transaction messages, instructions or instruction plans into a transaction plan without executing it.
-- `client.planTransaction`: Same as `client.planTransactions` but asserts a single transaction message is returned.
-- `client.sendTransactions`: Sends transaction messages, instructions or instruction plans to the cluster by using the client's transaction planner and executor.
-- `client.sendTransaction`: Same as `client.sendTransactions` but ensuring only a single transaction is sent.
-
-### Configuration
-
-| Option                   | Type                     | Description                                                                                                     |
-| ------------------------ | ------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| `payer`                  | `TransactionSigner`      | Signer used to pay for transaction fees and on-chain account storage. Defaults to a generated and funded payer. |
-| `url`                    | `string`                 | Custom RPC URL. Defaults to `http://127.0.0.1:8899`.                                                            |
-| `rpcSubscriptionsConfig` | `RpcSubscriptionsConfig` | Configuration for RPC subscriptions. Defaults to `{ url: 'ws://127.0.0.1:8900' }`.                              |
-| `priorityFees`           | `MicroLamports`          | Priority fees in micro-lamports per compute unit. Defaults to no priority fees.                                 |
-| `maxConcurrency`         | `number`                 | Maximum number of concurrent transaction executions. Defaults to `10`.                                          |
-| `skipPreflight`          | `boolean`                | Whether to skip preflight simulation when sending transactions. Defaults to `false`.                            |

--- a/packages/kit-client-rpc/src/index.ts
+++ b/packages/kit-client-rpc/src/index.ts
@@ -59,26 +59,16 @@ export type ClientConfig<TClusterUrl extends ClusterUrl = ClusterUrl> = {
 /**
  * Creates a default RPC client with all essential plugins configured.
  *
- * This function sets up a client with RPC capabilities, payer configuration,
- * transaction planning and execution, and instruction plan sending functionality.
- * It's designed for production use with real Solana clusters.
- *
- * @param config - Configuration object containing the payer, URL, and optional RPC subscriptions config.
- * @returns A fully configured default client ready for transaction operations.
- *
- * @example
+ * @deprecated Add a payer to your client using any payer plugin from
+ * `@solana/kit-plugin-payer`, then use `solanaRpc` from `@solana/kit-plugin-rpc`.
  * ```ts
- * import { createClient } from '@solana/kit-client-rpc';
- * import { generateKeyPairSigner } from '@solana/kit';
+ * import { createClient } from '@solana/kit';
+ * import { solanaRpc } from '@solana/kit-plugin-rpc';
+ * import { payer } from '@solana/kit-plugin-payer';
  *
- * const payer = await generateKeyPairSigner();
- * const client = createClient({
- *   url: 'https://api.mainnet-beta.solana.com',
- *   payer,
- * });
- *
- * // Use the client
- * const result = await client.sendTransaction([myInstruction]);
+ * const client = createClient()
+ *     .use(payer(myPayer))
+ *     .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
  * ```
  */
 export function createClient<TClusterUrl extends ClusterUrl>(config: ClientConfig<TClusterUrl>) {
@@ -94,33 +84,16 @@ export function createClient<TClusterUrl extends ClusterUrl>(config: ClientConfi
 /**
  * Creates a default RPC client configured for localhost development.
  *
- * This function sets up a client connected to a local validator with airdrop
- * functionality, automatic payer generation (if not provided), and all essential
- * transaction capabilities. Perfect for local development and testing.
- *
- * @param config - Optional configuration object with an optional payer.
- * @returns A fully configured client ready for localhost development.
- *
- * @example
+ * @deprecated Add a payer to your client using any payer plugin from
+ * `@solana/kit-plugin-payer`, then use `solanaLocalRpc` from `@solana/kit-plugin-rpc`.
  * ```ts
- * import { createLocalClient } from '@solana/kit-client-rpc';
+ * import { createClient } from '@solana/kit';
+ * import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+ * import { payerFromFile } from '@solana/kit-plugin-payer';
  *
- * // Creates a client with auto-generated and funded payer
- * const client = await createLocalClient();
- *
- * // Use the client
- * const result = await client.sendTransaction([myInstruction]);
- * console.log('Payer address:', client.payer.address);
- * ```
- *
- * @example
- * Using a custom payer.
- * ```ts
- * import { createLocalClient } from '@solana/kit-client-rpc';
- * import { generateKeyPairSigner } from '@solana/kit';
- *
- * const customPayer = await generateKeyPairSigner();
- * const client = await createLocalClient({ payer: customPayer });
+ * const client = createClient()
+ *     .use(payerFromFile('~/.config/solana/id.json'))
+ *     .use(solanaLocalRpc());
  * ```
  */
 export function createLocalClient(

--- a/packages/kit-plugin-airdrop/README.md
+++ b/packages/kit-plugin-airdrop/README.md
@@ -16,11 +16,13 @@
 
 ```diff
   import { createClient } from '@solana/kit';
-- import { airdrop, localhostRpc } from '@solana/kit-plugins';
-+ import { localhostRpc, rpcAirdrop } from '@solana/kit-plugin-rpc';
+- import { airdrop } from '@solana/kit-plugin-airdrop';
++ import { rpcAirdrop } from '@solana/kit-plugin-rpc';
+  import { solanaRpcConnection, solanaRpcSubscriptionsConnection } from '@solana/kit-plugin-rpc';
 
   const client = createClient()
-      .use(localhostRpc())
+      .use(solanaRpcConnection('http://127.0.0.1:8899'))
+      .use(solanaRpcSubscriptionsConnection('ws://127.0.0.1:8900'))
 -     .use(airdrop());
 +     .use(rpcAirdrop());
 ```
@@ -29,11 +31,12 @@
 
 ```diff
   import { createClient } from '@solana/kit';
-- import { airdrop, litesvm } from '@solana/kit-plugins';
-+ import { litesvm, litesvmAirdrop } from '@solana/kit-plugin-litesvm';
+- import { airdrop } from '@solana/kit-plugin-airdrop';
++ import { litesvmAirdrop } from '@solana/kit-plugin-litesvm';
+  import { litesvmConnection } from '@solana/kit-plugin-litesvm';
 
   const client = createClient()
-      .use(litesvm())
+      .use(litesvmConnection())
 -     .use(airdrop());
 +     .use(litesvmAirdrop());
 ```

--- a/packages/kit-plugins/README.md
+++ b/packages/kit-plugins/README.md
@@ -8,7 +8,7 @@
 [npm-url]: https://www.npmjs.com/package/@solana/kit-plugins
 
 > [!WARNING]
-> This package is deprecated. Install individual plugin packages directly instead, or use the pre-configured client packages for a quick start.
+> This package is deprecated. Install individual plugin packages directly instead.
 >
 > | Deprecated import from `@solana/kit-plugins`                                                 | Use instead                                                                                                                      |
 > | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
@@ -17,6 +17,6 @@
 > | `litesvm`, `litesvmAirdrop`, `litesvmTransactionPlanner`, `litesvmTransactionPlanExecutor`   | [`@solana/kit-plugin-litesvm`](../kit-plugin-litesvm)                                                                            |
 > | `transactionPlanner`, `transactionPlanExecutor`, `planAndSendTransactions`                   | [`@solana/kit-plugin-instruction-plan`](../kit-plugin-instruction-plan)                                                          |
 > | `airdrop`                                                                                    | [`@solana/kit-plugin-rpc`](../kit-plugin-rpc) or [`@solana/kit-plugin-litesvm`](../kit-plugin-litesvm)                           |
-> | `createDefaultRpcClient`                                                                     | `createClient` from [`@solana/kit-client-rpc`](../kit-client-rpc)                                                                |
-> | `createDefaultLocalhostRpcClient`                                                            | `createLocalClient` from [`@solana/kit-client-rpc`](../kit-client-rpc)                                                           |
-> | `createDefaultLiteSVMClient`                                                                 | `createClient` from [`@solana/kit-client-litesvm`](../kit-client-litesvm)                                                        |
+> | `createDefaultRpcClient`                                                                     | `solanaRpc` from [`@solana/kit-plugin-rpc`](../kit-plugin-rpc)                                                                   |
+> | `createDefaultLocalhostRpcClient`                                                            | `solanaLocalRpc` from [`@solana/kit-plugin-rpc`](../kit-plugin-rpc)                                                              |
+> | `createDefaultLiteSVMClient`                                                                 | `litesvm` from [`@solana/kit-plugin-litesvm`](../kit-plugin-litesvm)                                                             |


### PR DESCRIPTION
This PR deprecates `@solana/kit-client-rpc` and `@solana/kit-client-litesvm` in favor of the new all-in-one plugins (`solanaRpc`, `solanaLocalRpc`, `litesvm`, etc.) from the individual plugin packages. Client source files are marked with `@deprecated` JSDoc tags, READMEs are replaced with migration guides, and the root README is revamped to present plugins as the primary way to build Solana clients. Deprecated package READMEs (`kit-plugins`, `kit-plugin-airdrop`) are also updated to point to the latest non-deprecated alternatives.