### PR TITLE
Add React hooks subpath to `@solana/kit-plugin-wallet`

### DIFF
--- a/.changeset/sparkly-forks-wish.md
+++ b/.changeset/sparkly-forks-wish.md
@@ -1,0 +1,25 @@
+---
+'@solana/kit-plugin-wallet': minor
+---
+
+Add a `@solana/kit-plugin-wallet/react` subpath exposing React hooks for wallet state and actions. State hooks (`useWalletStatus`, `useConnectedWallet`, `useWallets`) subscribe to individual slices of `WalletState` via `useSyncExternalStore`; action hooks (`useConnect`, `useDisconnect`, `useSignIn`, `useSignMessage`, `useSelectAccount`) wrap the wallet actions. `react` and `@solana/react` are optional peer dependencies, so the default entry point is unchanged.
+
+```tsx
+import { useConnect, useConnectedWallet, useWallets, useWalletStatus } from '@solana/kit-plugin-wallet/react';
+
+function WalletButton() {
+    const status = useWalletStatus();
+    const wallets = useWallets();
+    const connected = useConnectedWallet();
+    const { dispatch: connect, isRunning } = useConnect();
+
+    if (status === 'pending') return null;
+    if (connected) return <p>Connected: {connected.account.address}</p>;
+
+    return wallets.map(wallet => (
+        <button key={wallet.name} disabled={isRunning} onClick={() => connect(wallet)}>
+            Connect {wallet.name}
+        </button>
+    ));
+}
+```

--- a/packages/kit-plugin-wallet/README.md
+++ b/packages/kit-plugin-wallet/README.md
@@ -169,11 +169,54 @@ All wallet state is accessed via `client.wallet.getState()`, which returns a ref
     const output = await client.wallet.signIn(selectedWallet, { domain: window.location.host });
     ```
 
+## React hooks
+
+The `@solana/kit-plugin-wallet/react` subpath exposes hooks for reading wallet state and driving wallet actions from React components. Install the optional peer dependencies (`react` and [`@solana/react`](https://www.npmjs.com/package/@solana/react)) and render your tree inside a `ClientProvider` whose client has a wallet plugin installed.
+
+The **state** hooks subscribe via `useSyncExternalStore`, each to a single slice of `WalletState`, so a component only re-renders when the slice it reads changes:
+
+| Hook                 | Returns                                                        |
+| -------------------- | -------------------------------------------------------------- |
+| `useWalletStatus`    | The current `WalletStatus`.                                    |
+| `useConnectedWallet` | The active connection (`{ account, signer, wallet }`) or null. |
+| `useWallets`         | The discovered wallets for the client's chain.                 |
+
+The **action** hooks wrap the async wallet actions with `useAction` from `@solana/react`, returning its result (`dispatch`, `dispatchAsync`, `data`, `error`, `status`, `isRunning`, `reset`, …). The hook manages the `AbortSignal` internally, so an in-flight call is aborted when a newer one is dispatched:
+
+| Hook               | Wraps                                                                     |
+| ------------------ | ------------------------------------------------------------------------- |
+| `useConnect`       | `client.wallet.connect` — `dispatch(wallet)`                              |
+| `useDisconnect`    | `client.wallet.disconnect` — `dispatch()`                                 |
+| `useSignIn`        | `client.wallet.signIn` — `dispatch(wallet, input)`                        |
+| `useSignMessage`   | `client.wallet.signMessage` — `dispatch(message)`                         |
+| `useSelectAccount` | `client.wallet.selectAccount` — returns the synchronous callback directly |
+
+```tsx
+import { useConnect, useConnectedWallet, useWallets, useWalletStatus } from '@solana/kit-plugin-wallet/react';
+
+function WalletButton() {
+    const status = useWalletStatus();
+    const wallets = useWallets();
+    const connected = useConnectedWallet();
+    const { dispatch: connect, isRunning } = useConnect();
+
+    if (status === 'pending') return null; // avoid flashing UI before auto-reconnect resolves
+
+    if (connected) return <p>Connected: {connected.account.address}</p>;
+
+    return wallets.map(wallet => (
+        <button key={wallet.name} disabled={isRunning} onClick={() => connect(wallet)}>
+            Connect {wallet.name}
+        </button>
+    ));
+}
+```
+
 ## Framework integration
 
 The plugin exposes `subscribe` and `getState` for binding wallet state to any UI framework.
 
-**React** — use `useSyncExternalStore` for concurrent-mode-safe rendering:
+**React** — prefer the ready-made [React hooks](#react-hooks) above; they wrap the pattern below. To bind state manually (e.g. to read the whole snapshot at once), use `useSyncExternalStore` for concurrent-mode-safe rendering:
 
 ```tsx
 import { useSyncExternalStore } from 'react';

