### PR TITLE
Refactor plan executor to use `estimateResourceLimits` functions

### DIFF
--- a/.changeset/eager-coats-tie.md
+++ b/.changeset/eager-coats-tie.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-rpc': minor
+---
+
+Use Kit's resource limit estimation helpers in the RPC transaction planner and executor. In addition to the compute unit limit, the executor now estimates the loaded accounts data size limit for version 1 transactions, and the planner fills provisory resource limits accordingly. Behavior is unchanged for legacy and version 0 transactions.

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ yarn-error.log*
 test-ledger/
 target/
 CHANGELOG.md
+
+# LLM
+.claude/worktrees/

--- a/packages/kit-plugin-rpc/README.md
+++ b/packages/kit-plugin-rpc/README.md
@@ -222,7 +222,7 @@ const client = createClient()
 
 ## `rpcTransactionPlanner` plugin
 
-This plugin provides a default transaction planner that creates transaction messages with a fee payer, a provisory compute unit limit, and optional priority fees.
+This plugin provides a default transaction planner that creates transaction messages with a fee payer, provisory resource limits (a compute unit limit, plus a loaded accounts data size limit for version 1 transactions), and optional priority fees.
 
 ### Installation
 
@@ -256,7 +256,7 @@ All options are provided via a `TransactionPlannerConfig` object:
 
 ## `rpcTransactionPlanExecutor` plugin
 
-This plugin provides a default transaction plan executor that estimates compute units, signs, and sends transactions via RPC.
+This plugin provides a default transaction plan executor that estimates resource limits, signs, and sends transactions via RPC. Resource limit estimation covers the compute unit limit and, for version 1 transactions, the loaded accounts data size limit.
 
 ### Installation
 
