### PR TITLE
Add React hooks to `@solana/kit-plugin-wallet`

### DIFF
--- a/.changeset/sparkly-forks-wish.md
+++ b/.changeset/sparkly-forks-wish.md
@@ -1,0 +1,25 @@
+---
+'@solana/kit-plugin-wallet': minor
+---
+
+Add a `@solana/kit-plugin-wallet/react` subpath exposing React hooks for wallet state and actions. State hooks (`useWalletStatus`, `useConnectedWallet`, `useWallets`) subscribe to individual slices of `WalletState` via `useSyncExternalStore`; action hooks (`useConnect`, `useDisconnect`, `useSignIn`, `useSignMessage`, `useSelectAccount`) wrap the wallet actions. `react` and `@solana/react` are optional peer dependencies, so the default entry point is unchanged.
+
+```tsx
+import { useConnect, useConnectedWallet, useWallets, useWalletStatus } from '@solana/kit-plugin-wallet/react';
+
+function WalletButton() {
+    const status = useWalletStatus();
+    const wallets = useWallets();
+    const connected = useConnectedWallet();
+    const { dispatch: connect, isRunning } = useConnect();
+
+    if (status === 'pending') return null;
+    if (connected) return <p>Connected: {connected.account.address}</p>;
+
+    return wallets.map(wallet => (
+        <button key={wallet.name} disabled={isRunning} onClick={() => connect(wallet)}>
+            Connect {wallet.name}
+        </button>
+    ));
+}
+```

--- a/packages/kit-plugin-wallet/README.md
+++ b/packages/kit-plugin-wallet/README.md
@@ -169,11 +169,54 @@ All wallet state is accessed via `client.wallet.getState()`, which returns a ref
     const output = await client.wallet.signIn(selectedWallet, { domain: window.location.host });
     ```
 
+## React hooks
+
+The `@solana/kit-plugin-wallet/react` subpath exposes hooks for reading wallet state and driving wallet actions from React components. Install the optional peer dependencies (`react` and [`@solana/react`](https://www.npmjs.com/package/@solana/react)) and render your tree inside a `ClientProvider` whose client has a wallet plugin installed.
+
+The **state** hooks subscribe via `useSyncExternalStore`, each to a single slice of `WalletState`, so a component only re-renders when the slice it reads changes:
+
+| Hook                 | Returns                                                        |
+| -------------------- | -------------------------------------------------------------- |
+| `useWalletStatus`    | The current `WalletStatus`.                                    |
+| `useConnectedWallet` | The active connection (`{ account, signer, wallet }`) or null. |
+| `useWallets`         | The discovered wallets for the client's chain.                 |
+
+The **action** hooks wrap the async wallet actions with `useAction` from `@solana/react`, returning its result (`dispatch`, `dispatchAsync`, `data`, `error`, `status`, `isRunning`, `reset`, …). The hook manages the `AbortSignal` internally, so an in-flight call is aborted when a newer one is dispatched:
+
+| Hook               | Wraps                                                                     |
+| ------------------ | ------------------------------------------------------------------------- |
+| `useConnect`       | `client.wallet.connect` — `dispatch(wallet)`                              |
+| `useDisconnect`    | `client.wallet.disconnect` — `dispatch()`                                 |
+| `useSignIn`        | `client.wallet.signIn` — `dispatch(wallet, input)`                        |
+| `useSignMessage`   | `client.wallet.signMessage` — `dispatch(message)`                         |
+| `useSelectAccount` | `client.wallet.selectAccount` — returns the synchronous callback directly |
+
+```tsx
+import { useConnect, useConnectedWallet, useWallets, useWalletStatus } from '@solana/kit-plugin-wallet/react';
+
+function WalletButton() {
+    const status = useWalletStatus();
+    const wallets = useWallets();
+    const connected = useConnectedWallet();
+    const { dispatch: connect, isRunning } = useConnect();
+
+    if (status === 'pending') return null; // avoid flashing UI before auto-reconnect resolves
+
+    if (connected) return <p>Connected: {connected.account.address}</p>;
+
+    return wallets.map(wallet => (
+        <button key={wallet.name} disabled={isRunning} onClick={() => connect(wallet)}>
+            Connect {wallet.name}
+        </button>
+    ));
+}
+```
+
 ## Framework integration
 
 The plugin exposes `subscribe` and `getState` for binding wallet state to any UI framework.
 
-**React** — use `useSyncExternalStore` for concurrent-mode-safe rendering:
+**React** — prefer the ready-made [React hooks](#react-hooks) above; they wrap the pattern below. To bind state manually (e.g. to read the whole snapshot at once), use `useSyncExternalStore` for concurrent-mode-safe rendering:
 
 ```tsx
 import { useSyncExternalStore } from 'react';

--- a/packages/kit-plugin-wallet/package.json
+++ b/packages/kit-plugin-wallet/package.json
@@ -22,6 +22,7 @@
     "files": [
         "./dist/types",
         "./dist/index.*",
+        "./dist/react/index.*",
         "./src/"
     ],
     "type": "commonjs",
