### PR TITLE
fix(kit-plugin-rpc): derive ws://...:8900 for local validator rpcUrl

### DIFF
--- a/.changeset/huge-lands-argue.md
+++ b/.changeset/huge-lands-argue.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-rpc': patch
+---
+
+Fix `solanaRpcConnection` WebSocket URL derivation for the canonical local validator endpoint. When `rpcUrl` is `http://127.0.0.1:8899` or `http://localhost:8899`, the derived `rpcSubscriptionsUrl` now correctly targets port `8900` to match `solana-test-validator` defaults. Non-default ports and remote endpoints are unchanged.

--- a/packages/kit-plugin-rpc/README.md
+++ b/packages/kit-plugin-rpc/README.md
@@ -38,7 +38,7 @@ const client = createClient()
 All options are provided via a `SolanaRpcConfig` object:
 
 - `rpcUrl` **(required)**: URL of the Solana RPC endpoint.
-- `rpcSubscriptionsUrl`: URL of the RPC Subscriptions endpoint. Defaults to the `rpcUrl` with the protocol changed from `http` to `ws`.
+- `rpcSubscriptionsUrl`: URL of the RPC Subscriptions endpoint. Defaults to the `rpcUrl` with the protocol changed from `http` to `ws`. As a convenience, the exact strings `http://127.0.0.1:8899` and `http://localhost:8899` (the canonical local validator RPC endpoints) are rewritten to port `8900`. The match is exact-string only — any other host, scheme, or port (including `https://localhost:8899` or `http://0.0.0.0:8899`) is left untouched. Pass `rpcSubscriptionsUrl` explicitly when your RPC and WebSocket endpoints use different ports.
 - `rpcConfig`: Optional configuration forwarded to `createSolanaRpc`.
 - `rpcSubscriptionsConfig`: Optional configuration forwarded to `createSolanaRpcSubscriptions`.
 - `transactionConfig`: Options to configure how transaction messages are created. See `rpcTransactionPlanner` options below.
