### PR TITLE
wallet plugin: reflect updated authorized accounts in wallets list

### DIFF
--- a/.changeset/curly-donkeys-slide.md
+++ b/.changeset/curly-donkeys-slide.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-wallet': patch
+---
+
+Fix `client.wallet.getState().wallets` not reflecting accounts authorized during connect/signIn/reconnect until an unrelated wallet event fired.

--- a/packages/kit-plugin-wallet/src/store.ts
+++ b/packages/kit-plugin-wallet/src/store.ts
@@ -289,7 +289,22 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
         const signer = tryCreateSigner(account);
         resubscribeToWalletEvents(wallet);
         disconnectingWalletName = null;
-        updateState({ account, connectedWallet: wallet, signer, status: 'connected' });
+        // Reconcile `wallets` alongside the connection: `connect`/`signIn`/silent
+        // reconnect authorize accounts on the underlying wallet, which regenerates
+        // its registry handle. Without rebuilding the list here, `getState().wallets`
+        // would keep the pre-connect handle (empty `.accounts`) until an unrelated
+        // `standard:events change` happened to fire — so consumers reading the
+        // just-connected wallet from `wallets` (e.g. rendering its authorized
+        // accounts) would see it as unconnected. `reconcileWalletList` returns the
+        // existing reference when the visible set is unchanged, keeping the snapshot
+        // churn-free when connect didn't actually add accounts.
+        updateState({
+            account,
+            connectedWallet: wallet,
+            signer,
+            status: 'connected',
+            wallets: reconcileWalletList(),
+        });
         if (options?.persist !== false) {
             persistAccount(account, wallet);
         }

--- a/packages/kit-plugin-wallet/test/store.test.ts
+++ b/packages/kit-plugin-wallet/test/store.test.ts
@@ -281,6 +281,30 @@ describe.skipIf(!__BROWSER__)('store (browser)', () => {
         expect(store.getState().connected!.account.address).toBe(newAccount.address);
     });
 
+    it('reflects accounts authorized during connect in the discovered-wallet list', async () => {
+        // Wallet starts with no authorized accounts (the realistic pre-connect state).
+        const mockWallet = createMockUiWallet({ accounts: [], name: 'TestWallet' });
+        registerWallet(mockWallet);
+
+        // Connect authorizes an account, regenerating the wallet's registry handle.
+        const account = createMockAccount();
+        connectMock.mockImplementationOnce(() => {
+            updateRegisteredWallet(createMockUiWallet({ accounts: [account], name: 'TestWallet' }));
+            return Promise.resolve();
+        });
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(mockWallet);
+
+        // `wallets` must reflect the newly authorized account immediately — not stay
+        // stale until an unrelated `standard:events change` fires. Consumers rendering
+        // the wallet from `useWallets()` rely on `.accounts` to know it is connected.
+        const state = store.getState();
+        expect(state.connected!.wallet.accounts.length).toBe(1);
+        expect(state.wallets[0].accounts.length).toBe(1);
+        expect(state.wallets[0]).toBe(state.connected!.wallet);
+    });
+
     it('transitions through connecting status', async () => {
         const account = createMockAccount();
         const mockWallet = createMockUiWallet({
@@ -659,6 +683,40 @@ describe.skipIf(!__BROWSER__)('store (browser)', () => {
         expect(state.status).toBe('connected');
         expect(state.connected).not.toBeNull();
         expect(state.connected!.account.address).toBe(account.address);
+    });
+
+    it('reflects accounts authorized during signIn in the discovered-wallet list', async () => {
+        // Wallet starts with no authorized accounts (the realistic pre-signIn state).
+        const mockWallet = createMockUiWallet({
+            accounts: [],
+            features: ['standard:connect', 'standard:events', 'solana:signIn'],
+            name: 'TestWallet',
+        });
+        registerWallet(mockWallet);
+
+        // SIWS authorizes an account, regenerating the wallet's registry handle.
+        const account = createMockAccount();
+        signInMock.mockImplementationOnce(() => {
+            updateRegisteredWallet(
+                createMockUiWallet({
+                    accounts: [account],
+                    features: ['standard:connect', 'standard:events', 'solana:signIn'],
+                    name: 'TestWallet',
+                }),
+            );
+            return Promise.resolve([{ account: { address: account.address } }]);
+        });
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.signIn(mockWallet, {});
+
+        // `wallets` must reflect the newly authorized account immediately — not stay
+        // stale until an unrelated `standard:events change` fires. Consumers rendering
+        // the wallet from `useWallets()` rely on `.accounts` to know it is connected.
+        const state = store.getState();
+        expect(state.connected!.wallet.accounts.length).toBe(1);
+        expect(state.wallets[0].accounts.length).toBe(1);
+        expect(state.wallets[0]).toBe(state.connected!.wallet);
     });
 
     it('signIn reverts to disconnected if rejected', async () => {
@@ -1969,6 +2027,36 @@ describe.skipIf(!__BROWSER__)('store auto-connect (browser)', () => {
         expect(state.status).toBe('connected');
         expect(state.connected!.account.address).toBe(account.address);
         expect(connectMock).toHaveBeenCalledWith({ silent: true });
+    });
+
+    it('reflects accounts authorized during silent reconnect in the discovered-wallet list', async () => {
+        const account = createMockAccount();
+
+        // Wallet is registered but starts with no authorized accounts (the realistic
+        // state before a silent reconnect re-authorizes the saved account).
+        const mockWallet = createMockUiWallet({ accounts: [], name: 'TestWallet' });
+        registerWallet(mockWallet);
+
+        // The silent reconnect re-authorizes the saved account, regenerating the
+        // wallet's registry handle.
+        connectMock.mockImplementationOnce(() => {
+            updateRegisteredWallet(createMockUiWallet({ accounts: [account], name: 'TestWallet' }));
+            return Promise.resolve();
+        });
+
+        const storage = createMockStorage({ 'kit-wallet': `TestWallet:${account.address}` });
+        const store = createWalletStore({ chain: 'solana:mainnet', storage });
+
+        await vi.advanceTimersByTimeAsync(0);
+
+        // `wallets` must reflect the newly authorized account immediately — not stay
+        // stale until an unrelated `standard:events change` fires. Consumers rendering
+        // the wallet from `useWallets()` rely on `.accounts` to know it is connected.
+        const state = store.getState();
+        expect(state.status).toBe('connected');
+        expect(state.connected!.wallet.accounts.length).toBe(1);
+        expect(state.wallets[0].accounts.length).toBe(1);
+        expect(state.wallets[0]).toBe(state.connected!.wallet);
     });
 
     it('transitions to disconnected when storage is empty', async () => {


### PR DESCRIPTION
This PR fixes a bug spotted while using the wallet plugin for our Kit react example app, which stress tests the multi wallet/multi account design. After connecting account(s) from a wallet, some parts of the UI would not reflect those changes.