@@ -35,22 +36,36 @@
     "types": "./dist/types/index.d.ts",
     "react-native": "./dist/index.react-native.mjs",
     "exports": {
-        "types": "./dist/types/index.d.ts",
-        "react-native": "./dist/index.react-native.mjs",
-        "browser": {
-            "import": "./dist/index.browser.mjs",
-            "require": "./dist/index.browser.cjs"
+        ".": {
+            "types": "./dist/types/index.d.ts",
+            "react-native": "./dist/index.react-native.mjs",
+            "browser": {
+                "import": "./dist/index.browser.mjs",
+                "require": "./dist/index.browser.cjs"
+            },
+            "node": {
+                "import": "./dist/index.node.mjs",
+                "require": "./dist/index.node.cjs"
+            }
         },
-        "node": {
-            "import": "./dist/index.node.mjs",
-            "require": "./dist/index.node.cjs"
+        "./react": {
+            "types": "./dist/types/react/index.d.ts",
+            "react-native": "./dist/react/index.react-native.mjs",
+            "browser": {
+                "import": "./dist/react/index.browser.mjs",
+                "require": "./dist/react/index.browser.cjs"
+            },
+            "node": {
+                "import": "./dist/react/index.node.mjs",
+                "require": "./dist/react/index.node.cjs"
+            }
         }
     },
     "scripts": {
         "build": "rimraf dist && tsup && tsc -p ./tsconfig.declarations.json",
         "dev": "vitest --project node",
         "test": "pnpm test:types && pnpm test:treeshakability && pnpm test:unit",
-        "test:treeshakability": "for file in dist/index.*.mjs; do agadoo $file; done",
+        "test:treeshakability": "for file in dist/index.*.mjs dist/react/index.*.mjs; do agadoo $file; done",
         "test:types": "tsc --noEmit",
         "test:unit": "vitest run"
     },
@@ -66,10 +81,25 @@
         "@wallet-standard/ui-registry": "^1.1.1"
     },
     "devDependencies": {
-        "@wallet-standard/errors": "^0.1.2"
+        "@solana/react": "^7.0.0",
+        "@testing-library/react": "^16.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@wallet-standard/errors": "^0.1.2",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
     },
     "peerDependencies": {
-        "@solana/kit": "^7.0.0"
+        "@solana/kit": "^7.0.0",
+        "@solana/react": "^7.0.0",
+        "react": "^18.0.0 || ^19.0.0"
+    },
+    "peerDependenciesMeta": {
+        "@solana/react": {
+            "optional": true
+        },
+        "react": {
+            "optional": true
+        }
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-plugin-wallet/src/react/__typetests__/index.ts
+++ b/packages/kit-plugin-wallet/src/react/__typetests__/index.ts
@@ -1,0 +1,85 @@
+import type { ReadonlyUint8Array, SignatureBytes } from '@solana/kit';
+import type { SolanaSignInInput, SolanaSignInOutput } from '@solana/wallet-standard-features';
+import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui';
+
+import type { WalletState, WalletStatus } from '../../types';
+import {
+    useConnect,
+    useConnectedWallet,
+    useDisconnect,
+    useSelectAccount,
+    useSignIn,
+    useSignMessage,
+    useWallets,
+    useWalletStatus,
+} from '../index';
+
+// NB: hooks are only type-checked here, never executed.
+
+// [DESCRIBE] useWalletStatus
+{
+    const status = useWalletStatus();
+    status satisfies WalletStatus;
+}
+
+// [DESCRIBE] useConnectedWallet
+{
+    const connected = useConnectedWallet();
+    connected satisfies WalletState['connected'];
+    // The connection is nullable when disconnected.
+    connected satisfies { account: UiWalletAccount } | null;
+}
+
+// [DESCRIBE] useWallets
+{
+    const wallets = useWallets();
+    wallets satisfies readonly UiWallet[];
+}
+
+// [DESCRIBE] useConnect
+{
+    const action = useConnect();
+    action.dispatch(null as unknown as UiWallet);
+    action.data satisfies readonly UiWalletAccount[] | undefined;
+    // @ts-expect-error dispatch requires the wallet argument.
+    action.dispatch();
+}
+
+// [DESCRIBE] useDisconnect
+{
+    const action = useDisconnect();
+    // The wallet argument is optional — omit it to disconnect the active wallet.
+    action.dispatch();
+    // Or pass a specific wallet to deauthorize.
+    action.dispatch(null as unknown as UiWallet);
+    action.data satisfies void | undefined;
+}
+
+// [DESCRIBE] useSignIn
+{
+    const action = useSignIn();
+    action.dispatch(null as unknown as UiWallet, null as unknown as SolanaSignInInput);
+    action.data satisfies SolanaSignInOutput | undefined;
+    // @ts-expect-error dispatch requires both the wallet and the sign-in input.
+    action.dispatch(null as unknown as UiWallet);
+}
+
+// [DESCRIBE] useSignMessage
+{
+    const action = useSignMessage();
+    action.dispatch(new Uint8Array());
+    action.data satisfies SignatureBytes | undefined;
+}
+{
+    // dispatch accepts a ReadonlyUint8Array (e.g. codec output) without a cast.
+    const action = useSignMessage();
+    action.dispatch(null as unknown as ReadonlyUint8Array);
+}
+
+// [DESCRIBE] useSelectAccount
+{
+    const selectAccount = useSelectAccount();
+    selectAccount(null as unknown as UiWalletAccount) satisfies void;
+    // @ts-expect-error selectAccount requires the account argument.
+    selectAccount();
+}

--- a/packages/kit-plugin-wallet/src/react/index.ts
+++ b/packages/kit-plugin-wallet/src/react/index.ts
@@ -1,0 +1,226 @@
+import type { ReadonlyUint8Array, SignatureBytes } from '@solana/kit';
+import { type ActionResult, useAction, useClientCapability } from '@solana/react';
+import type { SolanaSignInInput, SolanaSignInOutput } from '@solana/wallet-standard-features';
+import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui';
+import { useSyncExternalStore } from 'react';
+
+import type { ClientWithWallet, WalletNamespace, WalletState, WalletStatus } from '../types';
+
+/**
+ * Reads the wallet namespace from the nearest `ClientProvider`, asserting at mount that a wallet
+ * plugin is installed. Shared by every hook in this module so the capability check, error hook
+ * name, and provider hint stay in one place.
+ */
+function useWalletNamespace(hookName: string): WalletNamespace {
+    return useClientCapability<ClientWithWallet>({
+        capability: 'wallet',
+        hookName,
+        providerHint: 'Install a wallet plugin on the client, e.g. `walletSigner()`.',
+    }).wallet;
+}
+
+// -- State hooks ------------------------------------------------------------
+
+/**
+ * Subscribes to the wallet connection status from a React component.
+ *
+ * Wraps `client.wallet.subscribe` / `getState` with `useSyncExternalStore`, re-rendering only when
+ * the status changes. Requires a `ClientProvider` whose client has a wallet plugin installed;
+ * asserts this at mount with {@link useClientCapability}.
+ *
+ * @returns The current {@link WalletStatus} (`'pending'` on the server and in React Native).
+ *
+ * @example
+ * ```tsx
+ * const status = useWalletStatus();
+ * if (status === 'pending') return null; // avoid flashing UI before auto-reconnect resolves
+ * ```
+ *
+ * @see {@link useConnectedWallet}
+ * @see {@link useWallets}
+ */
+export function useWalletStatus(): WalletStatus {
+    const wallet = useWalletNamespace('useWalletStatus');
+    const getStatus = () => wallet.getState().status;
+    return useSyncExternalStore(wallet.subscribe, getStatus, getStatus);
+}
+
+/**
+ * Subscribes to the active wallet connection from a React component.
+ *
+ * Wraps `client.wallet.subscribe` / `getState` with `useSyncExternalStore`, re-rendering only when
+ * the connection changes (connect, disconnect, or account switch). Requires a `ClientProvider`
+ * whose client has a wallet plugin installed; asserts this at mount with {@link useClientCapability}.
+ *
+ * @returns The active connection — `{ account, signer, wallet }` — or `null` when disconnected.
+ *   `signer` is `null` for read-only wallets.
+ *
+ * @example
+ * ```tsx
+ * const connected = useConnectedWallet();
+ * return connected ? <p>{connected.account.address}</p> : <p>Not connected</p>;
+ * ```
+ *
+ * @see {@link useWalletStatus}
+ * @see {@link useWallets}
+ */
+export function useConnectedWallet(): WalletState['connected'] {
+    const wallet = useWalletNamespace('useConnectedWallet');
+    const getConnected = () => wallet.getState().connected;
+    return useSyncExternalStore(wallet.subscribe, getConnected, getConnected);
+}
+
+/**
+ * Subscribes to the list of discovered wallets from a React component.
+ *
+ * Wraps `client.wallet.subscribe` / `getState` with `useSyncExternalStore`, re-rendering only when
+ * the discovered-wallet list changes. Requires a `ClientProvider` whose client has a wallet plugin
+ * installed; asserts this at mount with {@link useClientCapability}.
+ *
+ * @returns All discovered wallets matching the client's configured chain and filter (empty on the
+ *   server and in React Native).
+ *
+ * @example
+ * ```tsx
+ * const wallets = useWallets();
+ * const connect = useConnect();
+ * return wallets.map(w => <button key={w.name} onClick={() => connect.dispatch(w)}>{w.name}</button>);
+ * ```
+ *
+ * @see {@link useWalletStatus}
+ * @see {@link useConnectedWallet}
+ */
+export function useWallets(): readonly UiWallet[] {
+    const wallet = useWalletNamespace('useWallets');
+    const getWallets = () => wallet.getState().wallets;
+    return useSyncExternalStore(wallet.subscribe, getWallets, getWallets);
+}
+
+// -- Action hooks -----------------------------------------------------------
+
+/**
+ * Connects to a wallet from a React component.
+ *
+ * Wraps `client.wallet.connect` with {@link useAction}. Requires a `ClientProvider` whose client
+ * has a wallet plugin installed; asserts this at mount with {@link useClientCapability}. An
+ * in-flight connect is superseded when a newer one is dispatched.
+ *
+ * `dispatch`/`dispatchAsync` take the {@link UiWallet} to connect to and resolve with the wallet's
+ * accounts once connected.
+ *
+ * @example
+ * ```tsx
+ * const { dispatch, isRunning } = useConnect();
+ * <button disabled={isRunning} onClick={() => dispatch(wallet)}>Connect</button>
+ * ```
+ *
+ * @see {@link useDisconnect}
+ * @see {@link useSignIn}
+ */
+export function useConnect(): ActionResult<[wallet: UiWallet], readonly UiWalletAccount[]> {
+    const wallet = useWalletNamespace('useConnect');
+    return useAction((abortSignal, uiWallet: UiWallet) => wallet.connect(uiWallet, { abortSignal }));
+}
+
+/**
+ * Disconnects a wallet from a React component.
+ *
+ * Wraps `client.wallet.disconnect` with {@link useAction}. Requires a `ClientProvider` whose client
+ * has a wallet plugin installed; asserts this at mount with {@link useClientCapability}.
+ *
+ * `dispatch`/`dispatchAsync` take an optional {@link UiWallet}. Called with no argument they
+ * disconnect the active wallet; passing a non-active, currently authorized wallet deauthorizes that
+ * wallet while leaving the active connection in place.
+ *
+ * @example
+ * ```tsx
+ * const { dispatch, isRunning } = useDisconnect();
+ * // Disconnect the active wallet:
+ * <button disabled={isRunning} onClick={() => dispatch()}>Disconnect</button>
+ * // Or deauthorize a specific wallet:
+ * <button disabled={isRunning} onClick={() => dispatch(wallet)}>Forget this wallet</button>
+ * ```
+ *
+ * @see {@link useConnect}
+ */
+export function useDisconnect(): ActionResult<[wallet?: UiWallet], void> {
+    const wallet = useWalletNamespace('useDisconnect');
+    return useAction((abortSignal, uiWallet?: UiWallet) => wallet.disconnect(uiWallet, { abortSignal }));
+}
+
+/**
+ * Signs in with a wallet (Sign In With Solana) from a React component.
+ *
+ * Wraps `client.wallet.signIn` with {@link useAction}. Requires a `ClientProvider` whose client has
+ * a wallet plugin installed; asserts this at mount with {@link useClientCapability}. Like
+ * {@link useConnect}, this establishes a full connection. An in-flight connect is superseded when a
+ * newer one is dispatched.
+ *
+ * `dispatch`/`dispatchAsync` take the {@link UiWallet} and a `SolanaSignInInput` (pass `{}` for no
+ * customization) and resolve with the wallet's sign-in output.
+ *
+ * @example
+ * ```tsx
+ * const { dispatch } = useSignIn();
+ * dispatch(wallet, { domain: window.location.host });
+ * ```
+ *
+ * @see {@link useConnect}
+ */
+export function useSignIn(): ActionResult<[wallet: UiWallet, input: SolanaSignInInput], SolanaSignInOutput> {
+    const wallet = useWalletNamespace('useSignIn');
+    return useAction((abortSignal, uiWallet: UiWallet, input: SolanaSignInInput) =>
+        wallet.signIn(uiWallet, input, { abortSignal }),
+    );
+}
+
+/**
+ * Signs an arbitrary message with the connected account from a React component.
+ *
+ * Wraps `client.wallet.signMessage` with {@link useAction}. Requires a `ClientProvider` whose
+ * client has a wallet plugin installed; asserts this at mount with {@link useClientCapability}.
+ * A stale in-flight dispatch is dropped from the hook's state when a newer one starts (though
+ * the wallet may still complete the older request in the background).
+ *
+ * `dispatch`/`dispatchAsync` take the message bytes and resolve with the signature. The bytes are
+ * only read, never mutated, so a {@link ReadonlyUint8Array} (e.g. the output of a `@solana/kit`
+ * codec) is accepted directly without a cast.
+ *
+ * @example
+ * ```tsx
+ * const { dispatch } = useSignMessage();
+ * dispatch(new TextEncoder().encode('Hello'));
+ * ```
+ */
+export function useSignMessage(): ActionResult<[message: ReadonlyUint8Array], SignatureBytes> {
+    const wallet = useWalletNamespace('useSignMessage');
+    return useAction((abortSignal, message: ReadonlyUint8Array) => wallet.signMessage(message, { abortSignal }));
+}
+
+/**
+ * Returns a callback that selects a wallet account.
+ *
+ * Requires a `ClientProvider` whose client has a wallet plugin installed; asserts this at mount
+ * with {@link useClientCapability}. Unlike the other action hooks, `selectAccount` is synchronous —
+ * this hook returns the bound function directly rather than an `ActionResult`.
+ *
+ * The account may belong to any currently authorized wallet, not only the active one. Selecting an
+ * account from a different authorized wallet switches the active connection to that wallet
+ * synchronously (no prompt), leaving the previously active wallet authorized.
+ *
+ * @returns The `selectAccount` function — call it with a {@link UiWalletAccount} belonging to any
+ *   currently authorized wallet. It throws if the account's handle can't be resolved to an
+ *   authorized wallet (or isn't among that wallet's accounts), or that wallet is currently
+ *   disconnecting.
+ *
+ * @example
+ * ```tsx
+ * const selectAccount = useSelectAccount();
+ * <button onClick={() => selectAccount(account)}>Use this account</button>
+ * ```
+ *
+ * @see {@link useConnectedWallet}
+ */
+export function useSelectAccount(): WalletNamespace['selectAccount'] {
+    return useWalletNamespace('useSelectAccount').selectAccount;
+}

--- a/packages/kit-plugin-wallet/test/useWalletActions.react.test.tsx
+++ b/packages/kit-plugin-wallet/test/useWalletActions.react.test.tsx
@@ -1,0 +1,126 @@
+import { ClientProvider } from '@solana/react';
+import { renderHook } from '@testing-library/react';
+import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui';
+import { createElement, type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useConnect, useDisconnect, useSelectAccount, useSignIn, useSignMessage } from '../src/react';
+
+function wrapperFor(wallet: object) {
+    return ({ children }: { children: ReactNode }) =>
+        createElement(ClientProvider, { client: { wallet } as never }, children);
+}
+
+const uiWallet = {} as UiWallet;
+const account = {} as UiWalletAccount;
+
+describe('useConnect', () => {
+    it('throws at mount when the client lacks a wallet namespace', () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+        expect(() =>
+            renderHook(() => useConnect(), {
+                wrapper: ({ children }) => createElement(ClientProvider, { client: {} as never }, children),
+            }),
+        ).toThrow(/useConnect/);
+        consoleError.mockRestore();
+    });
+
+    it('dispatches connect with the wallet and a threaded abort signal, returning its result', async () => {
+        const accounts = [account];
+        const connect = vi.fn().mockResolvedValue(accounts);
+        const { result: hook } = renderHook(() => useConnect(), { wrapper: wrapperFor({ connect }) });
+
+        const returned = await hook.current.dispatchAsync(uiWallet);
+
+        expect(returned).toBe(accounts);
+        expect(connect).toHaveBeenCalledWith(
+            uiWallet,
+            expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
+        );
+    });
+
+    it('surfaces a rejecting connect via the returned promise', async () => {
+        const error = new Error('declined');
+        const connect = vi.fn().mockRejectedValue(error);
+        const { result: hook } = renderHook(() => useConnect(), { wrapper: wrapperFor({ connect }) });
+
+        await expect(hook.current.dispatchAsync(uiWallet)).rejects.toBe(error);
+    });
+});
+
+describe('useDisconnect', () => {
+    it('dispatches disconnect for the active wallet with a threaded abort signal', async () => {
+        const disconnect = vi.fn().mockResolvedValue(undefined);
+        const { result: hook } = renderHook(() => useDisconnect(), { wrapper: wrapperFor({ disconnect }) });
+
+        await hook.current.dispatchAsync();
+
+        expect(disconnect).toHaveBeenCalledWith(
+            undefined,
+            expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
+        );
+    });
+
+    it('dispatches disconnect for a specific wallet with a threaded abort signal', async () => {
+        const disconnect = vi.fn().mockResolvedValue(undefined);
+        const { result: hook } = renderHook(() => useDisconnect(), { wrapper: wrapperFor({ disconnect }) });
+
+        await hook.current.dispatchAsync(uiWallet);
+
+        expect(disconnect).toHaveBeenCalledWith(
+            uiWallet,
+            expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
+        );
+    });
+});
+
+describe('useSignIn', () => {
+    it('dispatches signIn with the wallet, input, and a threaded abort signal', async () => {
+        const output = { account: {} };
+        const signIn = vi.fn().mockResolvedValue(output);
+        const { result: hook } = renderHook(() => useSignIn(), { wrapper: wrapperFor({ signIn }) });
+
+        const input = { domain: 'example.com' };
+        const returned = await hook.current.dispatchAsync(uiWallet, input);
+
+        expect(returned).toBe(output);
+        expect(signIn).toHaveBeenCalledWith(
+            uiWallet,
+            input,
+            expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
+        );
+    });
+});
+
+describe('useSignMessage', () => {
+    it('dispatches signMessage with the message and a threaded abort signal', async () => {
+        const signature = new Uint8Array(64);
+        const signMessage = vi.fn().mockResolvedValue(signature);
+        const { result: hook } = renderHook(() => useSignMessage(), { wrapper: wrapperFor({ signMessage }) });
+
+        const message = new TextEncoder().encode('Hello');
+        const returned = await hook.current.dispatchAsync(message);
+
+        expect(returned).toBe(signature);
+        expect(signMessage).toHaveBeenCalledWith(
+            message,
+            expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
+        );
+    });
+});
+
+describe('useSelectAccount', () => {
+    it('returns a callback that forwards to the client, stable across renders', () => {
+        const selectAccount = vi.fn();
+        const { result: hook, rerender } = renderHook(() => useSelectAccount(), {
+            wrapper: wrapperFor({ selectAccount }),
+        });
+
+        const first = hook.current;
+        first(account);
+        expect(selectAccount).toHaveBeenCalledWith(account);
+
+        rerender();
+        expect(hook.current).toBe(first);
+    });
+});

--- a/packages/kit-plugin-wallet/test/useWalletState.react.test.tsx
+++ b/packages/kit-plugin-wallet/test/useWalletState.react.test.tsx
@@ -1,0 +1,87 @@
+import { ClientProvider } from '@solana/react';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import type { UiWallet } from '@wallet-standard/ui';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useConnectedWallet, useWallets, useWalletStatus } from '../src/react';
+import type { WalletState } from '../src/types';
+
+// Unmount rendered trees between tests. This package doesn't enable vitest
+// globals, so @testing-library/react's auto-cleanup isn't registered.
+afterEach(cleanup);
+
+/**
+ * A minimal referentially-stable wallet store, mirroring the plugin's contract: `getState` returns
+ * the same object until `setState` replaces it, and `subscribe` notifies listeners on change.
+ */
+function createFakeStore(initial: WalletState) {
+    let state = initial;
+    const listeners = new Set<() => void>();
+    return {
+        getState: () => state,
+        setState(next: WalletState) {
+            state = next;
+            listeners.forEach(l => l());
+        },
+        subscribe(listener: () => void) {
+            listeners.add(listener);
+            return () => listeners.delete(listener);
+        },
+    };
+}
+
+function wrapperFor(wallet: object) {
+    return ({ children }: { children: ReactNode }) =>
+        createElement(ClientProvider, { client: { wallet } as never }, children);
+}
+
+const INITIAL: WalletState = { connected: null, status: 'disconnected', wallets: [] };
+
+describe('useWalletStatus', () => {
+    it('throws at mount when the client lacks a wallet namespace', () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+        expect(() =>
+            renderHook(() => useWalletStatus(), {
+                wrapper: ({ children }) => createElement(ClientProvider, { client: {} as never }, children),
+            }),
+        ).toThrow(/useWalletStatus/);
+        consoleError.mockRestore();
+    });
+
+    it('returns the current status and updates when it changes', () => {
+        const store = createFakeStore(INITIAL);
+        const { result } = renderHook(() => useWalletStatus(), { wrapper: wrapperFor(store) });
+
+        expect(result.current).toBe('disconnected');
+
+        act(() => store.setState({ ...INITIAL, status: 'connecting' }));
+        expect(result.current).toBe('connecting');
+    });
+});
+
+describe('useConnectedWallet', () => {
+    it('returns the active connection and updates when it changes', () => {
+        const store = createFakeStore(INITIAL);
+        const { result } = renderHook(() => useConnectedWallet(), { wrapper: wrapperFor(store) });
+
+        expect(result.current).toBeNull();
+
+        const connected = { account: {}, signer: null, wallet: {} } as WalletState['connected'];
+        act(() => store.setState({ ...INITIAL, connected, status: 'connected' }));
+        expect(result.current).toBe(connected);
+    });
+});
+
+describe('useWallets', () => {
+    it('returns the discovered wallets and updates when the list changes', () => {
+        const store = createFakeStore(INITIAL);
+        const { result } = renderHook(() => useWallets(), { wrapper: wrapperFor(store) });
+
+        expect(result.current).toEqual([]);
+
+        const wallets = [{} as UiWallet];
+        act(() => store.setState({ ...INITIAL, wallets }));
+        expect(result.current).toBe(wallets);
+    });
+});