--- a/packages/kit-plugin-wallet/package.json
+++ b/packages/kit-plugin-wallet/package.json
@@ -22,6 +22,7 @@
     "files": [
         "./dist/types",
         "./dist/index.*",
+        "./dist/react/index.*",
         "./src/"
     ],
     "type": "commonjs",
@@ -35,22 +36,36 @@
     "types": "./dist/types/index.d.ts",
     "react-native": "./dist/index.react-native.mjs",
     "exports": {
-        "types": "./dist/types/index.d.ts",
-        "react-native": "./dist/index.react-native.mjs",
-        "browser": {
-            "import": "./dist/index.browser.mjs",
-            "require": "./dist/index.browser.cjs"
+        ".": {
+            "types": "./dist/types/index.d.ts",
+            "react-native": "./dist/index.react-native.mjs",
+            "browser": {
+                "import": "./dist/index.browser.mjs",
+                "require": "./dist/index.browser.cjs"
+            },
+            "node": {
+                "import": "./dist/index.node.mjs",
+                "require": "./dist/index.node.cjs"
+            }
         },
-        "node": {
-            "import": "./dist/index.node.mjs",
-            "require": "./dist/index.node.cjs"
+        "./react": {
+            "types": "./dist/types/react/index.d.ts",
+            "react-native": "./dist/react/index.react-native.mjs",
+            "browser": {
+                "import": "./dist/react/index.browser.mjs",
+                "require": "./dist/react/index.browser.cjs"
+            },
+            "node": {
+                "import": "./dist/react/index.node.mjs",
+                "require": "./dist/react/index.node.cjs"
+            }
         }
     },
     "scripts": {
         "build": "rimraf dist && tsup && tsc -p ./tsconfig.declarations.json",
         "dev": "vitest --project node",
         "test": "pnpm test:types && pnpm test:treeshakability && pnpm test:unit",
-        "test:treeshakability": "for file in dist/index.*.mjs; do agadoo $file; done",
+        "test:treeshakability": "for file in dist/index.*.mjs dist/react/index.*.mjs; do agadoo $file; done",
         "test:types": "tsc --noEmit",
         "test:unit": "vitest run"
     },
@@ -66,10 +81,25 @@
         "@wallet-standard/ui-registry": "^1.1.1"
     },
     "devDependencies": {
-        "@wallet-standard/errors": "^0.1.2"
+        "@solana/react": "^7.0.0",
+        "@testing-library/react": "^16.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@wallet-standard/errors": "^0.1.2",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
     },
     "peerDependencies": {
-        "@solana/kit": "^7.0.0"
+        "@solana/kit": "^7.0.0",
+        "@solana/react": "^7.0.0",
+        "react": ">=18"
+    },
+    "peerDependenciesMeta": {
+        "@solana/react": {
+            "optional": true
+        },
+        "react": {
+            "optional": true
+        }
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-plugin-wallet/src/react/__typetests__/index.ts
+++ b/packages/kit-plugin-wallet/src/react/__typetests__/index.ts
@@ -1,0 +1,77 @@
+import type { SignatureBytes } from '@solana/kit';
+import type { SolanaSignInInput, SolanaSignInOutput } from '@solana/wallet-standard-features';
+import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui';
+
+import type { WalletState, WalletStatus } from '../../types';
+import {
+    useConnect,
+    useConnectedWallet,
+    useDisconnect,
+    useSelectAccount,
+    useSignIn,
+    useSignMessage,
+    useWallets,
+    useWalletStatus,
+} from '../index';
+
+// NB: hooks are only type-checked here, never executed.
+
+// [DESCRIBE] useWalletStatus
+{
+    const status = useWalletStatus();
+    status satisfies WalletStatus;
+}
+
+// [DESCRIBE] useConnectedWallet
+{
+    const connected = useConnectedWallet();
+    connected satisfies WalletState['connected'];
+    // The connection is nullable when disconnected.
+    connected satisfies { account: UiWalletAccount } | null;
+}
+
+// [DESCRIBE] useWallets
+{
+    const wallets = useWallets();
+    wallets satisfies readonly UiWallet[];
+}
+
+// [DESCRIBE] useConnect
+{
+    const action = useConnect();
+    action.dispatch(null as unknown as UiWallet);
+    action.data satisfies readonly UiWalletAccount[] | undefined;
+    // @ts-expect-error dispatch requires the wallet argument.
+    action.dispatch();
+}
+
+// [DESCRIBE] useDisconnect
+{
+    const action = useDisconnect();
+    action.dispatch();
+    action.data satisfies void | undefined;
+}
+
+// [DESCRIBE] useSignIn
+{
+    const action = useSignIn();
+    action.dispatch(null as unknown as UiWallet, null as unknown as SolanaSignInInput);
+    action.data satisfies SolanaSignInOutput | undefined;
+    // @ts-expect-error dispatch requires both the wallet and the sign-in input.
+    action.dispatch(null as unknown as UiWallet);
+}
+
+// [DESCRIBE] useSignMessage
+{
+    const action = useSignMessage();
+    action.dispatch(new Uint8Array());
+    action.data satisfies SignatureBytes | undefined;
+}
+
+// [DESCRIBE] useSelectAccount
+{
+    const selectAccount = useSelectAccount();
+    selectAccount(null as unknown as UiWalletAccount) satisfies void;
+    // @ts-expect-error selectAccount requires the account argument.
+    selectAccount();
+}

--- a/packages/kit-plugin-wallet/src/react/index.ts
+++ b/packages/kit-plugin-wallet/src/react/index.ts
@@ -1,0 +1,214 @@
+import type { SignatureBytes } from '@solana/kit';
+import { type ActionResult, useAction, useClientCapability } from '@solana/react';
+import type { SolanaSignInInput, SolanaSignInOutput } from '@solana/wallet-standard-features';
+import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui';
+import { useSyncExternalStore } from 'react';
+
+import type { ClientWithWallet, WalletNamespace, WalletState, WalletStatus } from '../types';
+
+/**
+ * Reads the wallet namespace from the nearest `ClientProvider`, asserting at mount that a wallet
+ * plugin is installed. Shared by every hook in this module so the capability check, error hook
+ * name, and provider hint stay in one place.
+ */
+function useWalletNamespace(hookName: string): WalletNamespace {
+    return useClientCapability<ClientWithWallet>({
+        capability: 'wallet',
+        hookName,
+        providerHint: 'Install a wallet plugin on the client, e.g. `walletSigner()`.',
+    }).wallet;
+}
+
+// -- State hooks ------------------------------------------------------------
+
+/**
+ * Subscribes to the wallet connection status from a React component.
+ *
+ * Wraps `client.wallet.subscribe` / `getState` with `useSyncExternalStore`, re-rendering only when
+ * the status changes. Requires a `ClientProvider` whose client has a wallet plugin installed;
+ * asserts this at mount with {@link useClientCapability}.
+ *
+ * @returns The current {@link WalletStatus} (`'pending'` on the server and in React Native).
+ *
+ * @example
+ * ```tsx
+ * const status = useWalletStatus();
+ * if (status === 'pending') return null; // avoid flashing UI before auto-reconnect resolves
+ * ```
+ *
+ * @see {@link useConnectedWallet}
+ * @see {@link useWallets}
+ */
+export function useWalletStatus(): WalletStatus {
+    const wallet = useWalletNamespace('useWalletStatus');
+    const getStatus = () => wallet.getState().status;
+    return useSyncExternalStore(wallet.subscribe, getStatus, getStatus);
+}
+
+/**
+ * Subscribes to the active wallet connection from a React component.
+ *
+ * Wraps `client.wallet.subscribe` / `getState` with `useSyncExternalStore`, re-rendering only when
+ * the connection changes (connect, disconnect, or account switch). Requires a `ClientProvider`
+ * whose client has a wallet plugin installed; asserts this at mount with {@link useClientCapability}.
+ *
+ * @returns The active connection — `{ account, signer, wallet }` — or `null` when disconnected.
+ *   `signer` is `null` for read-only wallets.
+ *
+ * @example
+ * ```tsx
+ * const connected = useConnectedWallet();
+ * return connected ? <p>{connected.account.address}</p> : <p>Not connected</p>;
+ * ```
+ *
+ * @see {@link useWalletStatus}
+ * @see {@link useWallets}
+ */
+export function useConnectedWallet(): WalletState['connected'] {
+    const wallet = useWalletNamespace('useConnectedWallet');
+    const getConnected = () => wallet.getState().connected;
+    return useSyncExternalStore(wallet.subscribe, getConnected, getConnected);
+}
+
+/**
+ * Subscribes to the list of discovered wallets from a React component.
+ *
+ * Wraps `client.wallet.subscribe` / `getState` with `useSyncExternalStore`, re-rendering only when
+ * the discovered-wallet list changes. Requires a `ClientProvider` whose client has a wallet plugin
+ * installed; asserts this at mount with {@link useClientCapability}.
+ *
+ * @returns All discovered wallets matching the client's configured chain and filter (empty on the
+ *   server and in React Native).
+ *
+ * @example
+ * ```tsx
+ * const wallets = useWallets();
+ * const connect = useConnect();
+ * return wallets.map(w => <button key={w.name} onClick={() => connect.dispatch(w)}>{w.name}</button>);
+ * ```
+ *
+ * @see {@link useWalletStatus}
+ * @see {@link useConnectedWallet}
+ */
+export function useWallets(): readonly UiWallet[] {
+    const wallet = useWalletNamespace('useWallets');
+    const getWallets = () => wallet.getState().wallets;
+    return useSyncExternalStore(wallet.subscribe, getWallets, getWallets);
+}
+
+// -- Action hooks -----------------------------------------------------------
+
+/**
+ * Connects to a wallet from a React component.
+ *
+ * Wraps `client.wallet.connect` with {@link useAction}. Requires a `ClientProvider` whose client
+ * has a wallet plugin installed; asserts this at mount with {@link useClientCapability}. The hook
+ * owns the `AbortSignal`, so an in-flight connect is aborted when a newer one is dispatched.
+ *
+ * `dispatch`/`dispatchAsync` take the {@link UiWallet} to connect to and resolve with the wallet's
+ * accounts once connected.
+ *
+ * @example
+ * ```tsx
+ * const { dispatch, isRunning } = useConnect();
+ * <button disabled={isRunning} onClick={() => dispatch(wallet)}>Connect</button>
+ * ```
+ *
+ * @see {@link useDisconnect}
+ * @see {@link useSignIn}
+ */
+export function useConnect(): ActionResult<[wallet: UiWallet], readonly UiWalletAccount[]> {
+    const wallet = useWalletNamespace('useConnect');
+    return useAction((abortSignal, uiWallet: UiWallet) => wallet.connect(uiWallet, { abortSignal }));
+}
+
+/**
+ * Disconnects the active wallet from a React component.
+ *
+ * Wraps `client.wallet.disconnect` with {@link useAction}. Requires a `ClientProvider` whose client
+ * has a wallet plugin installed; asserts this at mount with {@link useClientCapability}.
+ *
+ * `dispatch`/`dispatchAsync` take no arguments.
+ *
+ * @example
+ * ```tsx
+ * const { dispatch, isRunning } = useDisconnect();
+ * <button disabled={isRunning} onClick={() => dispatch()}>Disconnect</button>
+ * ```
+ *
+ * @see {@link useConnect}
+ */
+export function useDisconnect(): ActionResult<[], void> {
+    const wallet = useWalletNamespace('useDisconnect');
+    return useAction(abortSignal => wallet.disconnect({ abortSignal }));
+}
+
+/**
+ * Signs in with a wallet (Sign In With Solana) from a React component.
+ *
+ * Wraps `client.wallet.signIn` with {@link useAction}. Requires a `ClientProvider` whose client has
+ * a wallet plugin installed; asserts this at mount with {@link useClientCapability}. Like
+ * {@link useConnect}, this establishes a full connection; the hook owns the `AbortSignal`, so an
+ * in-flight sign-in is aborted when a newer one is dispatched.
+ *
+ * `dispatch`/`dispatchAsync` take the {@link UiWallet} and a `SolanaSignInInput` (pass `{}` for no
+ * customization) and resolve with the wallet's sign-in output.
+ *
+ * @example
+ * ```tsx
+ * const { dispatch } = useSignIn();
+ * dispatch(wallet, { domain: window.location.host });
+ * ```
+ *
+ * @see {@link useConnect}
+ */
+export function useSignIn(): ActionResult<[wallet: UiWallet, input: SolanaSignInInput], SolanaSignInOutput> {
+    const wallet = useWalletNamespace('useSignIn');
+    return useAction((abortSignal, uiWallet: UiWallet, input: SolanaSignInInput) =>
+        wallet.signIn(uiWallet, input, { abortSignal }),
+    );
+}
+
+/**
+ * Signs an arbitrary message with the connected account from a React component.
+ *
+ * Wraps `client.wallet.signMessage` with {@link useAction}. Requires a `ClientProvider` whose
+ * client has a wallet plugin installed; asserts this at mount with {@link useClientCapability}. The
+ * hook owns the `AbortSignal`, so an in-flight signature request is aborted when a newer one is
+ * dispatched.
+ *
+ * `dispatch`/`dispatchAsync` take the message bytes and resolve with the signature.
+ *
+ * @example
+ * ```tsx
+ * const { dispatch } = useSignMessage();
+ * dispatch(new TextEncoder().encode('Hello'));
+ * ```
+ */
+export function useSignMessage(): ActionResult<[message: Uint8Array], SignatureBytes> {
+    const wallet = useWalletNamespace('useSignMessage');
+    return useAction((abortSignal, message: Uint8Array) => wallet.signMessage(message, { abortSignal }));
+}
+
+/**
+ * Returns a callback that switches to a different account within the connected wallet.
+ *
+ * Requires a `ClientProvider` whose client has a wallet plugin installed; asserts this at mount
+ * with {@link useClientCapability}. Unlike the other action hooks, `selectAccount` is synchronous —
+ * this hook returns the bound function directly rather than an `ActionResult`. The returned
+ * reference is stable across renders.
+ *
+ * @returns The `selectAccount` function — call it with a {@link UiWalletAccount} belonging to the
+ *   connected wallet. It throws if no wallet is connected or the account is not available.
+ *
+ * @example
+ * ```tsx
+ * const selectAccount = useSelectAccount();
+ * <button onClick={() => selectAccount(account)}>Use this account</button>
+ * ```
+ *
+ * @see {@link useConnectedWallet}
+ */
+export function useSelectAccount(): WalletNamespace['selectAccount'] {
+    return useWalletNamespace('useSelectAccount').selectAccount;
+}

--- a/packages/kit-plugin-wallet/test/useWalletActions.react.test.tsx
+++ b/packages/kit-plugin-wallet/test/useWalletActions.react.test.tsx
@@ -1,0 +1,111 @@
+import { ClientProvider } from '@solana/react';
+import { renderHook } from '@testing-library/react';
+import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui';
+import { createElement, type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useConnect, useDisconnect, useSelectAccount, useSignIn, useSignMessage } from '../src/react';
+
+function wrapperFor(wallet: object) {
+    return ({ children }: { children: ReactNode }) =>
+        createElement(ClientProvider, { client: { wallet } as never }, children);
+}
+
+const uiWallet = {} as UiWallet;
+const account = {} as UiWalletAccount;
+
+describe('useConnect', () => {
+    it('throws at mount when the client lacks a wallet namespace', () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+        expect(() =>
+            renderHook(() => useConnect(), {
+                wrapper: ({ children }) => createElement(ClientProvider, { client: {} as never }, children),
+            }),
+        ).toThrow(/useConnect/);
+        consoleError.mockRestore();
+    });
+
+    it('dispatches connect with the wallet and a threaded abort signal, returning its result', async () => {
+        const accounts = [account];
+        const connect = vi.fn().mockResolvedValue(accounts);
+        const { result: hook } = renderHook(() => useConnect(), { wrapper: wrapperFor({ connect }) });
+
+        const returned = await hook.current.dispatchAsync(uiWallet);
+
+        expect(returned).toBe(accounts);
+        expect(connect).toHaveBeenCalledWith(
+            uiWallet,
+            expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
+        );
+    });
+
+    it('surfaces a rejecting connect via the returned promise', async () => {
+        const error = new Error('declined');
+        const connect = vi.fn().mockRejectedValue(error);
+        const { result: hook } = renderHook(() => useConnect(), { wrapper: wrapperFor({ connect }) });
+
+        await expect(hook.current.dispatchAsync(uiWallet)).rejects.toBe(error);
+    });
+});
+
+describe('useDisconnect', () => {
+    it('dispatches disconnect with a threaded abort signal', async () => {
+        const disconnect = vi.fn().mockResolvedValue(undefined);
+        const { result: hook } = renderHook(() => useDisconnect(), { wrapper: wrapperFor({ disconnect }) });
+
+        await hook.current.dispatchAsync();
+
+        expect(disconnect).toHaveBeenCalledWith(expect.objectContaining({ abortSignal: expect.any(AbortSignal) }));
+    });
+});
+
+describe('useSignIn', () => {
+    it('dispatches signIn with the wallet, input, and a threaded abort signal', async () => {
+        const output = { account: {} };
+        const signIn = vi.fn().mockResolvedValue(output);
+        const { result: hook } = renderHook(() => useSignIn(), { wrapper: wrapperFor({ signIn }) });
+
+        const input = { domain: 'example.com' };
+        const returned = await hook.current.dispatchAsync(uiWallet, input);
+
+        expect(returned).toBe(output);
+        expect(signIn).toHaveBeenCalledWith(
+            uiWallet,
+            input,
+            expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
+        );
+    });
+});
+
+describe('useSignMessage', () => {
+    it('dispatches signMessage with the message and a threaded abort signal', async () => {
+        const signature = new Uint8Array(64);
+        const signMessage = vi.fn().mockResolvedValue(signature);
+        const { result: hook } = renderHook(() => useSignMessage(), { wrapper: wrapperFor({ signMessage }) });
+
+        const message = new TextEncoder().encode('Hello');
+        const returned = await hook.current.dispatchAsync(message);
+
+        expect(returned).toBe(signature);
+        expect(signMessage).toHaveBeenCalledWith(
+            message,
+            expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
+        );
+    });
+});
+
+describe('useSelectAccount', () => {
+    it('returns a callback that forwards to the client, stable across renders', () => {
+        const selectAccount = vi.fn();
+        const { result: hook, rerender } = renderHook(() => useSelectAccount(), {
+            wrapper: wrapperFor({ selectAccount }),
+        });
+
+        const first = hook.current;
+        first(account);
+        expect(selectAccount).toHaveBeenCalledWith(account);
+
+        rerender();
+        expect(hook.current).toBe(first);
+    });
+});

--- a/packages/kit-plugin-wallet/test/useWalletState.react.test.tsx
+++ b/packages/kit-plugin-wallet/test/useWalletState.react.test.tsx
@@ -1,0 +1,83 @@
+import { ClientProvider } from '@solana/react';
+import { act, renderHook } from '@testing-library/react';
+import type { UiWallet } from '@wallet-standard/ui';
+import { createElement, type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useConnectedWallet, useWallets, useWalletStatus } from '../src/react';
+import type { WalletState } from '../src/types';
+
+/**
+ * A minimal referentially-stable wallet store, mirroring the plugin's contract: `getState` returns
+ * the same object until `setState` replaces it, and `subscribe` notifies listeners on change.
+ */
+function createFakeStore(initial: WalletState) {
+    let state = initial;
+    const listeners = new Set<() => void>();
+    return {
+        getState: () => state,
+        setState(next: WalletState) {
+            state = next;
+            listeners.forEach(l => l());
+        },
+        subscribe(listener: () => void) {
+            listeners.add(listener);
+            return () => listeners.delete(listener);
+        },
+    };
+}
+
+function wrapperFor(wallet: object) {
+    return ({ children }: { children: ReactNode }) =>
+        createElement(ClientProvider, { client: { wallet } as never }, children);
+}
+
+const INITIAL: WalletState = { connected: null, status: 'disconnected', wallets: [] };
+
+describe('useWalletStatus', () => {
+    it('throws at mount when the client lacks a wallet namespace', () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+        expect(() =>
+            renderHook(() => useWalletStatus(), {
+                wrapper: ({ children }) => createElement(ClientProvider, { client: {} as never }, children),
+            }),
+        ).toThrow(/useWalletStatus/);
+        consoleError.mockRestore();
+    });
+
+    it('returns the current status and updates when it changes', () => {
+        const store = createFakeStore(INITIAL);
+        const { result } = renderHook(() => useWalletStatus(), { wrapper: wrapperFor(store) });
+
+        expect(result.current).toBe('disconnected');
+
+        act(() => store.setState({ ...INITIAL, status: 'connecting' }));
+        expect(result.current).toBe('connecting');
+    });
+});
+
+describe('useConnectedWallet', () => {
+    it('returns the active connection and updates when it changes', () => {
+        const store = createFakeStore(INITIAL);
+        const { result } = renderHook(() => useConnectedWallet(), { wrapper: wrapperFor(store) });
+
+        expect(result.current).toBeNull();
+
+        const connected = { account: {}, signer: null, wallet: {} } as WalletState['connected'];
+        act(() => store.setState({ ...INITIAL, connected, status: 'connected' }));
+        expect(result.current).toBe(connected);
+    });
+});
+
+describe('useWallets', () => {
+    it('returns the discovered wallets and updates when the list changes', () => {
+        const store = createFakeStore(INITIAL);
+        const { result } = renderHook(() => useWallets(), { wrapper: wrapperFor(store) });
+
+        expect(result.current).toEqual([]);
+
+        const wallets = [{} as UiWallet];
+        act(() => store.setState({ ...INITIAL, wallets }));
+        expect(result.current).toBe(wallets);
+    });
+});

