### PR TITLE
Raise `@solana/kit` peer dependency to ^6.10.0

### DIFF
--- a/.changeset/fiery-moments-return.md
+++ b/.changeset/fiery-moments-return.md
@@ -1,0 +1,13 @@
+---
+'@solana/kit-plugin-instruction-plan': patch
+'@solana/kit-client-litesvm': patch
+'@solana/kit-plugin-litesvm': patch
+'@solana/kit-plugin-airdrop': patch
+'@solana/kit-plugin-signer': patch
+'@solana/kit-client-rpc': patch
+'@solana/kit-plugin-payer': patch
+'@solana/kit-plugin-rpc': patch
+'@solana/kit-plugins': patch
+---
+
+Require `@solana/kit@^6.10.0`. The `@solana/kit` peer dependency range is raised from `^6.8.0` to `^6.10.0` to match `@solana/kit-plugin-wallet` and the version resolved across the workspace. This also corrects a latent incompatibility: `@solana/kit-plugin-payer` and `@solana/kit-plugin-rpc` import APIs (`ExtendedClient`, `estimateResourceLimitsFactory`) that were only introduced in `@solana/kit@6.10.0`, so the previous `^6.8.0` range understated their true requirement.

--- a/packages/kit-client-litesvm/package.json
+++ b/packages/kit-client-litesvm/package.json
@@ -57,7 +57,7 @@
         "@solana/kit-plugin-payer": "workspace:*"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.8.0"
+        "@solana/kit": "^6.10.0"
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-client-rpc/package.json
+++ b/packages/kit-client-rpc/package.json
@@ -57,7 +57,7 @@
         "@solana/kit-plugin-rpc": "workspace:*"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.8.0"
+        "@solana/kit": "^6.10.0"
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-plugin-airdrop/package.json
+++ b/packages/kit-plugin-airdrop/package.json
@@ -56,7 +56,7 @@
         "@solana/kit-plugin-rpc": "workspace:*"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.8.0"
+        "@solana/kit": "^6.10.0"
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-plugin-instruction-plan/package.json
+++ b/packages/kit-plugin-instruction-plan/package.json
@@ -53,7 +53,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.8.0"
+        "@solana/kit": "^6.10.0"
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-plugin-litesvm/package.json
+++ b/packages/kit-plugin-litesvm/package.json
@@ -59,7 +59,7 @@
         "@solana-program/system": "^0.12.2"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.8.0"
+        "@solana/kit": "^6.10.0"
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-plugin-payer/package.json
+++ b/packages/kit-plugin-payer/package.json
@@ -53,7 +53,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.8.0"
+        "@solana/kit": "^6.10.0"
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-plugin-rpc/package.json
+++ b/packages/kit-plugin-rpc/package.json
@@ -55,7 +55,7 @@
         "@solana/kit-plugin-instruction-plan": "workspace:*"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.8.0"
+        "@solana/kit": "^6.10.0"
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-plugin-signer/package.json
+++ b/packages/kit-plugin-signer/package.json
@@ -54,7 +54,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.8.0"
+        "@solana/kit": "^6.10.0"
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-plugins/package.json
+++ b/packages/kit-plugins/package.json
@@ -60,7 +60,7 @@
         "@solana/kit-plugin-rpc": "workspace:*"
     },
     "peerDependencies": {
-        "@solana/kit": "^6.8.0"
+        "@solana/kit": "^6.10.0"
     },
     "browserslist": [
         "supports bigint and not dead",


### PR DESCRIPTION
This PR raises the `@solana/kit` peer dependency range from `^6.8.0` to `^6.10.0` across the plugin and client packages, bringing them in line with `@solana/kit-plugin-wallet` (already on `^6.10.0`) and the version resolved throughout the workspace. Beyond consistency, it corrects a real latent incompatibility: `@solana/kit-plugin-payer` and `@solana/kit-plugin-rpc` import `ExtendedClient` and `estimateResourceLimitsFactory`, which were only introduced in `@solana/kit@6.10.0`, so their previous `^6.8.0` range understated the actual requirement and would fail to type-check for consumers on 6.8/6.9. `@solana/kit-plugin-wallet` is left untouched as it already declares the correct range.