--- a/packages/kit-plugin-wallet/tsconfig.declarations.json
+++ b/packages/kit-plugin-wallet/tsconfig.declarations.json
@@ -7,5 +7,5 @@
         "rootDir": "./src"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["src/index.ts", "src/react/index.ts", "src/types"]
 }

--- a/packages/kit-plugin-wallet/tsup.config.ts
+++ b/packages/kit-plugin-wallet/tsup.config.ts
@@ -2,4 +2,4 @@ import { defineConfig } from 'tsup';
 
 import { getPackageBuildConfigs } from '../../tsup.config.base';
 
-export default defineConfig(getPackageBuildConfigs());
+export default defineConfig(getPackageBuildConfigs({ entry: ['./src/index.ts', './src/react/index.ts'] }));

--- a/packages/kit-plugin-wallet/vitest.config.mts
+++ b/packages/kit-plugin-wallet/vitest.config.mts
@@ -1,4 +1,4 @@
-import { defineConfig, mergeConfig } from 'vitest/config';
+import { configDefaults, defineConfig, mergeConfig } from 'vitest/config';
 
 import { getVitestConfig } from '../../vitest.config.base.mjs';
 
@@ -10,12 +10,16 @@ function withWalletMocks(config: ReturnType<typeof getVitestConfig>) {
     });
 }
 