--- a/packages/kit-plugin-wallet/tsconfig.declarations.json
+++ b/packages/kit-plugin-wallet/tsconfig.declarations.json
@@ -7,5 +7,5 @@
         "rootDir": "./src"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["src/index.ts", "src/react/index.ts", "src/types"]
 }

--- a/packages/kit-plugin-wallet/tsup.config.ts
+++ b/packages/kit-plugin-wallet/tsup.config.ts
@@ -2,4 +2,4 @@ import { defineConfig } from 'tsup';
 
 import { getPackageBuildConfigs } from '../../tsup.config.base';
 
-export default defineConfig(getPackageBuildConfigs());
+export default defineConfig(getPackageBuildConfigs({ entry: ['./src/index.ts', './src/react/index.ts'] }));

--- a/packages/kit-plugin-wallet/vitest.config.mts
+++ b/packages/kit-plugin-wallet/vitest.config.mts
@@ -1,4 +1,4 @@
-import { defineConfig, mergeConfig } from 'vitest/config';
+import { configDefaults, defineConfig, mergeConfig } from 'vitest/config';
 
 import { getVitestConfig } from '../../vitest.config.base.mjs';
 
@@ -10,12 +10,16 @@ function withWalletMocks(config: ReturnType<typeof getVitestConfig>) {
     });
 }
 