@@ -146,7 +146,7 @@ const client = createClient().use(solanaRpcConnection({ rpcUrl: mainnet('https:/
 All options are provided via a `SolanaRpcConnectionConfig` object:
 
 - `rpcUrl` **(required)**: URL of the Solana RPC endpoint.
-- `rpcSubscriptionsUrl`: URL of the RPC Subscriptions endpoint. Defaults to the `rpcUrl` with the protocol changed from `http` to `ws`.
+- `rpcSubscriptionsUrl`: URL of the RPC Subscriptions endpoint. Defaults to the `rpcUrl` with the protocol changed from `http` to `ws`. As a convenience, the exact strings `http://127.0.0.1:8899` and `http://localhost:8899` (the canonical local validator RPC endpoints) are rewritten to port `8900`. The match is exact-string only — any other host, scheme, or port (including `https://localhost:8899` or `http://0.0.0.0:8899`) is left untouched. Pass `rpcSubscriptionsUrl` explicitly when your RPC and WebSocket endpoints use different ports.
 - `rpcConfig`: Optional configuration forwarded to `createSolanaRpc`.
 - `rpcSubscriptionsConfig`: Optional configuration forwarded to `createSolanaRpcSubscriptions`.
 

--- a/packages/kit-plugin-rpc/src/solana-rpc.ts
+++ b/packages/kit-plugin-rpc/src/solana-rpc.ts
@@ -190,6 +190,24 @@ export function solanaDevnetRpc(config?: Partial<SolanaRpcConfig<string>>) {
         );
 }
 
+const LOCAL_VALIDATOR_RPC_URL = 'http://127.0.0.1:8899';
+const LOCAL_VALIDATOR_RPC_SUBSCRIPTIONS_URL = 'ws://127.0.0.1:8900';
+
+// Lookup table for canonical solana-test-validator RPC endpoints, whose
+// WebSocket listens on port 8900 rather than the RPC port 8899. The match is
+// intentionally exact-string (not a hostname/port heuristic) to avoid silently
+// rewriting user-customized validator setups that happen to use port 8899 —
+// anything not in this table falls through to a plain protocol swap in
+// {@link deriveRpcSubscriptionsUrl}.
+const LOCAL_VALIDATOR_RPC_SUBSCRIPTIONS_URLS: { readonly [rpcUrl: string]: string } = {
+    [LOCAL_VALIDATOR_RPC_URL]: LOCAL_VALIDATOR_RPC_SUBSCRIPTIONS_URL,
+    'http://localhost:8899': 'ws://localhost:8900',
+};
+
+function deriveRpcSubscriptionsUrl(rpcUrl: string): string {
+    return LOCAL_VALIDATOR_RPC_SUBSCRIPTIONS_URLS[rpcUrl] ?? rpcUrl.replace(/^http/, 'ws');
+}
+
 /**
  * Enhances a client with a full Solana local validator RPC setup.
  *
@@ -223,8 +241,8 @@ export function solanaLocalRpc(config?: Partial<SolanaRpcConfig<string>>) {
             client,
             solanaRpc({
                 ...config,
-                rpcSubscriptionsUrl: config?.rpcSubscriptionsUrl ?? 'ws://127.0.0.1:8900',
-                rpcUrl: config?.rpcUrl ?? 'http://127.0.0.1:8899',
+                rpcSubscriptionsUrl: config?.rpcSubscriptionsUrl ?? LOCAL_VALIDATOR_RPC_SUBSCRIPTIONS_URL,
+                rpcUrl: config?.rpcUrl ?? LOCAL_VALIDATOR_RPC_URL,
             }),
             rpcAirdrop(),
         );
@@ -237,7 +255,14 @@ export function solanaLocalRpc(config?: Partial<SolanaRpcConfig<string>>) {
  * This plugin creates both a Solana RPC using {@link createSolanaRpc} and Solana
  * RPC Subscriptions using {@link createSolanaRpcSubscriptions}, then installs
  * them on the client. When `rpcSubscriptionsUrl` is omitted, it is derived from
- * `rpcUrl` by swapping the `http`/`https` protocol for `ws`/`wss`.
+ * `rpcUrl` by swapping the `http`/`https` protocol for `ws`/`wss`. As a
+ * convenience, the exact strings `http://127.0.0.1:8899` and
+ * `http://localhost:8899` (the canonical `solana-test-validator` RPC
+ * endpoints) are rewritten to their matching subscriptions port `8900`. The
+ * match is exact-string only — any other host, scheme, or port (including
+ * `https://localhost:8899` or `http://0.0.0.0:8899`) is left untouched. Pass
+ * `rpcSubscriptionsUrl` explicitly when your RPC and WebSocket endpoints use
+ * different ports.
  *
  * @param config - Configuration describing the RPC and subscriptions endpoints.
  * @return A plugin that adds `client.rpc` and `client.rpcSubscriptions`.
@@ -269,7 +294,7 @@ export function solanaLocalRpc(config?: Partial<SolanaRpcConfig<string>>) {
  */
 export function solanaRpcConnection<TClusterUrl extends ClusterUrl>(config: SolanaRpcConnectionConfig<TClusterUrl>) {
     const rpc = createSolanaRpc<TClusterUrl>(config.rpcUrl, config.rpcConfig);
-    const rpcSubscriptionsUrl = config.rpcSubscriptionsUrl ?? (config.rpcUrl.replace(/^http/, 'ws') as TClusterUrl);
+    const rpcSubscriptionsUrl = config.rpcSubscriptionsUrl ?? (deriveRpcSubscriptionsUrl(config.rpcUrl) as TClusterUrl);
     const rpcSubscriptions = createSolanaRpcSubscriptions<TClusterUrl>(
         rpcSubscriptionsUrl,
         config.rpcSubscriptionsConfig,
@@ -335,7 +360,7 @@ export function rpc<TClusterUrl extends ClusterUrl>(
     rpcSubscriptionsConfig?: DefaultRpcSubscriptionsChannelConfig<TClusterUrl>,
 ) {
     const rpc = createSolanaRpc(url);
-    const rpcSubscriptionsUrl = rpcSubscriptionsConfig?.url ?? url.replace(/^http/, 'ws');
+    const rpcSubscriptionsUrl = rpcSubscriptionsConfig?.url ?? deriveRpcSubscriptionsUrl(url);
     const rpcSubscriptions = createSolanaRpcSubscriptions(rpcSubscriptionsUrl, rpcSubscriptionsConfig);
     return <T extends object>(client: T) => extendClient(client, { rpc, rpcSubscriptions });
 }
@@ -358,5 +383,8 @@ export function rpc<TClusterUrl extends ClusterUrl>(
  * ```
  */
 export function localhostRpc(url?: string, rpcSubscriptionsConfig?: DefaultRpcSubscriptionsChannelConfig<string>) {
-    return rpc<string>(url ?? 'http://127.0.0.1:8899', rpcSubscriptionsConfig ?? { url: 'ws://127.0.0.1:8900' });
+    return rpc<string>(
+        url ?? LOCAL_VALIDATOR_RPC_URL,
+        rpcSubscriptionsConfig ?? { url: LOCAL_VALIDATOR_RPC_SUBSCRIPTIONS_URL },
+    );
 }

--- a/packages/kit-plugin-rpc/test/index.test.ts
+++ b/packages/kit-plugin-rpc/test/index.test.ts
@@ -2,6 +2,7 @@ import { createClient, createSolanaRpc, createSolanaRpcSubscriptions, mainnet, T
 import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import {
+    rpc,
     rpcConnection,
     rpcSubscriptionsConnection,
     solanaDevnetRpc,
@@ -65,8 +66,33 @@ describe('solanaRpcConnection', () => {
     });
 
     it('also derives ws:// from http:// for unsecured endpoints', () => {
+        createClient().use(solanaRpcConnection({ rpcUrl: 'http://example.local:8080' }));
+        expect(createSolanaRpcSubscriptions).toHaveBeenCalledWith('ws://example.local:8080', undefined);
+    });
+
+    it('rewrites the canonical local validator RPC port (8899 -> 8900) when deriving the WebSocket URL', () => {
         createClient().use(solanaRpcConnection({ rpcUrl: 'http://127.0.0.1:8899' }));
-        expect(createSolanaRpcSubscriptions).toHaveBeenCalledWith('ws://127.0.0.1:8899', undefined);
+        expect(createSolanaRpcSubscriptions).toHaveBeenCalledWith('ws://127.0.0.1:8900', undefined);
+    });
+
+    it('also rewrites 8899 -> 8900 for the localhost hostname', () => {
+        createClient().use(solanaRpcConnection({ rpcUrl: 'http://localhost:8899' }));
+        expect(createSolanaRpcSubscriptions).toHaveBeenCalledWith('ws://localhost:8900', undefined);
+    });
+
+    it('preserves non-default localhost ports', () => {
+        createClient().use(solanaRpcConnection({ rpcUrl: 'http://127.0.0.1:9000' }));
+        expect(createSolanaRpcSubscriptions).toHaveBeenCalledWith('ws://127.0.0.1:9000', undefined);
+    });
+
+    it('does not rewrite the port for https://127.0.0.1:8899 (allowlist is exact-string http only)', () => {
+        createClient().use(solanaRpcConnection({ rpcUrl: 'https://127.0.0.1:8899' }));
+        expect(createSolanaRpcSubscriptions).toHaveBeenCalledWith('wss://127.0.0.1:8899', undefined);
+    });
+
+    it('derives wss:// from https:// for mainnet input', () => {
+        createClient().use(solanaRpcConnection({ rpcUrl: mainnet('https://api.mainnet-beta.solana.com') }));
+        expect(createSolanaRpcSubscriptions).toHaveBeenCalledWith('wss://api.mainnet-beta.solana.com', undefined);
     });
 
     it('accepts an explicit rpcSubscriptionsUrl', () => {
@@ -94,6 +120,13 @@ describe('solanaRpcConnection', () => {
             'wss://api.mainnet-beta.solana.com',
             rpcSubscriptionsConfig,
         );
+    });
+});
+
+describe('rpc (deprecated)', () => {
+    it('rewrites the canonical local validator RPC port (8899 -> 8900) when deriving the WebSocket URL', () => {
+        createClient().use(rpc('http://127.0.0.1:8899'));
+        expect(createSolanaRpcSubscriptions).toHaveBeenCalledWith('ws://127.0.0.1:8900', undefined);
     });
 });
 


### PR DESCRIPTION
## Summary

`solanaRpcConnection({ rpcUrl })` derived `rpcSubscriptionsUrl` by swapping protocol only, so `http://127.0.0.1:8899` produced `ws://127.0.0.1:8899` — the wrong port for `solana-test-validator`, whose WebSocket listens on `8900`. Subscriptions silently failed to connect.

This patch routes derivation through an exact-string lookup table (`LOCAL_VALIDATOR_RPC_SUBSCRIPTIONS_URLS`) that maps the two canonical local validator URLs (`http://127.0.0.1:8899`, `http://localhost:8899`) to their matching `:8900` subs URLs. Every other URL falls through to the existing protocol swap, so user-customized validator setups are untouched. `solanaLocalRpc` and the deprecated `localhostRpc` reference the same constants so defaults can't drift from the lookup table.

Introduced in #201. Tracked in [DEV-489](https://linear.app/solana-fndn/issue/DEV-489).

cc @lorisleiva for review.

## Test plan

- [x] `pnpm test` in `packages/kit-plugin-rpc` (144 passed)
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] Verified live against running `solana-test-validator`: both `http://127.0.0.1:8899` and `http://localhost:8899` derive working subs URLs and receive `slotNotifications`
- [x] New unit tests pin: 8899→8900 rewrite for both `127.0.0.1` and `localhost`; `https://127.0.0.1:8899` left untouched (exact-string http only); non-default ports preserved; `mainnet(...)` derivation unchanged; deprecated `rpc()` factory exercises the same helper