+// React hook tests need a DOM (`renderHook` → `react-dom`), so they run only in the browser
+// (happy-dom) project and are excluded from the node and react-native projects.
+const excludeReactTests = { test: { exclude: [...configDefaults.exclude, '**/*.react.test.tsx'] } };
+
 export default defineConfig({
     test: {
         projects: [
             withWalletMocks(getVitestConfig('browser')),
-            withWalletMocks(getVitestConfig('node')),
-            withWalletMocks(getVitestConfig('react-native')),
+            mergeConfig(withWalletMocks(getVitestConfig('node')), excludeReactTests),
+            mergeConfig(withWalletMocks(getVitestConfig('react-native')), excludeReactTests),
         ],
     },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,9 +212,24 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
     devDependencies:
+      '@solana/react':
+        specifier: ^7.0.0
+        version: 7.0.0(@solana/kit@7.0.0(typescript@7.0.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2)
+      '@testing-library/react':
+        specifier: ^16.0.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react':
+        specifier: ^18.0.0 || ^19.0.0
+        version: 19.2.17
       '@wallet-standard/errors':
         specifier: ^0.1.2
         version: 0.1.2
+      react:
+        specifier: ^18.0.0 || ^19.0.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^18.0.0 || ^19.0.0
+        version: 19.2.7(react@19.2.7)
 
   packages/kit-plugins:
     dependencies:
@@ -244,6 +259,14 @@ importers:
         version: link:../kit-plugin-rpc
 
 packages:
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
@@ -1410,6 +1433,22 @@ packages:
       typescript:
         optional: true
 
+  '@solana/react@7.0.0':
+    resolution: {integrity: sha512-+BDWCUdFpRkD+zGV2iiyEVWrF9AWw7tQsdiqHHAZa8Td/7CLYw+H8IjtuapMYNK2RZQhqKrSK9OWLE8rh63Qdg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
+      '@tanstack/react-query': ^5.0.0
+      react: '>=18'
+      swr: ^2.0.0
+    peerDependenciesMeta:
+      '@tanstack/react-query':
+        optional: true
+      react:
+        optional: true
+      swr:
+        optional: true
+
   '@solana/rpc-api@7.0.0':
     resolution: {integrity: sha512-MTtBO883st83CjWpo8B4g8EKzXaeoBX5N7+sv4vcvsn2q1NpY4SG3XejdX1FrKeTe9Xjbv0/FzFtykstbKe1UA==}
     engines: {node: '>=20.18.0'}
@@ -1601,6 +1640,25 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@turbo/darwin-64@2.10.4':
     resolution: {integrity: sha512-m1MUEI4MJ69r5CwfMYxmHi0H0rrgiYCBOp0tgBZ9x/YVvOb5uu/lRIDyDwdtH054R2yWeQaIigUGu6aCX9f8cA==}
     cpu: [x64]
@@ -1631,6 +1689,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1648,6 +1709,9 @@ packages:
 
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
@@ -1817,8 +1881,23 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
+  '@wallet-standard/experimental-features@0.2.1':
+    resolution: {integrity: sha512-GQ5fsg6Y64o/mOzRMKoannp0ArbQAybFcgxBJl896k0gC9NP9/RYUN/qWCZiwc+PYwmsGDCaF+MrnqhcGtl8dA==}
+    engines: {node: '>=22'}
+
   '@wallet-standard/features@1.1.1':
     resolution: {integrity: sha512-aCWYmVeSCGViyEU5k7GMoW8zxE4Gs+C1s1Pp2XLesvSNlnZ4PMES9HUnTB3hl0b3RVj7C61yze3IWyrncqg4MA==}
+    engines: {node: '>=22'}
+
+  '@wallet-standard/react-core@1.0.3':
+    resolution: {integrity: sha512-kN2Am5cNwIpqCSp+jvQu5J8bF6sdVNyYl9go4N8GDUpj+UJAg6Hfqx18ij7lWY3L8kF6Y9dwVH+DvVvj43elOA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  '@wallet-standard/react@1.0.3':
+    resolution: {integrity: sha512-stvjriEfuHnUwZ4PBqkm1/1z9YQpMH6KTHdAql9F3xFoIxm493Hg7IljRW7+5zBEtzwro4L1eQoxBLe34SdbfQ==}
     engines: {node: '>=22'}
 
   '@wallet-standard/ui-compare@1.0.3':
@@ -1858,6 +1937,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -1866,6 +1949,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -1946,6 +2032,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
 
@@ -1958,6 +2047,10 @@ packages:
       supports-color:
         optional: true
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -1965,6 +2058,9 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dotenv@8.6.0:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
@@ -2108,6 +2204,9 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
@@ -2180,6 +2279,10 @@ packages:
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
     engines: {node: 20 || >=22}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2362,11 +2465,27 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -2409,6 +2528,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -2673,6 +2795,14 @@ packages:
         optional: true
 
 snapshots:
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/runtime@7.29.2': {}
 
@@ -3573,6 +3703,27 @@ snapshots:
     optionalDependencies:
       typescript: 7.0.2
 
+  '@solana/react@7.0.0(@solana/kit@7.0.0(typescript@7.0.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2)':
+    dependencies:
+      '@solana/kit': 7.0.0(typescript@7.0.2)
+      '@solana/promises': 7.0.0(typescript@7.0.2)
+      '@solana/signers': 7.0.0(typescript@7.0.2)
+      '@solana/subscribable': 7.0.0(typescript@7.0.2)
+      '@solana/transaction-messages': 7.0.0(typescript@7.0.2)
+      '@solana/transactions': 7.0.0(typescript@7.0.2)
+      '@solana/wallet-standard-features': 1.4.0
+      '@wallet-standard/base': 1.1.1
+      '@wallet-standard/errors': 0.1.2
+      '@wallet-standard/react': 1.0.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@wallet-standard/ui': 1.0.3
+      '@wallet-standard/ui-registry': 1.1.1
+    optionalDependencies:
+      react: 19.2.7
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - react-dom
+      - typescript
+
   '@solana/rpc-api@7.0.0(typescript@7.0.2)':
     dependencies:
       '@solana/addresses': 7.0.0(typescript@7.0.2)
@@ -3852,6 +4003,26 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@turbo/darwin-64@2.10.4':
     optional: true
 
@@ -3870,6 +4041,8 @@ snapshots:
   '@turbo/windows-arm64@2.10.4':
     optional: true
 
+  '@types/aria-query@5.0.4': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -3886,6 +4059,10 @@ snapshots:
   '@types/node@26.1.1':
     dependencies:
       undici-types: 8.3.0
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
 
   '@types/whatwg-mimetype@3.0.2': {}
 
@@ -4005,9 +4182,32 @@ snapshots:
       chalk: 5.6.2
       commander: 13.1.0
 
+  '@wallet-standard/experimental-features@0.2.1':
+    dependencies:
+      '@wallet-standard/base': 1.1.1
+
   '@wallet-standard/features@1.1.1':
     dependencies:
       '@wallet-standard/base': 1.1.1
+
+  '@wallet-standard/react-core@1.0.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@wallet-standard/app': 1.1.1
+      '@wallet-standard/base': 1.1.1
+      '@wallet-standard/errors': 0.1.2
+      '@wallet-standard/experimental-features': 0.2.1
+      '@wallet-standard/features': 1.1.1
+      '@wallet-standard/ui': 1.0.3
+      '@wallet-standard/ui-registry': 1.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@wallet-standard/react@1.0.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@wallet-standard/react-core': 1.0.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@wallet-standard/ui-compare@1.0.3':
     dependencies:
@@ -4050,6 +4250,8 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-styles@5.2.0: {}
+
   any-promise@1.3.0: {}
 
   argparse@1.0.10:
@@ -4057,6 +4259,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   array-union@2.1.0: {}
 
@@ -4117,17 +4323,23 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  csstype@3.2.3: {}
+
   dataloader@1.4.0: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
+  dequal@2.0.3: {}
+
   detect-indent@6.1.0: {}
 
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dom-accessibility-api@0.5.16: {}
 
   dotenv@8.6.0: {}
 
@@ -4318,6 +4530,8 @@ snapshots:
 
   joycon@3.1.1: {}
 
+  js-tokens@4.0.0: {}
+
   js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
@@ -4380,6 +4594,8 @@ snapshots:
   lodash.startcase@4.4.0: {}
 
   lru-cache@11.2.6: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -4548,9 +4764,24 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
+  react@19.2.7: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -4638,6 +4869,8 @@ snapshots:
       queue-microtask: 1.2.3
 
   safer-buffer@2.1.2: {}
+
+  scheduler@0.27.0: {}
 
   semver@7.7.4: {}
 

--- a/tsup.config.base.ts
+++ b/tsup.config.base.ts
@@ -5,12 +5,13 @@ import { Format, Options as TsupConfig } from 'tsup';
 type Platform = 'browser' | 'node' | 'react-native';
 
 type BuildOptions = {
+    entry?: string[];
     format: Format;
     platform: Platform;
 };
 
 export function getBuildConfig(options: BuildOptions): TsupConfig {
-    const { format, platform } = options;
+    const { entry = ['./src/index.ts'], format, platform } = options;
     return {
         define: {
             __BROWSER__: `${platform === 'browser'}`,
@@ -20,7 +21,7 @@ export function getBuildConfig(options: BuildOptions): TsupConfig {
             __TEST__: 'false',
             __VERSION__: `"${env.npm_package_version}"`,
         },
-        entry: [`./src/index.ts`],
+        entry,
         esbuildOptions(options) {
             options.define = {
                 ...options.define,
@@ -48,12 +49,13 @@ export function getBuildConfig(options: BuildOptions): TsupConfig {
     };
 }
 
-export function getPackageBuildConfigs(): TsupConfig[] {
+export function getPackageBuildConfigs(options?: { entry?: string[] }): TsupConfig[] {
+    const { entry } = options ?? {};
     return [
-        getBuildConfig({ format: 'cjs', platform: 'node' }),
-        getBuildConfig({ format: 'esm', platform: 'node' }),
-        getBuildConfig({ format: 'cjs', platform: 'browser' }),
-        getBuildConfig({ format: 'esm', platform: 'browser' }),
-        getBuildConfig({ format: 'esm', platform: 'react-native' }),
+        getBuildConfig({ entry, format: 'cjs', platform: 'node' }),
+        getBuildConfig({ entry, format: 'esm', platform: 'node' }),
+        getBuildConfig({ entry, format: 'cjs', platform: 'browser' }),
+        getBuildConfig({ entry, format: 'esm', platform: 'browser' }),
+        getBuildConfig({ entry, format: 'esm', platform: 'react-native' }),
     ];
 }


### PR DESCRIPTION
This PR adds react hooks to the wallet plugin.

Includes three hooks that expose the wallet state using `useSyncExternalStore`, each exposing one of the three pieces of state. `useWalletStatus`, `useConnectedWallet`, and `useWallets`. These are separate hooks because they change independently and will have different re-render cadence. You can still use `useSyncExternalStore(client.wallet.subscribe, client.wallet.getState)` to subscribe to the whole state, but there isn't a specific hook for this.

Also includes four new action hooks, which are all just simple wrappers around wallet plugin functions: `useConnect`, `useDisconnect`, `useSignIn` and `useSignMessage`. A hook is also provided for `useSelectAccount`, which is just a synchronous callback.