### PR TITLE
chore: Drop deprecated package refs from docs, JSDoc, and examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Before presenting changes for review, verify locally:
 - `pnpm test` passes (type checking + unit tests across all environments).
 - `pnpm build` succeeds and does not produce uncommitted changes in the working tree.
 
-Running these in the relevant package directory (e.g. `pnpm test:unit` in `packages/kit-plugin-payer`) is sufficient for focused changes.
+Running these in the relevant package directory (e.g. `pnpm test:unit` in `packages/kit-plugin-signer`) is sufficient for focused changes.
 
 <!-- skills-inject:start -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,19 +8,14 @@ Thank you for your interest in contributing to Kit Plugins! This guide covers ev
 
 This is a monorepo managed with [pnpm](https://pnpm.io/) and [Turborepo](https://turbo.build/). It contains the following packages:
 
-| Package                                                                         | Description                                                    |
-| ------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| [`@solana/kit-plugins`](./packages/kit-plugins)                                 | **(deprecated)** Umbrella package that re-exports all plugins. |
-| [`@solana/kit-client-rpc`](./packages/kit-client-rpc)                           | Pre-configured RPC client factory.                             |
-| [`@solana/kit-client-litesvm`](./packages/kit-client-litesvm)                   | Pre-configured LiteSVM client factory.                         |
-| [`@solana/kit-plugin-rpc`](./packages/kit-plugin-rpc)                           | RPC connection plugins.                                        |
-| [`@solana/kit-plugin-payer`](./packages/kit-plugin-payer)                       | Transaction fee payer plugins.                                 |
-| [`@solana/kit-plugin-signer`](./packages/kit-plugin-signer)                     | Signer, payer, and identity plugins.                           |
-| [`@solana/kit-plugin-airdrop`](./packages/kit-plugin-airdrop)                   | SOL airdrop plugin.                                            |
-| [`@solana/kit-plugin-litesvm`](./packages/kit-plugin-litesvm)                   | LiteSVM support plugin.                                        |
-| [`@solana/kit-plugin-instruction-plan`](./packages/kit-plugin-instruction-plan) | Transaction planning and execution plugins.                    |
+| Package                                                                         | Description                                 |
+| ------------------------------------------------------------------------------- | ------------------------------------------- |
+| [`@solana/kit-plugin-rpc`](./packages/kit-plugin-rpc)                           | RPC connection plugins.                     |
+| [`@solana/kit-plugin-signer`](./packages/kit-plugin-signer)                     | Signer, payer, and identity plugins.        |
+| [`@solana/kit-plugin-litesvm`](./packages/kit-plugin-litesvm)                   | LiteSVM support plugin.                     |
+| [`@solana/kit-plugin-instruction-plan`](./packages/kit-plugin-instruction-plan) | Transaction planning and execution plugins. |
 
-The umbrella package (`@solana/kit-plugins`) is deprecated. It re-exports everything from the individual plugin packages via `export *` statements for backward compatibility, but consumers should import from the individual `kit-plugin-*` packages directly.
+The repo also contains a deprecated umbrella package (`@solana/kit-plugins`) and several deprecated single-purpose packages (`@solana/kit-plugin-payer`, `@solana/kit-plugin-airdrop`, `@solana/kit-client-rpc`, `@solana/kit-client-litesvm`). They re-export from the active packages via `export *` for backward compatibility, but new code should import from the individual `kit-plugin-*` packages above directly.
 
 ## Getting started
 
@@ -48,10 +43,10 @@ You can also run commands within individual packages:
 
 ```sh
 # Run unit tests for a specific package.
-pnpm test:unit --filter @solana/kit-plugin-payer
+pnpm test:unit --filter @solana/kit-plugin-signer
 
 # Or navigate to the package directory.
-cd packages/kit-plugin-payer
+cd packages/kit-plugin-signer
 pnpm test:unit   # Unit tests only.
 pnpm test:types  # Type checking only.
 pnpm build       # Build only this package.
@@ -128,7 +123,7 @@ Any PR that should trigger a new package release must include a [changeset](http
 
 ```md
 ---
-'@solana/kit-plugin-payer': minor
+'@solana/kit-plugin-signer': minor
 ---
 
 Add `payerOrGeneratedPayer` plugin that uses an explicit payer when provided, or generates a new one funded with 100 SOL via airdrop as a fallback.

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ A library for [Solana Kit](https://github.com/anza-xyz/kit) that helps you **bui
 Use the `solanaRpc` bundle plugin to set up a full Solana RPC client with transaction planning and execution.
 
 ```sh
-pnpm install @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-payer
+pnpm install @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-signer
 ```
 
 ```ts
 import { createClient } from '@solana/kit';
 import { solanaRpc } from '@solana/kit-plugin-rpc';
-import { payer } from '@solana/kit-plugin-payer';
+import { payer } from '@solana/kit-plugin-signer';
 
 const client = createClient()
     .use(payer(myProductionSigner))
@@ -45,13 +45,13 @@ For mainnet type safety (preventing accidental use of devnet-only features like 
 Use `solanaLocalRpc` which defaults to `http://127.0.0.1:8899` and includes airdrop support.
 
 ```sh
-pnpm install @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-payer
+pnpm install @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-signer
 ```
 
 ```ts
 import { createClient } from '@solana/kit';
 import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
-import { payerFromFile } from '@solana/kit-plugin-payer';
+import { payerFromFile } from '@solana/kit-plugin-signer';
 
 const client = createClient().use(payerFromFile('~/.config/solana/id.json')).use(solanaLocalRpc());
 
@@ -67,13 +67,13 @@ For devnet, use `solanaDevnetRpc` which defaults to `https://api.devnet.solana.c
 Use the `litesvm` bundle plugin for fast local blockchain simulation without a network connection.
 
 ```sh
-pnpm install @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-payer
+pnpm install @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-signer
 ```
 
 ```ts
 import { createClient, lamports } from '@solana/kit';
 import { litesvm } from '@solana/kit-plugin-litesvm';
-import { generatedPayer } from '@solana/kit-plugin-payer';
+import { generatedPayer } from '@solana/kit-plugin-signer';
 
 const client = await createClient().use(generatedPayer()).use(litesvm());
 
@@ -102,7 +102,7 @@ import {
     rpcTransactionPlanner,
     rpcTransactionPlanExecutor,
 } from '@solana/kit-plugin-rpc';
-import { payerFromFile } from '@solana/kit-plugin-payer';
+import { payerFromFile } from '@solana/kit-plugin-signer';
 import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
 
 const client = await createClient()
@@ -120,12 +120,12 @@ Note that since core plugin interfaces are defined in `@solana/kit` itself, you'
 
 This repo provides the following individual plugin packages. You can learn more about each package by following the links to their READMEs below.
 
-| Package                                                                         | Version                                                                                                                                                      | Description                        | Plugins                                                                                                                                                                                  |
-| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`@solana/kit-plugin-rpc`](./packages/kit-plugin-rpc)                           | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-rpc.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-rpc)                           | Connect to Solana clusters         | `solanaRpc`, `solanaMainnetRpc`, `solanaDevnetRpc`, `solanaLocalRpc`, `solanaRpcConnection`, `rpcAirdrop`, `rpcGetMinimumBalance`, `rpcTransactionPlanner`, `rpcTransactionPlanExecutor` |
-| [`@solana/kit-plugin-payer`](./packages/kit-plugin-payer)                       | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-payer.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-payer)                       | Manage transaction fee payers      | `payer`, `payerFromFile`, `generatedPayer`, `generatedPayerWithSol`                                                                                                                      |
-| [`@solana/kit-plugin-litesvm`](./packages/kit-plugin-litesvm)                   | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-litesvm.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-litesvm)                   | LiteSVM support                    | `litesvm`, `litesvmConnection`, `litesvmAirdrop`, `litesvmGetMinimumBalance`, `litesvmTransactionPlanner`, `litesvmTransactionPlanExecutor`                                              |
-| [`@solana/kit-plugin-instruction-plan`](./packages/kit-plugin-instruction-plan) | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-instruction-plan.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-instruction-plan) | Transaction planning and execution | `transactionPlanner`, `transactionPlanExecutor`, `planAndSendTransactions`                                                                                                               |
+| Package                                                                         | Version                                                                                                                                                      | Description                         | Plugins                                                                                                                                                                                                                                                                           |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`@solana/kit-plugin-rpc`](./packages/kit-plugin-rpc)                           | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-rpc.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-rpc)                           | Connect to Solana clusters          | `solanaRpc`, `solanaMainnetRpc`, `solanaDevnetRpc`, `solanaLocalRpc`, `solanaRpcConnection`, `rpcAirdrop`, `rpcGetMinimumBalance`, `rpcTransactionPlanner`, `rpcTransactionPlanExecutor`                                                                                          |
+| [`@solana/kit-plugin-signer`](./packages/kit-plugin-signer)                     | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-signer.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-signer)                     | Signer, payer, and identity plugins | `signer`, `payer`, `identity`, `signerFromFile`, `payerFromFile`, `identityFromFile`, `generatedSigner`, `generatedPayer`, `generatedIdentity`, `generatedSignerWithSol`, `generatedPayerWithSol`, `generatedIdentityWithSol`, `airdropSigner`, `airdropPayer`, `airdropIdentity` |
+| [`@solana/kit-plugin-litesvm`](./packages/kit-plugin-litesvm)                   | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-litesvm.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-litesvm)                   | LiteSVM support                     | `litesvm`, `litesvmConnection`, `litesvmAirdrop`, `litesvmGetMinimumBalance`, `litesvmTransactionPlanner`, `litesvmTransactionPlanExecutor`                                                                                                                                       |
+| [`@solana/kit-plugin-instruction-plan`](./packages/kit-plugin-instruction-plan) | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-instruction-plan.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-instruction-plan) | Transaction planning and execution  | `transactionPlanner`, `transactionPlanExecutor`, `planAndSendTransactions`                                                                                                                                                                                                        |
 
 ## Community Plugins
 

--- a/examples/token-airdrop/package.json
+++ b/examples/token-airdrop/package.json
@@ -5,7 +5,8 @@
         "@solana-program/system": "^0.12.0",
         "@solana-program/token": "^0.13.0",
         "@solana/kit": "^6.8.0",
-        "@solana/kit-client-rpc": "workspace:*"
+        "@solana/kit-plugin-rpc": "workspace:*",
+        "@solana/kit-plugin-signer": "workspace:*"
     },
     "type": "module",
     "scripts": {

--- a/examples/token-airdrop/src/index.ts
+++ b/examples/token-airdrop/src/index.ts
@@ -1,12 +1,15 @@
 import {
+    createClient,
     flattenTransactionPlanResult,
     generateKeyPairSigner,
     isInstructionWithData,
+    lamports,
     parallelInstructionPlan,
     passthroughFailedTransactionPlanExecution,
     sequentialInstructionPlan,
 } from '@solana/kit';
-import { createLocalClient } from '@solana/kit-client-rpc';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
 import {
     getSystemErrorMessage,
     isSystemError,
@@ -25,7 +28,10 @@ import {
 // Use `pnpm start --fail` to make the example fail and see error handling
 const shouldFail = process.argv.includes('--fail');
 
-const client = await createLocalClient();
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(100_000_000_000n)));
 const { payer } = client;
 
 // Generate 100 random recipient addresses

--- a/examples/transfer-lamports/package.json
+++ b/examples/transfer-lamports/package.json
@@ -4,7 +4,8 @@
     "dependencies": {
         "@solana-program/system": "^0.12.0",
         "@solana/kit": "^6.8.0",
-        "@solana/kit-client-rpc": "workspace:*"
+        "@solana/kit-plugin-rpc": "workspace:*",
+        "@solana/kit-plugin-signer": "workspace:*"
     },
     "type": "module",
     "scripts": {

--- a/examples/transfer-lamports/src/index.ts
+++ b/examples/transfer-lamports/src/index.ts
@@ -1,4 +1,5 @@
 import {
+    createClient,
     generateKeyPairSigner,
     getFirstFailedSingleTransactionPlanResult,
     isInstructionWithData,
@@ -7,7 +8,8 @@ import {
     SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN,
     type TransactionPlanResult,
 } from '@solana/kit';
-import { createLocalClient } from '@solana/kit-client-rpc';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
 import {
     getSystemErrorMessage,
     getTransferSolInstruction,
@@ -19,7 +21,10 @@ import {
 // Use `pnpm start --fail` to make the example fail and see error handling
 const shouldFail = process.argv.includes('--fail');
 
-const client = await createLocalClient();
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(100_000_000_000n)));
 
 // Generate a random recipient address
 const destinationAccountAddress = (await generateKeyPairSigner()).address;

--- a/packages/kit-plugin-litesvm/README.md
+++ b/packages/kit-plugin-litesvm/README.md
@@ -29,7 +29,7 @@ The client must have a `payer` set before applying this plugin.
 ```ts
 import { createClient } from '@solana/kit';
 import { litesvm } from '@solana/kit-plugin-litesvm';
-import { payer } from '@solana/kit-plugin-payer';
+import { payer } from '@solana/kit-plugin-signer';
 
 const client = createClient().use(payer(myPayer)).use(litesvm());
 ```
@@ -142,7 +142,7 @@ import {
     litesvmTransactionPlanner,
     litesvmTransactionPlanExecutor,
 } from '@solana/kit-plugin-litesvm';
-import { generatedPayer } from '@solana/kit-plugin-payer';
+import { generatedPayer } from '@solana/kit-plugin-signer';
 
 const client = await createClient()
     .use(litesvmConnection())
@@ -180,7 +180,7 @@ import {
     litesvmTransactionPlanner,
     litesvmTransactionPlanExecutor,
 } from '@solana/kit-plugin-litesvm';
-import { generatedPayer } from '@solana/kit-plugin-payer';
+import { generatedPayer } from '@solana/kit-plugin-signer';
 
 const client = await createClient()
     .use(litesvmConnection())

--- a/packages/kit-plugin-litesvm/src/litesvm.ts
+++ b/packages/kit-plugin-litesvm/src/litesvm.ts
@@ -30,7 +30,7 @@ export type LiteSvmConfig = {
  * ```ts
  * import { createClient } from '@solana/kit';
  * import { litesvm } from '@solana/kit-plugin-litesvm';
- * import { payer } from '@solana/kit-plugin-payer';
+ * import { payer } from '@solana/kit-plugin-signer';
  *
  * const client = createClient()
  *     .use(payer(myPayer))

--- a/packages/kit-plugin-litesvm/src/transaction-plan-executor.ts
+++ b/packages/kit-plugin-litesvm/src/transaction-plan-executor.ts
@@ -23,7 +23,7 @@ import { getSolanaErrorFromLiteSvmFailure, isFailedTransaction } from './transac
  * ```ts
  * import { createClient } from '@solana/kit';
  * import { litesvmConnection, litesvmTransactionPlanner, litesvmTransactionPlanExecutor } from '@solana/kit-plugin-litesvm';
- * import { generatedPayer } from '@solana/kit-plugin-payer';
+ * import { generatedPayer } from '@solana/kit-plugin-signer';
  *
  * const client = await createClient()
  *     .use(litesvmConnection())

--- a/packages/kit-plugin-litesvm/src/transaction-planner.ts
+++ b/packages/kit-plugin-litesvm/src/transaction-planner.ts
@@ -23,7 +23,7 @@ import {
  * ```ts
  * import { createClient } from '@solana/kit';
  * import { litesvmConnection, litesvmTransactionPlanner, litesvmTransactionPlanExecutor } from '@solana/kit-plugin-litesvm';
- * import { generatedPayer } from '@solana/kit-plugin-payer';
+ * import { generatedPayer } from '@solana/kit-plugin-signer';
  *
  * const client = await createClient()
  *     .use(litesvmConnection())

--- a/packages/kit-plugin-rpc/README.md
+++ b/packages/kit-plugin-rpc/README.md
@@ -26,7 +26,7 @@ The client must have a `payer` set before applying this plugin.
 ```ts
 import { createClient } from '@solana/kit';
 import { solanaRpc } from '@solana/kit-plugin-rpc';
-import { payer } from '@solana/kit-plugin-payer';
+import { payer } from '@solana/kit-plugin-signer';
 
 const client = createClient()
     .use(payer(myPayer))
@@ -63,7 +63,7 @@ A convenience wrapper around `solanaRpc` that types the connection as a mainnet 
 ```ts
 import { createClient } from '@solana/kit';
 import { solanaMainnetRpc } from '@solana/kit-plugin-rpc';
-import { payer } from '@solana/kit-plugin-payer';
+import { payer } from '@solana/kit-plugin-signer';
 
 const client = createClient()
     .use(payer(myPayer))
@@ -83,7 +83,7 @@ A convenience wrapper around `solanaRpc` that defaults to the public devnet endp
 ```ts
 import { createClient } from '@solana/kit';
 import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
-import { payerFromFile } from '@solana/kit-plugin-payer';
+import { payerFromFile } from '@solana/kit-plugin-signer';
 
 const client = createClient().use(payerFromFile('~/.config/solana/id.json')).use(solanaDevnetRpc());
 ```
@@ -106,7 +106,7 @@ A convenience wrapper around `solanaRpc` that defaults to `http://127.0.0.1:8899
 ```ts
 import { createClient } from '@solana/kit';
 import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
-import { payerFromFile } from '@solana/kit-plugin-payer';
+import { payerFromFile } from '@solana/kit-plugin-signer';
 
 const client = createClient().use(payerFromFile('~/.config/solana/id.json')).use(solanaLocalRpc());
 ```
@@ -231,7 +231,7 @@ The client must have a `payer` set before applying this plugin.
 ```ts
 import { createClient } from '@solana/kit';
 import { solanaRpcConnection, rpcTransactionPlanner, rpcTransactionPlanExecutor } from '@solana/kit-plugin-rpc';
-import { generatedPayer } from '@solana/kit-plugin-payer';
+import { generatedPayer } from '@solana/kit-plugin-signer';
 
 const client = await createClient()
     .use(solanaRpcConnection({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
@@ -265,7 +265,7 @@ This plugin requires `rpc` and `rpcSubscriptions` to be configured on the client
 ```ts
 import { createClient } from '@solana/kit';
 import { solanaRpcConnection, rpcTransactionPlanner, rpcTransactionPlanExecutor } from '@solana/kit-plugin-rpc';
-import { generatedPayer } from '@solana/kit-plugin-payer';
+import { generatedPayer } from '@solana/kit-plugin-signer';
 
 const client = await createClient()
     .use(solanaRpcConnection({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))

--- a/packages/kit-plugin-rpc/src/solana-rpc.ts
+++ b/packages/kit-plugin-rpc/src/solana-rpc.ts
@@ -98,7 +98,7 @@ export type SolanaRpcConfig<TClusterUrl extends ClusterUrl = ClusterUrl> = Solan
  * ```ts
  * import { createClient } from '@solana/kit';
  * import { solanaRpc } from '@solana/kit-plugin-rpc';
- * import { payer } from '@solana/kit-plugin-payer';
+ * import { payer } from '@solana/kit-plugin-signer';
  *
  * const client = createClient()
  *     .use(payer(myPayer))
@@ -135,7 +135,7 @@ export function solanaRpc<TClusterUrl extends ClusterUrl>(config: SolanaRpcConfi
  * ```ts
  * import { createClient } from '@solana/kit';
  * import { solanaMainnetRpc } from '@solana/kit-plugin-rpc';
- * import { payer } from '@solana/kit-plugin-payer';
+ * import { payer } from '@solana/kit-plugin-signer';
  *
  * const client = createClient()
  *     .use(payer(myPayer))
@@ -167,7 +167,7 @@ export function solanaMainnetRpc(config: SolanaRpcConfig<string>) {
  * ```ts
  * import { createClient } from '@solana/kit';
  * import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
- * import { payerFromFile } from '@solana/kit-plugin-payer';
+ * import { payerFromFile } from '@solana/kit-plugin-signer';
  *
  * const client = createClient()
  *     .use(payerFromFile("~/.config/solana/id.json"))
@@ -206,7 +206,7 @@ export function solanaDevnetRpc(config?: Partial<SolanaRpcConfig<string>>) {
  * ```ts
  * import { createClient } from '@solana/kit';
  * import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
- * import { payerFromFile } from '@solana/kit-plugin-payer';
+ * import { payerFromFile } from '@solana/kit-plugin-signer';
  *
  * const client = createClient()
  *     .use(payerFromFile("~/.config/solana/id.json"))

--- a/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
+++ b/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
@@ -39,7 +39,7 @@ const MAX_COMPUTE_UNIT_LIMIT = 1_400_000;
  * ```ts
  * import { createClient } from '@solana/kit';
  * import { solanaRpcConnection, rpcTransactionPlanner, rpcTransactionPlanExecutor } from '@solana/kit-plugin-rpc';
- * import { generatedPayer } from '@solana/kit-plugin-payer';
+ * import { generatedPayer } from '@solana/kit-plugin-signer';
  *
  * const client = await createClient()
  *     .use(solanaRpcConnection({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))

--- a/packages/kit-plugin-rpc/src/transaction-planner.ts
+++ b/packages/kit-plugin-rpc/src/transaction-planner.ts
@@ -25,7 +25,7 @@ import {
  * ```ts
  * import { createClient } from '@solana/kit';
  * import { solanaRpcConnection, rpcTransactionPlanner, rpcTransactionPlanExecutor } from '@solana/kit-plugin-rpc';
- * import { generatedPayer } from '@solana/kit-plugin-payer';
+ * import { generatedPayer } from '@solana/kit-plugin-signer';
  *
  * const client = await createClient()
  *     .use(solanaRpcConnection({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,9 +71,12 @@ importers:
       '@solana/kit':
         specifier: ^6.8.0
         version: 6.8.0(typescript@5.9.3)
-      '@solana/kit-client-rpc':
+      '@solana/kit-plugin-rpc':
         specifier: workspace:*
-        version: link:../../packages/kit-client-rpc
+        version: link:../../packages/kit-plugin-rpc
+      '@solana/kit-plugin-signer':
+        specifier: workspace:*
+        version: link:../../packages/kit-plugin-signer
 
   examples/transfer-lamports:
     dependencies:
@@ -83,9 +86,12 @@ importers:
       '@solana/kit':
         specifier: ^6.8.0
         version: 6.8.0(typescript@5.9.3)
-      '@solana/kit-client-rpc':
+      '@solana/kit-plugin-rpc':
         specifier: workspace:*
-        version: link:../../packages/kit-client-rpc
+        version: link:../../packages/kit-plugin-rpc
+      '@solana/kit-plugin-signer':
+        specifier: workspace:*
+        version: link:../../packages/kit-plugin-signer
 
   packages/kit-client-litesvm:
     dependencies:


### PR DESCRIPTION
@lorisleiva noticed a readme on NPM this morning that referenced the old payer package, so figured I'd help clean up some deprecated references:

Scrubs references to deprecated packages:

- `@solana/kit-plugin-payer`
- `@solana/kit-client-rpc`
- `@solana/kit-client-litesvm`
- `@solana/kit-plugin-airdrop`

From:
- active READMEs, 
- contributor docs, and 
- JSDoc example blocks

Also migrates `examples/transfer-lamports` and `examples/token-airdrop` runtime code from `createLocalClient` to the granular plugin composition `generatedSigner` + `solanaLocalRpc` + `airdropSigner`. 

Deprecated packages keep their own self-contained migration notices.

## Test plan

- [x] `pnpm test` passes (22/22 packages)
- [x] `pnpm build` clean (no uncommitted dist changes)
- [x] `pnpm lint` passes for all touched files
- [x] Examples typecheck and lint cleanly with the new plugin composition