### PR TITLE
test: add signer override tests

### DIFF
--- a/packages/kit-plugin-signer/test/signer.test.ts
+++ b/packages/kit-plugin-signer/test/signer.test.ts
@@ -31,3 +31,35 @@ describe('identity', () => {
         expect(client.identity).toBe(mySigner);
     });
 });
+
+describe('override behavior', () => {
+    it('allows payer() to override a payer previously set by signer()', async () => {
+        const userSigner = await generateKeyPairSigner();
+        const feePayer = await generateKeyPairSigner();
+
+        const client = createClient().use(signer(userSigner)).use(payer(feePayer));
+
+        expect(client.identity).toBe(userSigner);
+        expect(client.payer).toBe(feePayer);
+    });
+
+    it('allows identity() to override an identity previously set by signer()', async () => {
+        const originalSigner = await generateKeyPairSigner();
+        const newIdentity = await generateKeyPairSigner();
+
+        const client = createClient().use(signer(originalSigner)).use(identity(newIdentity));
+
+        expect(client.payer).toBe(originalSigner);
+        expect(client.identity).toBe(newIdentity);
+    });
+
+    it('allows signer() to override both fields set by an earlier signer()', async () => {
+        const originalSigner = await generateKeyPairSigner();
+        const replacementSigner = await generateKeyPairSigner();
+
+        const client = createClient().use(signer(originalSigner)).use(signer(replacementSigner));
+
+        expect(client.payer).toBe(replacementSigner);
+        expect(client.identity).toBe(replacementSigner);
+    });
+});


### PR DESCRIPTION
Adds regression tests covering `extendClient` override behavior - chaining two plugins that set the same client field (e.g. `signer()` then `payer()`).

All three tests currently throw `TypeError: Cannot redefine property: <field>` and will pass once the upstream fix lands.

### Depends on

- anza-xyz/kit#1569 - fixes `extendClient` to allow later plugins to override keys set by earlier plugins

### Test plan

- [X] Tests fail on current `@solana/plugin-core@6.8.0` (reproduces the bug)
- [X] Tests pass against anza-xyz/kit#1569 (verified locally via `pnpm patch`)
