### PR TITLE
Republish `@solana/kit-plugin-litesvm` with litesvm 1.2.0

### DIFF
--- a/.changeset/frank-clowns-reply.md
+++ b/.changeset/frank-clowns-reply.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-litesvm': patch
+---
+
+Require `litesvm@^1.2.0`. The underlying `litesvm` dependency was bumped from `1.1.0` to `1.2.0` without an accompanying changeset, so the `0.12.0` release left `@solana/kit-plugin-litesvm` behind at `0.10.0`. This republishes the package so the updated `litesvm` range reaches consumers.


### PR DESCRIPTION
This PR adds a missing changeset for `@solana/kit-plugin-litesvm`. The `litesvm` dependency was bumped from `1.1.0` to `1.2.0` in #282 without a changeset, so the `0.12.0` release left the plugin stranded at `0.10.0` while `@solana/kit-client-litesvm` was published at `0.12.0` pinned to the stale plugin. Adding this changeset brings the plugin back into the release set so it is republished with the `litesvm@^1.2.0` range, and the linked release group repoints the client to the updated plugin.