### PR TITLE
Add readonly variants of SolanaRpc plugins

### DIFF
--- a/.changeset/ten-kings-hug.md
+++ b/.changeset/ten-kings-hug.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-rpc': minor
+---
+
+Add a read-only RPC pathway: `solanaRpcReadOnly()` plus the cluster convenience wrappers `solanaMainnetRpcReadOnly()`, `solanaDevnetRpcReadOnly()`, and `solanaLocalRpcReadOnly()` (and the matching `SolanaRpcReadOnlyConfig` type). These install `client.rpc`, `client.rpcSubscriptions`, and `client.getMinimumBalance` without the transaction-planning or transaction-sending plugins, so they have no `payer` prerequisite. The devnet and local variants also install `rpcAirdrop` (airdrop does not require a payer). Use for dashboards, explorers, on-chain watchers, and other read-only flows.

--- a/packages/kit-plugin-rpc/README.md
+++ b/packages/kit-plugin-rpc/README.md
@@ -120,6 +120,97 @@ _See `solanaRpc` for available features, plus:_
     await client.airdrop(address('HQVxiMVDoV9jzG4tpoxmDZsNfWvaHXm8DGGv93Gka75v'), lamports(1_000_000_000n));
     ```
 
+## `solanaRpcReadOnly` plugin
+
+The `solanaRpcReadOnly` plugin sets up a read-only Solana RPC client in a single call. It installs an RPC connection, RPC Subscriptions, and minimum balance computation on the client, but does not install transaction planning or transaction sending.
+
+Unlike `solanaRpc`, this plugin does not require a `payer` on the client, making it ideal for dashboards, explorers, on-chain watchers, and other read-only flows.
+
+### Installation
+
+```ts
+import { createClient } from '@solana/kit';
+import { solanaRpcReadOnly } from '@solana/kit-plugin-rpc';
+
+const client = createClient().use(solanaRpcReadOnly({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
+```
+
+### Options
+
+All options are provided via a `SolanaRpcReadOnlyConfig` object:
+
+- `rpcUrl` **(required)**: URL of the Solana RPC endpoint.
+- `rpcSubscriptionsUrl`: URL of the RPC Subscriptions endpoint. Defaults to the `rpcUrl` with the protocol changed from `http` to `ws`.
+- `rpcConfig`: Optional configuration forwarded to `createSolanaRpc`.
+- `rpcSubscriptionsConfig`: Optional configuration forwarded to `createSolanaRpcSubscriptions`.
+
+### Features
+
+- `rpc`: Call any Solana RPC method.
+- `rpcSubscriptions`: Subscribe to Solana RPC notifications.
+- `getMinimumBalance`: Compute minimum lamports for rent exemption.
+
+## `solanaMainnetRpcReadOnly` plugin
+
+A convenience wrapper around `solanaRpcReadOnly` that types the connection as a mainnet URL, preventing accidental use of devnet-only features such as airdrops.
+
+### Installation
+
+```ts
+import { createClient } from '@solana/kit';
+import { solanaMainnetRpcReadOnly } from '@solana/kit-plugin-rpc';
+
+const client = createClient().use(solanaMainnetRpcReadOnly({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
+```
+
+### Features
+
+_See `solanaRpcReadOnly` for available features._
+
+## `solanaDevnetRpcReadOnly` plugin
+
+A convenience wrapper around `solanaRpcReadOnly` that defaults to the public devnet endpoint (`https://api.devnet.solana.com`) and includes airdrop support for requesting SOL from the faucet.
+
+### Installation
+
+```ts
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpcReadOnly } from '@solana/kit-plugin-rpc';
+
+const client = createClient().use(solanaDevnetRpcReadOnly());
+```
+
+### Features
+
+_See `solanaRpcReadOnly` for available features, plus:_
+
+- `airdrop`: Request SOL from the devnet faucet.
+    ```ts
+    await client.airdrop(address('HQVxiMVDoV9jzG4tpoxmDZsNfWvaHXm8DGGv93Gka75v'), lamports(1_000_000_000n));
+    ```
+
+## `solanaLocalRpcReadOnly` plugin
+
+A convenience wrapper around `solanaRpcReadOnly` that defaults to `http://127.0.0.1:8899` for the RPC and `ws://127.0.0.1:8900` for subscriptions, and includes airdrop support.
+
+### Installation
+
+```ts
+import { createClient } from '@solana/kit';
+import { solanaLocalRpcReadOnly } from '@solana/kit-plugin-rpc';
+
+const client = createClient().use(solanaLocalRpcReadOnly());
+```
+
+### Features
+
+_See `solanaRpcReadOnly` for available features, plus:_
+
+- `airdrop`: Request SOL from the local validator faucet.
+    ```ts
+    await client.airdrop(address('HQVxiMVDoV9jzG4tpoxmDZsNfWvaHXm8DGGv93Gka75v'), lamports(1_000_000_000n));
+    ```
+
 ## `rpcConnection` plugin
 
 The `rpcConnection` plugin sets a provided `Rpc` instance on the client. This is the generic variant that works with any RPC API.

--- a/packages/kit-plugin-rpc/src/solana-rpc.ts
+++ b/packages/kit-plugin-rpc/src/solana-rpc.ts
@@ -22,23 +22,12 @@ import { rpcTransactionPlanner, TransactionPlannerConfig } from './transaction-p
  *
  * @typeParam TClusterUrl - The type of the RPC endpoint URL.
  */
-export type SolanaRpcConfig<TClusterUrl extends ClusterUrl = ClusterUrl> = {
+export type SolanaRpcConfig<TClusterUrl extends ClusterUrl = ClusterUrl> = SolanaRpcReadOnlyConfig<TClusterUrl> & {
     /**
      * The maximum number of concurrent transaction executions allowed.
      * Defaults to 10.
      */
     maxConcurrency?: number;
-    /** Optional configuration forwarded to {@link createSolanaRpc}. */
-    rpcConfig?: Parameters<typeof createSolanaRpc>[1];
-    /** Optional configuration forwarded to {@link createSolanaRpcSubscriptions}. */
-    rpcSubscriptionsConfig?: Parameters<typeof createSolanaRpcSubscriptions>[1];
-    /**
-     * URL of the Solana RPC Subscriptions endpoint.
-     * Defaults to the `rpcUrl` with the protocol changed from `http` to `ws`.
-     */
-    rpcSubscriptionsUrl?: TClusterUrl;
-    /** URL of the Solana RPC endpoint. */
-    rpcUrl: TClusterUrl;
     /**
      * Whether to skip the preflight simulation when sending transactions.
      *
@@ -89,12 +78,7 @@ export function solanaRpc<TClusterUrl extends ClusterUrl>(config: SolanaRpcConfi
     return <T extends ClientWithPayer>(client: T) =>
         pipe(
             client,
-            solanaRpcConnection<TClusterUrl>(config.rpcUrl, config.rpcConfig),
-            solanaRpcSubscriptionsConnection<TClusterUrl>(
-                config.rpcSubscriptionsUrl ?? (config.rpcUrl.replace(/^http/, 'ws') as TClusterUrl),
-                config.rpcSubscriptionsConfig,
-            ),
-            rpcGetMinimumBalance(),
+            solanaRpcReadOnly<TClusterUrl>(config),
             rpcTransactionPlanner(config.transactionConfig),
             rpcTransactionPlanExecutor({ maxConcurrency: config.maxConcurrency, skipPreflight: config.skipPreflight }),
             planAndSendTransactions(),
@@ -202,6 +186,171 @@ export function solanaLocalRpc(config?: Partial<SolanaRpcConfig<string>>) {
         pipe(
             client,
             solanaRpc({
+                ...config,
+                rpcSubscriptionsUrl: config?.rpcSubscriptionsUrl ?? 'ws://127.0.0.1:8900',
+                rpcUrl: config?.rpcUrl ?? 'http://127.0.0.1:8899',
+            }),
+            rpcAirdrop(),
+        );
+}
+
+/**
+ * Configuration for the read-only Solana RPC setup.
+ *
+ * A strict subset of {@link SolanaRpcConfig} that excludes every field only
+ * relevant to transaction sending (`maxConcurrency`, `skipPreflight`,
+ * `transactionConfig`) since {@link solanaRpcReadOnly} never installs the
+ * transaction-planning or transaction-sending halves.
+ *
+ * @typeParam TClusterUrl - The type of the RPC endpoint URL.
+ */
+export type SolanaRpcReadOnlyConfig<TClusterUrl extends ClusterUrl = ClusterUrl> = {
+    /** Optional configuration forwarded to {@link createSolanaRpc}. */
+    rpcConfig?: Parameters<typeof createSolanaRpc>[1];
+    /** Optional configuration forwarded to {@link createSolanaRpcSubscriptions}. */
+    rpcSubscriptionsConfig?: Parameters<typeof createSolanaRpcSubscriptions>[1];
+    /**
+     * URL of the Solana RPC Subscriptions endpoint.
+     * Defaults to the `rpcUrl` with the protocol changed from `http` to `ws`.
+     */
+    rpcSubscriptionsUrl?: TClusterUrl;
+    /** URL of the Solana RPC endpoint. */
+    rpcUrl: TClusterUrl;
+};
+
+/**
+ * Enhances a client with a read-only Solana RPC setup: the RPC connection,
+ * RPC Subscriptions, and minimum-balance computation. Unlike {@link solanaRpc},
+ * this plugin does *not* install transaction planning or transaction sending,
+ * so it has no `payer` prerequisite.
+ *
+ * Use this for dashboards, explorers, on-chain watchers, and other flows
+ * that only read from the chain.
+ *
+ * @param config - Configuration for the Solana RPC connection.
+ * @return A plugin that adds `client.rpc`, `client.rpcSubscriptions`, and
+ * `client.getMinimumBalance`.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from '@solana/kit';
+ * import { solanaRpcReadOnly } from '@solana/kit-plugin-rpc';
+ *
+ * const client = createClient().use(solanaRpcReadOnly({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
+ * const { value: balance } = await client.rpc.getBalance(address).send();
+ * ```
+ *
+ * @see {@link solanaRpc}
+ * @see {@link solanaRpcConnection}
+ * @see {@link solanaRpcSubscriptionsConnection}
+ */
+export function solanaRpcReadOnly<TClusterUrl extends ClusterUrl>(config: SolanaRpcReadOnlyConfig<TClusterUrl>) {
+    return <T extends object>(client: T) =>
+        pipe(
+            client,
+            solanaRpcConnection<TClusterUrl>(config.rpcUrl, config.rpcConfig),
+            solanaRpcSubscriptionsConnection<TClusterUrl>(
+                config.rpcSubscriptionsUrl ?? (config.rpcUrl.replace(/^http/, 'ws') as TClusterUrl),
+                config.rpcSubscriptionsConfig,
+            ),
+            rpcGetMinimumBalance(),
+        );
+}
+
+/**
+ * Enhances a client with a read-only Solana mainnet RPC setup.
+ *
+ * Convenience wrapper around {@link solanaRpcReadOnly} that types the
+ * connection as a mainnet URL, preventing accidental use of devnet-only
+ * features such as airdrops.
+ *
+ * @param config - Configuration for the Solana RPC connection.
+ * @return A plugin that applies {@link solanaRpcReadOnly} with a mainnet URL type.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from '@solana/kit';
+ * import { solanaMainnetRpcReadOnly } from '@solana/kit-plugin-rpc';
+ *
+ * const client = createClient()
+ *     .use(solanaMainnetRpcReadOnly({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
+ * ```
+ *
+ * @see {@link solanaRpcReadOnly}
+ * @see {@link solanaDevnetRpcReadOnly}
+ * @see {@link solanaLocalRpcReadOnly}
+ */
+export function solanaMainnetRpcReadOnly(config: SolanaRpcReadOnlyConfig<string>) {
+    return <T extends object>(client: T) =>
+        pipe(client, solanaRpcReadOnly<MainnetUrl>(config as SolanaRpcReadOnlyConfig<MainnetUrl>));
+}
+
+/**
+ * Enhances a client with a read-only Solana devnet RPC setup.
+ *
+ * Convenience wrapper around {@link solanaRpcReadOnly} that defaults to the
+ * public devnet endpoint and includes {@link rpcAirdrop} to request SOL from
+ * the faucet.
+ *
+ * @param config - Optional configuration overrides. Defaults `rpcUrl` to
+ * `https://api.devnet.solana.com`.
+ * @return A plugin that applies {@link solanaRpcReadOnly} with a devnet URL
+ * type and airdrop support.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from '@solana/kit';
+ * import { solanaDevnetRpcReadOnly } from '@solana/kit-plugin-rpc';
+ *
+ * const client = createClient().use(solanaDevnetRpcReadOnly());
+ * await client.airdrop(myAddress, lamports(1_000_000_000n));
+ * ```
+ *
+ * @see {@link solanaRpcReadOnly}
+ * @see {@link solanaMainnetRpcReadOnly}
+ * @see {@link solanaLocalRpcReadOnly}
+ */
+export function solanaDevnetRpcReadOnly(config?: Partial<SolanaRpcReadOnlyConfig<string>>) {
+    return <T extends object>(client: T) =>
+        pipe(
+            client,
+            solanaRpcReadOnly<DevnetUrl>({
+                ...config,
+                rpcUrl: config?.rpcUrl ?? 'https://api.devnet.solana.com',
+            } as SolanaRpcReadOnlyConfig<DevnetUrl>),
+            rpcAirdrop(),
+        );
+}
+
+/**
+ * Enhances a client with a read-only Solana local validator RPC setup.
+ *
+ * Convenience wrapper around {@link solanaRpcReadOnly} that defaults to
+ * `http://127.0.0.1:8899` for the RPC and `ws://127.0.0.1:8900` for
+ * subscriptions, and includes {@link rpcAirdrop} for requesting SOL from
+ * the local faucet.
+ *
+ * @param config - Optional configuration overrides.
+ * @return A plugin that applies {@link solanaRpcReadOnly} with localhost
+ * defaults and airdrop support.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from '@solana/kit';
+ * import { solanaLocalRpcReadOnly } from '@solana/kit-plugin-rpc';
+ *
+ * const client = createClient().use(solanaLocalRpcReadOnly());
+ * ```
+ *
+ * @see {@link solanaRpcReadOnly}
+ * @see {@link solanaMainnetRpcReadOnly}
+ * @see {@link solanaDevnetRpcReadOnly}
+ */
+export function solanaLocalRpcReadOnly(config?: Partial<SolanaRpcReadOnlyConfig<string>>) {
+    return <T extends object>(client: T) =>
+        pipe(
+            client,
+            solanaRpcReadOnly({
                 ...config,
                 rpcSubscriptionsUrl: config?.rpcSubscriptionsUrl ?? 'ws://127.0.0.1:8900',
                 rpcUrl: config?.rpcUrl ?? 'http://127.0.0.1:8899',

--- a/packages/kit-plugin-rpc/test/index.test.ts
+++ b/packages/kit-plugin-rpc/test/index.test.ts
@@ -5,10 +5,14 @@ import {
     rpcConnection,
     rpcSubscriptionsConnection,
     solanaDevnetRpc,
+    solanaDevnetRpcReadOnly,
     solanaLocalRpc,
+    solanaLocalRpcReadOnly,
     solanaMainnetRpc,
+    solanaMainnetRpcReadOnly,
     solanaRpc,
     solanaRpcConnection,
+    solanaRpcReadOnly,
     solanaRpcSubscriptionsConnection,
 } from '../src';
 
@@ -83,6 +87,98 @@ describe('solanaRpc', () => {
                 }),
             );
         expect(client).toHaveProperty('rpcSubscriptions');
+    });
+});
+
+describe('solanaRpcReadOnly', () => {
+    it('sets up rpc, rpcSubscriptions, and getMinimumBalance without a payer', () => {
+        const client = createClient().use(solanaRpcReadOnly({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
+        expect(client).toHaveProperty('rpc');
+        expect(client).toHaveProperty('rpcSubscriptions');
+        expect(client).toHaveProperty('getMinimumBalance');
+    });
+
+    it('does not install transaction planning or sending', () => {
+        const client = createClient().use(solanaRpcReadOnly({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
+        expect(client).not.toHaveProperty('sendTransaction');
+        expect(client).not.toHaveProperty('sendTransactions');
+        expect(client).not.toHaveProperty('planTransaction');
+        expect(client).not.toHaveProperty('planTransactions');
+        expect(client).not.toHaveProperty('transactionPlanner');
+        expect(client).not.toHaveProperty('transactionPlanExecutor');
+    });
+
+    it('derives the WebSocket URL from the RPC URL by default', () => {
+        const client = createClient().use(solanaRpcReadOnly({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
+        expect(client).toHaveProperty('rpcSubscriptions');
+    });
+
+    it('accepts an explicit rpcSubscriptionsUrl', () => {
+        const client = createClient().use(
+            solanaRpcReadOnly({
+                rpcSubscriptionsUrl: 'wss://custom-ws.solana.com',
+                rpcUrl: 'https://api.mainnet-beta.solana.com',
+            }),
+        );
+        expect(client).toHaveProperty('rpcSubscriptions');
+    });
+});
+
+describe('solanaMainnetRpcReadOnly', () => {
+    it('sets up a mainnet read-only client without a payer', () => {
+        const client = createClient().use(solanaMainnetRpcReadOnly({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
+        expect(client).toHaveProperty('rpc');
+        expect(client).toHaveProperty('rpcSubscriptions');
+        expect(client).toHaveProperty('getMinimumBalance');
+    });
+
+    it('does not include airdrop or transaction sending', () => {
+        const client = createClient().use(solanaMainnetRpcReadOnly({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
+        expect(client).not.toHaveProperty('airdrop');
+        expect(client).not.toHaveProperty('sendTransaction');
+        expect(client).not.toHaveProperty('sendTransactions');
+    });
+});
+
+describe('solanaDevnetRpcReadOnly', () => {
+    it('sets up a devnet read-only client with airdrop and without a payer', () => {
+        const client = createClient().use(solanaDevnetRpcReadOnly());
+        expect(client).toHaveProperty('rpc');
+        expect(client).toHaveProperty('rpcSubscriptions');
+        expect(client).toHaveProperty('getMinimumBalance');
+        expect(client).toHaveProperty('airdrop');
+    });
+
+    it('does not install transaction sending', () => {
+        const client = createClient().use(solanaDevnetRpcReadOnly());
+        expect(client).not.toHaveProperty('sendTransaction');
+        expect(client).not.toHaveProperty('sendTransactions');
+    });
+
+    it('accepts custom config overrides', () => {
+        const client = createClient().use(solanaDevnetRpcReadOnly({ rpcUrl: 'https://my-devnet-rpc.com' }));
+        expect(client).toHaveProperty('rpc');
+    });
+});
+
+describe('solanaLocalRpcReadOnly', () => {
+    it('sets up a localhost read-only client with airdrop and without a payer', () => {
+        const client = createClient().use(solanaLocalRpcReadOnly());
+        expect(client).toHaveProperty('rpc');
+        expect(client).toHaveProperty('rpcSubscriptions');
+        expect(client).toHaveProperty('getMinimumBalance');
+        expect(client).toHaveProperty('airdrop');
+    });
+
+    it('does not install transaction sending', () => {
+        const client = createClient().use(solanaLocalRpcReadOnly());
+        expect(client).not.toHaveProperty('sendTransaction');
+        expect(client).not.toHaveProperty('sendTransactions');
+    });
+
+    it('accepts custom config overrides', () => {
+        const client = createClient().use(solanaLocalRpcReadOnly({ rpcUrl: 'http://127.0.0.1:9999' }));
+        expect(client).toHaveProperty('rpc');
     });
 });
 


### PR DESCRIPTION
This PR adds a `solanaRpcReadOnly` plugin, as well as cluster-specific variants. This includes the RPC, RPC subscriptions, getMinimumBalance, and airdrop (on appropriate clusters). It does not include transaction planning/sending, and therefore does not require a payer.

It's defined as a strict subset of the `solanaRpc` plugin, which is refactored to compose from the readonly variant to avoid drift. Similarly its config is a subset of the `solanaRpc` config, excluding fields related to transaction sending.

This is useful for a range of apps/scripts that use Solana data but do not need to themselves send transactions. I came across the idea while speccing a react library, but figured it makes sense as an independent plugin too.