@@ -286,20 +286,20 @@ const client = await createClient()
     const transactionPlanResult = await client.transactionPlanExecutor(myTransactionPlan);
     ```
 
-### Preflight and Compute Unit Estimation
+### Preflight and Resource Limit Estimation
 
-By default, the executor estimates compute units by simulating the transaction before sending it. When estimation is performed, preflight is skipped to avoid a redundant second simulation. When the transaction has an explicit compute unit limit (no estimation needed), preflight runs as the only simulation.
+By default, the executor estimates resource limits by simulating the transaction before sending it. This covers the compute unit limit and, for version 1 transactions, the loaded accounts data size limit. When estimation is performed, preflight is skipped to avoid a redundant second simulation. When every applicable resource limit is already explicitly set (no estimation needed), preflight runs as the only simulation.
 
 Setting `skipPreflight: true` changes the behavior:
 
 - Preflight is always skipped regardless of whether estimation was performed.
-- If the compute unit estimation simulation fails, the consumed units from the failed simulation are used to set the compute unit limit (with a 10% buffer) so the transaction still reaches the validator. This is useful for debugging failed transactions in an explorer.
+- If the resource limit estimation simulation fails, the consumed resources from the failed simulation are used to set the limits (with a 10% buffer on compute units) so the transaction still reaches the validator. This is useful for debugging failed transactions in an explorer.
 
-| Scenario            | `skipPreflight: false` (default) | `skipPreflight: true`           |
-| ------------------- | -------------------------------- | ------------------------------- |
-| Estimation succeeds | Set CU, skip preflight           | Set CU, skip preflight          |
-| Estimation fails    | Throw                            | Use consumed CU, skip preflight |
-| Explicit CU limit   | Run preflight                    | Skip preflight                  |
+| Scenario            | `skipPreflight: false` (default) | `skipPreflight: true`                  |
+| ------------------- | -------------------------------- | -------------------------------------- |
+| Estimation succeeds | Set limits, skip preflight       | Set limits, skip preflight             |
+| Estimation fails    | Throw                            | Use consumed resources, skip preflight |
+| Explicit limits set | Run preflight                    | Skip preflight                         |
 
 ## Deprecated plugins
 

--- a/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
+++ b/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
@@ -3,33 +3,32 @@ import {
     ClientWithRpc,
     ClientWithRpcSubscriptions,
     createTransactionPlanExecutor,
-    estimateComputeUnitLimitFactory,
+    estimateAndSetResourceLimitsFactory,
+    estimateResourceLimitsFactory,
     extendClient,
     GetEpochInfoApi,
     GetLatestBlockhashApi,
     GetSignatureStatusesApi,
-    getTransactionMessageComputeUnitLimit,
     isSolanaError,
     pipe,
+    ResourceLimitsEstimate,
     sendAndConfirmTransactionFactory,
     SendTransactionApi,
-    setTransactionMessageComputeUnitLimit,
     setTransactionMessageLifetimeUsingBlockhash,
     SignatureNotificationsApi,
     signTransactionMessageWithSigners,
     SimulateTransactionApi,
     SlotNotificationsApi,
-    SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
+    SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_RESOURCE_LIMITS,
     TransactionPlanExecutorConfig,
 } from '@solana/kit';
-
-const MAX_COMPUTE_UNIT_LIMIT = 1_400_000;
 
 /**
  * A plugin that provides a default transaction plan executor using RPC.
  *
- * The executor handles compute unit estimation, transaction signing, and
- * sending via RPC. A concurrency limit can be set to avoid hitting rate
+ * The executor handles resource limit estimation (compute units and, for
+ * version 1 transactions, the loaded accounts data size), transaction signing,
+ * and sending via RPC. A concurrency limit can be set to avoid hitting rate
  * limits when sending many transactions in parallel.
  *
  * @param config - Optional configuration for the executor.
@@ -58,16 +57,16 @@ export function rpcTransactionPlanExecutor(
         /**
          * Whether to skip the preflight simulation when sending transactions.
          *
-         * When `false` (default), preflight is skipped only if a compute unit
+         * When `false` (default), preflight is skipped only if a resource limit
          * estimation simulation was already performed for that transaction.
-         * If the transaction has an explicit compute unit limit (i.e. no
+         * If every applicable resource limit is already explicitly set (i.e. no
          * estimation was needed), preflight runs as the only simulation.
          *
          * When `true`, preflight is always skipped and the transaction is sent
-         * directly to the validator. Additionally, if the compute unit estimation
-         * simulation fails, the consumed units from the failed simulation are used
-         * to set the compute unit limit so the transaction still reaches the
-         * validator. This is useful for debugging failed transactions in an explorer.
+         * directly to the validator. Additionally, if the resource limit estimation
+         * simulation fails, the consumed resources from the failed simulation are
+         * used to set the limits so the transaction still reaches the validator.
+         * This is useful for debugging failed transactions in an explorer.
          *
          * Defaults to `false`.
          */
@@ -97,25 +96,29 @@ export function rpcTransactionPlanExecutor(
             rpc: client.rpc,
             rpcSubscriptions: client.rpcSubscriptions,
         });
-        const estimateCULimit = estimateComputeUnitLimitFactory({ rpc: client.rpc });
+        const estimateResourceLimits = estimateResourceLimitsFactory({ rpc: client.rpc });
+        const skipPreflight = config.skipPreflight ?? false;
 
         const transactionPlanExecutor = createTransactionPlanExecutor({
             executeTransactionMessage: limitFunction(async (context, transactionMessage, executorConfig) => {
-                const needsCuEstimation = needsComputeUnitEstimation(transactionMessage);
                 const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send(executorConfig);
+
+                // `estimateAndSetResourceLimits` only invokes our estimator when a
+                // resource limit actually needs estimating, so this flag tells us
+                // whether an estimation simulation was performed. When it was, we
+                // skip the redundant preflight simulation while sending.
+                let didSimulateToEstimate = false;
+                const estimateAndSetResourceLimits = estimateAndSetResourceLimitsFactory(
+                    bufferAndRecoverResourceLimits(estimateResourceLimits, skipPreflight, () => {
+                        didSimulateToEstimate = true;
+                    }),
+                );
+
                 const signedTransaction = await pipe(
                     transactionMessage,
                     tx => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
                     tx => (context.message = tx),
-                    async tx =>
-                        needsCuEstimation
-                            ? await estimateAndSetComputeUnitLimit(
-                                  tx,
-                                  estimateCULimit,
-                                  config.skipPreflight ?? false,
-                                  executorConfig,
-                              )
-                            : tx,
+                    async tx => await estimateAndSetResourceLimits(tx, executorConfig),
                     async tx => (context.message = await tx),
                     async tx => await signTransactionMessageWithSigners(await tx, executorConfig),
                     async tx => (context.transaction = await tx),
@@ -123,7 +126,7 @@ export function rpcTransactionPlanExecutor(
                 assertIsTransactionWithBlockhashLifetime(signedTransaction);
                 await sendAndConfirmTransaction(signedTransaction, {
                     commitment: 'confirmed',
-                    skipPreflight: config.skipPreflight || needsCuEstimation,
+                    skipPreflight: skipPreflight || didSimulateToEstimate,
                     ...executorConfig,
                 });
                 return signedTransaction;
@@ -135,66 +138,70 @@ export function rpcTransactionPlanExecutor(
 }
 
 /**
- * Checks whether a transaction message needs compute unit estimation.
+ * Wraps a resource limit estimator to add a 10% compute unit buffer and,
+ * optionally, recover from failed estimation simulations.
  *
- * Estimation is needed when the transaction has no `SetComputeUnitLimit`
- * instruction, or when it has a provisory (`0`) or maximum (`1,400,000`)
- * compute unit limit.
+ * The returned estimator is intended to be passed to
+ * {@link estimateAndSetResourceLimitsFactory}, which only calls it when a
+ * resource limit actually needs estimating. The `onSimulate` callback is
+ * therefore invoked exactly once an estimation simulation has been performed
+ * and we are proceeding to send (i.e. not on a non-recoverable failure).
  *
- * @param transactionMessage - The transaction message to check.
- * @returns `true` if the transaction needs compute unit estimation, `false` otherwise.
+ * A 10% buffer is applied to the compute unit limit only, to account for
+ * variations between simulation and execution.
+ *
+ * When `skipPreflight` is `true` and the estimation simulation fails, the
+ * consumed resources from the failed simulation are used so the transaction
+ * can still reach the validator for debugging purposes.
+ *
+ * @param estimateResourceLimits - The underlying estimator, typically created by
+ *   {@link estimateResourceLimitsFactory}.
+ * @param skipPreflight - Whether to recover from failed simulations using consumed resources.
+ * @param onSimulate - Called once a simulation has been performed and an estimate produced.
+ * @returns An estimator that applies a compute unit buffer and recovery behaviour.
  */
-function needsComputeUnitEstimation(
-    transactionMessage: Parameters<typeof getTransactionMessageComputeUnitLimit>[0],
-): boolean {
-    const computeUnitLimit = getTransactionMessageComputeUnitLimit(transactionMessage);
-    return !computeUnitLimit || computeUnitLimit === MAX_COMPUTE_UNIT_LIMIT;
-}
-
-/**
- * Estimates the compute unit limit for a transaction message via simulation
- * and sets the result on the message with a 10% buffer.
- *
- * When `skipPreflight` is `true` and the estimation simulation fails, the consumed
- * units from the failed simulation are used so the transaction can still reach the
- * validator for debugging purposes.
- *
- * @param transactionMessage - The transaction message to estimate and set the compute unit limit on.
- * @param estimateCULimit - A function that estimates the compute unit limit via simulation.
- * @param skipPreflight - Whether to recover from failed simulations using consumed units.
- * @param config - Optional configuration forwarded to the estimator (e.g. abort signal).
- * @returns The updated transaction message with the estimated compute unit limit.
- */
-async function estimateAndSetComputeUnitLimit<
-    TMessage extends Parameters<typeof setTransactionMessageComputeUnitLimit>[1],
->(
-    transactionMessage: TMessage,
-    estimateCULimit: (tx: TMessage, config?: { abortSignal?: AbortSignal }) => Promise<number>,
+function bufferAndRecoverResourceLimits(
+    estimateResourceLimits: ReturnType<typeof estimateResourceLimitsFactory>,
     skipPreflight: boolean,
-    config?: { abortSignal?: AbortSignal },
-) {
-    let estimatedUnits;
-    try {
-        estimatedUnits = await estimateCULimit(transactionMessage, config);
-    } catch (error) {
-        if (
-            skipPreflight &&
-            isSolanaError(error, SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT)
-        ) {
-            // Use consumed units from the failed simulation so the
-            // transaction can still reach the validator for debugging.
-            // The unitsConsumed field is a raw bigint from the RPC response,
-            // so we downcast it to a u32 number, capping at 4_294_967_295.
-            const bigintUnits = error.context.unitsConsumed ?? 0n;
-            estimatedUnits = bigintUnits > 4_294_967_295n ? 4_294_967_295 : Number(bigintUnits);
-        } else {
-            throw error;
+    onSimulate: () => void,
+): ReturnType<typeof estimateResourceLimitsFactory> {
+    return async (transactionMessage, config) => {
+        let estimate: ResourceLimitsEstimate<typeof transactionMessage>;
+        try {
+            estimate = await estimateResourceLimits(transactionMessage, config);
+        } catch (error) {
+            if (
+                skipPreflight &&
+                isSolanaError(error, SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_RESOURCE_LIMITS)
+            ) {
+                // Use the consumed resources from the failed simulation so the
+                // transaction can still reach the validator for debugging.
+                // The unitsConsumed field is a raw bigint from the RPC response,
+                // so we downcast it to a u32 number, capping at 4_294_967_295.
+                const bigintUnits = error.context.unitsConsumed ?? 0n;
+                const computeUnitLimit = bigintUnits > 4_294_967_295n ? 4_294_967_295 : Number(bigintUnits);
+                estimate = (
+                    error.context.loadedAccountsDataSize == null
+                        ? { computeUnitLimit }
+                        : { computeUnitLimit, loadedAccountsDataSizeLimit: error.context.loadedAccountsDataSize }
+                ) as ResourceLimitsEstimate<typeof transactionMessage>;
+            } else {
+                throw error;
+            }
         }
-    }
 
-    // Multiply the simulated limit by 1.1 to add a 10% buffer.
-    const units = Math.ceil(estimatedUnits * 1.1);
-    return setTransactionMessageComputeUnitLimit(units, transactionMessage);
+        // Reaching this point means a simulation was performed (either it
+        // succeeded, or it failed and we recovered from it) and we are
+        // proceeding to send, so signal it. A non-recoverable failure throws
+        // above and never gets here.
+        onSimulate();
+
+        // Multiply the estimated compute unit limit by 1.1 to add a 10% buffer.
+        return {
+            ...estimate,
+            computeUnitLimit: Math.ceil(estimate.computeUnitLimit * 1.1),
+        } as ResourceLimitsEstimate<typeof transactionMessage>;
+    };
 }
 
 /**

--- a/packages/kit-plugin-rpc/src/transaction-planner.ts
+++ b/packages/kit-plugin-rpc/src/transaction-planner.ts
@@ -3,7 +3,7 @@ import {
     createTransactionMessage,
     createTransactionPlanner,
     extendClient,
-    fillTransactionMessageProvisoryComputeUnitLimit,
+    fillTransactionMessageProvisoryResourceLimits,
     MicroLamports,
     pipe,
     setTransactionMessageComputeUnitPrice,
@@ -15,7 +15,8 @@ import {
  *
  * The planner creates transaction messages with:
  * - The configured fee payer.
- * - A provisory compute unit limit (to be estimated later by the executor).
+ * - Provisory resource limits (a compute unit limit, plus a loaded accounts data
+ *   size limit for version 1 transactions) to be estimated later by the executor.
  * - Optional priority fees.
  *
  * @param config - Optional configuration for the planner.
@@ -41,7 +42,7 @@ export function rpcTransactionPlanner(config: TransactionPlannerConfig = {}) {
                 return pipe(
                     createTransactionMessage({ version: config.version ?? 0 }),
                     tx => setTransactionMessageFeePayerSigner(client.payer, tx),
-                    tx => fillTransactionMessageProvisoryComputeUnitLimit(tx),
+                    tx => fillTransactionMessageProvisoryResourceLimits(tx),
                     tx =>
                         config.microLamportsPerComputeUnit
                             ? setTransactionMessageComputeUnitPrice(config.microLamportsPerComputeUnit, tx)

--- a/packages/kit-plugin-rpc/test/transaction-plan-executor.test.ts
+++ b/packages/kit-plugin-rpc/test/transaction-plan-executor.test.ts
@@ -10,6 +10,7 @@ import {
     sendAndConfirmTransactionFactory,
     setTransactionMessageComputeUnitLimit,
     setTransactionMessageFeePayerSigner,
+    setTransactionMessageLoadedAccountsDataSizeLimit,
     singleInstructionPlan,
     singleTransactionPlan,
     SingleTransactionPlanResult,
@@ -223,6 +224,139 @@ describe('rpcTransactionPlanExecutor', () => {
         expect(sendAndConfirmTransaction).toHaveBeenCalledExactlyOnceWith(expect.anything(), {
             commitment: 'confirmed',
             skipPreflight: true,
+        });
+    });
+
+    it('estimates the loaded accounts data size for version 1 transactions', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        // A version 1 transaction requires the simulation to return a loaded accounts data size.
+        const simulateTransaction = vi
+            .fn()
+            .mockResolvedValue({ value: { loadedAccountsDataSize: 5000, unitsConsumed: 42n } });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
+        (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
+
+        const client = createClient()
+            .use(() => ({ payer, rpc, rpcSubscriptions }))
+            .use(rpcTransactionPlanExecutor());
+
+        const txMessage = setTransactionMessageFeePayerSigner(
+            payer,
+            // @ts-expect-error Version 1 transaction messages work at runtime but are not yet in the public type.
+            createTransactionMessage({ version: 1 }),
+        );
+        await client.transactionPlanExecutor(singleTransactionPlan(txMessage));
+
+        // Estimation runs a single simulation, so preflight is skipped when sending.
+        expect(simulateTransaction).toHaveBeenCalledOnce();
+        expect(sendAndConfirmTransaction).toHaveBeenCalledExactlyOnceWith(expect.anything(), {
+            commitment: 'confirmed',
+            skipPreflight: true,
+        });
+    });
+
+    it('throws when a version 1 transaction simulation omits the loaded accounts data size', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        // The RPC omits `loadedAccountsDataSize`, which is required for version 1 transactions.
+        const simulateTransaction = vi.fn().mockResolvedValue({ value: { unitsConsumed: 42n } });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
+        (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
+
+        const client = createClient()
+            .use(() => ({ payer, rpc, rpcSubscriptions }))
+            // Even with skipPreflight, a missing data size cannot be recovered.
+            .use(rpcTransactionPlanExecutor({ skipPreflight: true }));
+
+        const txMessage = setTransactionMessageFeePayerSigner(
+            payer,
+            // @ts-expect-error Version 1 transaction messages work at runtime but are not yet in the public type.
+            createTransactionMessage({ version: 1 }),
+        );
+        const promise = client.transactionPlanExecutor(singleTransactionPlan(txMessage));
+
+        await expect(promise).rejects.toThrow();
+        expect(sendAndConfirmTransaction).not.toHaveBeenCalled();
+    });
+
+    it('recovers the loaded accounts data size for version 1 transactions when estimation fails and skipPreflight is true', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        // The estimation simulation fails, but still reports the consumed resources,
+        // including the loaded accounts data size required for version 1 transactions.
+        const simulateTransaction = vi.fn().mockResolvedValue({
+            value: { err: 'AccountNotFound', loadedAccountsDataSize: 5000, unitsConsumed: 200n },
+        });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
+        (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
+
+        const client = createClient()
+            .use(() => ({ payer, rpc, rpcSubscriptions }))
+            .use(rpcTransactionPlanExecutor({ skipPreflight: true }));
+
+        const txMessage = setTransactionMessageFeePayerSigner(
+            payer,
+            // @ts-expect-error Version 1 transaction messages work at runtime but are not yet in the public type.
+            createTransactionMessage({ version: 1 }),
+        );
+        await client.transactionPlanExecutor(singleTransactionPlan(txMessage));
+
+        // The recovered limits let the transaction reach the validator with preflight skipped.
+        expect(sendAndConfirmTransaction).toHaveBeenCalledExactlyOnceWith(expect.anything(), {
+            commitment: 'confirmed',
+            skipPreflight: true,
+        });
+    });
+
+    it('does not simulate when a version 1 transaction already has explicit resource limits', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        const simulateTransaction = vi.fn();
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
+        (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
+
+        const client = createClient()
+            .use(() => ({ payer, rpc, rpcSubscriptions }))
+            .use(rpcTransactionPlanExecutor());
+
+        // Both applicable resource limits are explicit, so no estimation is needed.
+        const txMessage = pipe(
+            // @ts-expect-error Version 1 transaction messages work at runtime but are not yet in the public type.
+            createTransactionMessage({ version: 1 }),
+            tx => setTransactionMessageFeePayerSigner(payer, tx),
+            tx => setTransactionMessageComputeUnitLimit(500, tx),
+            tx => setTransactionMessageLoadedAccountsDataSizeLimit(5000, tx),
+        );
+        await client.transactionPlanExecutor(singleTransactionPlan(txMessage));
+
+        // No simulation should have been performed.
+        expect(simulateTransaction).not.toHaveBeenCalled();
+
+        // Preflight should run as the only simulation.
+        expect(sendAndConfirmTransaction).toHaveBeenCalledExactlyOnceWith(expect.anything(), {
+            commitment: 'confirmed',
+            skipPreflight: false,
         });
     });
 


### PR DESCRIPTION
This PR refactors `kit-plugin-rpc` to use the `estimateResourceLimits` functions from Kit instead of the `estimateComputeUnitLimits` ones.

For legacy and v0 transactions the behavior is unchanged, these set compute unit limit exactly the same as the previous helpers. But for v1 transactions we now additionally estimate and set the `loadedAccountsDataSizeLimit` resource.

This will allow users of the default transaction planner/executor to send v1 transactions when those are enabled.

Note that `TransactionPlannerConfig.version` still not does include v1, as the Kit `createTransactionMessage` type doesn't. This is just preparatory for that version being available. 