+// React hook tests need a DOM (`renderHook` → `react-dom`), so they run only in the browser
+// (happy-dom) project and are excluded from the node and react-native projects.
+const excludeReactTests = { test: { exclude: [...configDefaults.exclude, '**/*.react.test.tsx'] } };
+
 export default defineConfig({
     test: {
         projects: [
             withWalletMocks(getVitestConfig('browser')),
-            withWalletMocks(getVitestConfig('node')),
-            withWalletMocks(getVitestConfig('react-native')),
+            mergeConfig(withWalletMocks(getVitestConfig('node')), excludeReactTests),
+            mergeConfig(withWalletMocks(getVitestConfig('react-native')), excludeReactTests),
         ],
     },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,9 +228,24 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
     devDependencies:
+      '@solana/react':
+        specifier: ^7.0.0
+        version: 7.0.0(@solana/kit@7.0.0(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+      '@testing-library/react':
+        specifier: ^16.0.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react':
+        specifier: ^18.0.0 || ^19.0.0
+        version: 19.2.17
       '@wallet-standard/errors':
         specifier: ^0.1.2
         version: 0.1.2
+      react:
+        specifier: ^18.0.0 || ^19.0.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^18.0.0 || ^19.0.0
+        version: 19.2.7(react@19.2.7)
 
   packages/kit-plugins:
     dependencies:


### PR DESCRIPTION
This PR adds react hooks to the wallet plugin.

Includes three hooks that expose the wallet state using `useSyncExternalStore`, each exposing one of the three pieces of state. `useWalletStatus`, `useConnectedWallet`, and `useWallets`. These are separate hooks because they change independently and will have different re-render cadence. You can still use `useSyncExternalStore(client.wallet.subscribe, client.wallet.getState)` to subscribe to the whole state, but there isn't a specific hook for this.

Also includes four new action hooks, which are all just simple wrappers around wallet plugin functions: `useConnect`, `useDisconnect`, `useSignIn` and `useSignMessage`. A hook is also provided for `useSelectAccount`, which is just a synchronous callback.