### PR TITLE
wallet plugin: subscribe to change events for all discovered wallets

### DIFF
--- a/.changeset/clean-candles-jog.md
+++ b/.changeset/clean-candles-jog.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-wallet': minor
+---
+
+Keep every discovered wallet's account state live by subscribing to wallet-standard `change` events for all discovered wallets, not just the connected one. This is an internal refactor with no public API change: `client.wallet.getState().wallets` now reflects account/feature changes for non-active wallets as they happen.

--- a/packages/kit-plugin-wallet/src/store.ts
+++ b/packages/kit-plugin-wallet/src/store.ts
@@ -101,7 +101,11 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
 
     const listeners = new Set<() => void>();
     const signerListeners = new Set<() => void>();
-    let walletEventsCleanup: (() => void) | null = null;
+    // One `standard:events change` subscription per discovered wallet, keyed by
+    // name (the stable identity; the UiWallet handle regenerates on changes). The
+    // underlying subscription attaches to the raw wallet's events, so it survives
+    // handle regeneration — no need to resubscribe when a wallet's accounts change.
+    const walletEventSubscriptions = new Map<string, () => void>();
     let reconnectCleanup: (() => void) | null = null;
     let userHasSelected = false;
     let connectGeneration = 0;
@@ -154,6 +158,10 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
     function updateState(updates: Partial<WalletStoreState>): void {
         const prev = state;
         state = { ...state, ...updates };
+
+        if (state.wallets !== prev.wallets) {
+            syncWalletEventSubscriptions(state.wallets);
+        }
 
         // Signer subscribers (`subscribeToPayer` / `subscribeToIdentity`) fire
         // only when the observed signer changes.
@@ -227,6 +235,29 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
         return next;
     }
 
+    // Reconcile the per-wallet event subscriptions against the current wallet set:
+    // subscribe wallets that just appeared, unsubscribe those that left. Called
+    // whenever `state.wallets` changes reference. Subscribing fires nothing, so
+    // this never causes re-render churn. `wallets` is the already-filtered visible
+    // list, so wallets excluded by chain/feature/`config.filter` are intentionally
+    // never subscribed — a `register` / `unregister` event reconciles them in or
+    // out of the list (and thus in or out of this map) when their eligibility
+    // changes.
+    function syncWalletEventSubscriptions(wallets: readonly UiWallet[]): void {
+        const names = new Set(wallets.map(w => w.name));
+        for (const [name, cleanup] of walletEventSubscriptions) {
+            if (!names.has(name)) {
+                cleanup();
+                walletEventSubscriptions.delete(name);
+            }
+        }
+        for (const w of wallets) {
+            if (!walletEventSubscriptions.has(w.name)) {
+                walletEventSubscriptions.set(w.name, subscribeToWalletEvents(w));
+            }
+        }
+    }
+
     // True if a wallet matching `uiWallet` (by name) is currently registered and
     // passes the filter. Used to re-check membership after an awaited connect /
     // sign-in / silent reconnect resolves: the wallet may have unregistered (or
@@ -253,8 +284,6 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
 
         // If the connected wallet was unregistered, disconnect locally.
         if (state.connectedWallet && !newWallets.some(w => w.name === state.connectedWallet!.name)) {
-            walletEventsCleanup?.();
-            walletEventsCleanup = null;
             updates.connectedWallet = null;
             updates.account = null;
             updates.signer = null;
@@ -272,11 +301,6 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
         reconnectCleanup = null;
     }
 
-    function resubscribeToWalletEvents(uiWallet: UiWallet): void {
-        walletEventsCleanup?.();
-        walletEventsCleanup = subscribeToWalletEvents(uiWallet);
-    }
-
     function setConnected(account: UiWalletAccount, wallet: UiWallet, options?: { persist?: boolean }): void {
         // The store may have been disposed while a connect / sign-in / silent
         // reconnect awaited. The `connectGeneration` guard at each call site
@@ -287,7 +311,6 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
         // itself connected.
         if (disposed) return;
         const signer = tryCreateSigner(account);
-        resubscribeToWalletEvents(wallet);
         disconnectingWalletName = null;
         // Reconcile `wallets` alongside the connection: `connect`/`signIn`/silent
         // reconnect authorize accounts on the underlying wallet, which regenerates
@@ -319,45 +342,43 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
         if (!uiWallet.features.includes(StandardEvents)) {
             return () => {};
         }
-
         const eventsFeature = getWalletFeature(
             uiWallet,
             StandardEvents,
         ) as StandardEventsFeature[typeof StandardEvents];
+        const walletName = uiWallet.name;
 
-        // The handler ignores the changed-property flags (`accounts`, `chains`,
-        // `features`) and instead reconciles the active account against the
-        // refreshed wallet. The signer is derived entirely from the account's
-        // features and chains, and the wallet-ui registry regenerates the
-        // account reference precisely when one of those changes — so the
-        // account reference is the single source of truth for whether the
-        // signer is affected, regardless of which flag the wallet sets.
+        // The handler intentionally ignores the changed-property flags
+        // (`accounts`, `chains`, `features`) the wallet passes and instead
+        // reconciles against the refreshed wallet. The signer is derived
+        // entirely from the active account's features and chains, and the
+        // wallet-ui registry regenerates the account reference precisely when
+        // one of those changes — so the account reference, not the flags, is
+        // the single source of truth for whether the signer is affected. Branch
+        // on the reconciled state below, never on `properties`.
         return eventsFeature.on('change', () => {
-            const refreshed = refreshUiWallet(uiWallet);
+            // Refresh the discovered list so this wallet's (and any others') accounts
+            // are current; `updateState` re-syncs subscriptions for added/removed wallets.
+            const newWallets = reconcileWalletList();
 
-            // If the wallet no longer passes the filter (e.g. it dropped the
-            // configured chain or a required feature), disconnect.
+            // Non-active wallet: reflect its new account/feature state in the list only.
+            if (!state.connectedWallet || state.connectedWallet.name !== walletName) {
+                updateState({ wallets: newWallets });
+                return;
+            }
+
+            // Active wallet: the original reconcile logic, unchanged.
+            const refreshed = refreshUiWallet(state.connectedWallet);
             if (!filterWallet(refreshed)) {
                 disconnectLocally();
                 return;
             }
-
             const result = reconcileActiveAccount(refreshed);
             if (result === null) {
                 disconnectLocally();
                 return;
             }
-
-            // `connectedWallet` is always refreshed so consumers reading
-            // `getState().connected.wallet` see current metadata; the signer
-            // (in `result`) only churns when the active account changed, which
-            // keeps the snapshot referentially stable on no-op change events.
-            // `wallets` is reconciled too: the registry regenerates the wallet
-            // handle on a change, so without this the list entry would keep the
-            // stale handle (`wallets[i] !== connected.wallet`). `reconcileWalletList`
-            // returns the existing reference on a no-op, preserving that stability.
-            updateState({ connectedWallet: refreshed, wallets: reconcileWalletList(), ...result });
-
+            updateState({ connectedWallet: refreshed, wallets: newWallets, ...result });
             if (result.account) {
                 persistAccount(result.account, refreshed);
             }
@@ -506,8 +527,6 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
     }
 
     function disconnectLocally(): void {
-        walletEventsCleanup?.();
-        walletEventsCleanup = null;
         disconnectingWalletName = null;
 
         updateState({
@@ -868,8 +887,10 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
             connectGeneration++;
             unsubRegister();
             unsubUnregister();
-            walletEventsCleanup?.();
-            walletEventsCleanup = null;
+            for (const cleanup of walletEventSubscriptions.values()) {
+                cleanup();
+            }
+            walletEventSubscriptions.clear();
             cancelReconnect();
             listeners.clear();
             signerListeners.clear();

--- a/packages/kit-plugin-wallet/test/_setup.ts
+++ b/packages/kit-plugin-wallet/test/_setup.ts
@@ -98,6 +98,10 @@ vi.mock('@wallet-standard/app', () => ({
 // updates the mapping, so refreshUiWallet returns the updated wallet.
 const rawToUi = new Map<object, UiWallet>();
 const nameToRaw = new Map<string, object>();
+// Maps each account handle (by object identity) to its owning raw wallet, so
+// the `getWalletForHandle` mock resolves account handles the way the real
+// registry's WeakMap does. Populated by registerWallet / updateRegisteredWallet.
+const accountToRaw = new WeakMap<object, object>();
 
 vi.mock('@wallet-standard/ui-registry', () => ({
     getOrCreateUiWalletForStandardWallet: (raw: object) => {
@@ -105,11 +109,13 @@ vi.mock('@wallet-standard/ui-registry', () => ({
         if (!ui) throw new Error('No UiWallet registered for this raw wallet');
         return ui;
     },
-    getWalletForHandle: (ui: UiWallet) => {
-        // Return the latest raw wallet for this name, so refreshUiWallet
-        // picks up updated registrations.
-        const raw = nameToRaw.get(ui.name);
-        if (!raw) throw new Error(`No raw wallet registered for "${ui.name}"`);
+    getWalletForHandle: (handle: UiWallet | UiWalletAccount) => {
+        // Account handle? Resolve by object identity, like the real WeakMap registry.
+        const rawFromAccount = accountToRaw.get(handle as unknown as object);
+        if (rawFromAccount) return rawFromAccount;
+        // Otherwise it's a wallet handle — resolve the latest raw wallet by name.
+        const raw = nameToRaw.get((handle as UiWallet).name);
+        if (!raw) throw new Error(`No raw wallet registered for "${(handle as UiWallet).name}"`);
         return raw;
     },
 }));
@@ -119,14 +125,20 @@ export let connectMock = vi.fn<() => Promise<void>>().mockResolvedValue(undefine
 export let disconnectMock = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
 export let signInMock: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue([{}]);
 export let signMessageMock: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue([{ signature: new Uint8Array(64) }]);
-export let eventListenerCleanup: ReturnType<typeof vi.fn> = vi.fn();
+export let eventListenerCleanup: ReturnType<typeof vi.fn<() => void>> = vi.fn<() => void>();
 
-// Captured wallet event handler — tests call this to simulate wallet change events.
-export let walletEventHandler: ((properties: Record<string, unknown>) => void) | null = null;
+// Active `standard:events` change handlers, keyed by wallet name. The store
+// subscribes to *every* discovered wallet, so a single slot can't represent
+// them; tests fire a specific wallet's handler via `emitWalletChange` and check
+// whether a wallet is subscribed via `walletEventHandlers.has(name)`.
+export const walletEventHandlers = new Map<string, (props: Record<string, unknown>) => void>();
+export function emitWalletChange(name: string, props: Record<string, unknown>): void {
+    walletEventHandlers.get(name)?.(props);
+}
 
 type IdentifierString = `${string}:${string}`;
 
-function resolveFeatureImpl(feature: IdentifierString): unknown {
+function resolveFeatureImpl(feature: IdentifierString, walletName?: string): unknown {
     if (feature === 'standard:connect') {
         return { connect: connectMock, version: '1.0.0' };
     }
@@ -136,8 +148,11 @@ function resolveFeatureImpl(feature: IdentifierString): unknown {
     if (feature === 'standard:events') {
         return {
             on: (_event: string, handler: (properties: Record<string, unknown>) => void) => {
-                walletEventHandler = handler;
-                return eventListenerCleanup;
+                if (walletName) walletEventHandlers.set(walletName, handler);
+                return () => {
+                    if (walletName) walletEventHandlers.delete(walletName);
+                    eventListenerCleanup();
+                };
             },
             version: '1.0.0',
         };
@@ -171,7 +186,7 @@ vi.mock('@wallet-standard/ui-features', () => ({
         if (!wallet.features.includes(feature)) {
             throw new Error(`Wallet "${wallet.name}" does not support ${feature}`);
         }
-        return resolveFeatureImpl(feature);
+        return resolveFeatureImpl(feature, wallet.name);
     },
 }));
 
@@ -194,6 +209,9 @@ export function registerWallet(uiWallet: UiWallet): void {
     const raw = createMockRawWallet(uiWallet);
     rawToUi.set(raw, uiWallet);
     nameToRaw.set(uiWallet.name, raw);
+    for (const account of uiWallet.accounts) {
+        accountToRaw.set(account as unknown as object, raw);
+    }
     registeredWallets.push(raw);
 }
 
@@ -202,6 +220,9 @@ export function updateRegisteredWallet(uiWallet: UiWallet): void {
     const raw = nameToRaw.get(uiWallet.name);
     if (raw) {
         rawToUi.set(raw, uiWallet);
+        for (const account of uiWallet.accounts) {
+            accountToRaw.set(account as unknown as object, raw);
+        }
     }
 }
 
@@ -232,6 +253,7 @@ function clearRegistry(): void {
     nameToRaw.clear();
     registryListeners.register = [];
     registryListeners.unregister = [];
+    walletEventHandlers.clear();
 }
 
 // -- Lifecycle --------------------------------------------------------------
@@ -243,8 +265,7 @@ beforeEach(() => {
     signInMock = vi.fn().mockResolvedValue([{}]);
     signMessageMock = vi.fn().mockResolvedValue([{ signature: new Uint8Array(64) }]);
     createSignerMock = vi.fn<(...args: unknown[]) => unknown>().mockReturnValue(mockSigner);
-    eventListenerCleanup = vi.fn();
-    walletEventHandler = null;
+    eventListenerCleanup = vi.fn<() => void>();
 });
 
 afterEach(() => {

--- a/packages/kit-plugin-wallet/test/store.test.ts
+++ b/packages/kit-plugin-wallet/test/store.test.ts
@@ -11,6 +11,7 @@ import {
     createMockUiWallet,
     createSignerMock,
     disconnectMock,
+    emitWalletChange,
     lateRegisterWallet,
     registerWallet,
     registryListeners,
@@ -18,7 +19,7 @@ import {
     signMessageMock,
     unregisterWallet,
     updateRegisteredWallet,
-    walletEventHandler,
+    walletEventHandlers,
 } from './_setup';
 
 describe.skipIf(__BROWSER__)('store (SSR / non-browser)', () => {
@@ -1668,7 +1669,7 @@ describe.skipIf(!__BROWSER__)('store wallet events (browser)', () => {
         wallet: ReturnType<typeof createMockUiWallet>,
     ) {
         await store.connect(wallet);
-        expect(walletEventHandler).not.toBeNull();
+        expect(walletEventHandlers.has(wallet.name)).toBe(true);
     }
 
     it('disconnects when wallet no longer passes filter after feature change', async () => {
@@ -1695,7 +1696,7 @@ describe.skipIf(!__BROWSER__)('store wallet events (browser)', () => {
                 name: 'TestWallet',
             }),
         );
-        walletEventHandler!({ features: true });
+        emitWalletChange('TestWallet', { features: true });
 
         const state = store.getState();
         expect(state.status).toBe('disconnected');
@@ -1722,7 +1723,7 @@ describe.skipIf(!__BROWSER__)('store wallet events (browser)', () => {
                 name: 'TestWallet',
             }),
         );
-        walletEventHandler!({ chains: true });
+        emitWalletChange('TestWallet', { chains: true });
 
         expect(store.getState().status).toBe('disconnected');
     });
@@ -1752,7 +1753,7 @@ describe.skipIf(!__BROWSER__)('store wallet events (browser)', () => {
                 name: 'TestWallet',
             }),
         );
-        walletEventHandler!({ chains: true });
+        emitWalletChange('TestWallet', { chains: true });
 
         // Still connected, and the signer was recreated for the regenerated account.
         const state = store.getState();
@@ -1781,7 +1782,7 @@ describe.skipIf(!__BROWSER__)('store wallet events (browser)', () => {
                 name: 'TestWallet',
             }),
         );
-        walletEventHandler!({ accounts: true });
+        emitWalletChange('TestWallet', { accounts: true });
 
         const state = store.getState();
         expect(state.status).toBe('connected');
@@ -1802,7 +1803,7 @@ describe.skipIf(!__BROWSER__)('store wallet events (browser)', () => {
         const snapshotBefore = store.getState();
 
         // Trigger accounts change but with same account reference.
-        walletEventHandler!({ accounts: true });
+        emitWalletChange('TestWallet', { accounts: true });
 
         // Snapshot should be stable — no unnecessary state change.
         expect(store.getState()).toBe(snapshotBefore);
@@ -1826,7 +1827,7 @@ describe.skipIf(!__BROWSER__)('store wallet events (browser)', () => {
                 name: 'TestWallet',
             }),
         );
-        walletEventHandler!({ accounts: true });
+        emitWalletChange('TestWallet', { accounts: true });
 
         const state = store.getState();
         expect(state.status).toBe('disconnected');
@@ -1845,7 +1846,7 @@ describe.skipIf(!__BROWSER__)('store wallet events (browser)', () => {
         await connectToWallet(store, mockWallet);
 
         // Trigger feature change — store should stay connected with a valid signer.
-        walletEventHandler!({ features: true });
+        emitWalletChange('TestWallet', { features: true });
 
         const state = store.getState();
         expect(state.status).toBe('connected');
@@ -1869,7 +1870,7 @@ describe.skipIf(!__BROWSER__)('store wallet events (browser)', () => {
         // A change event fires but nothing the signer depends on changed — the
         // registry returns the same account/wallet handles. The snapshot must
         // stay referentially stable and the signer must not be recreated.
-        walletEventHandler!({ features: true });
+        emitWalletChange('TestWallet', { features: true });
 
         expect(store.getState()).toBe(before);
         expect(createSignerMock).not.toHaveBeenCalled();
@@ -1899,7 +1900,7 @@ describe.skipIf(!__BROWSER__)('store wallet events (browser)', () => {
                 name: 'TestWallet',
             }),
         );
-        walletEventHandler!({ features: true });
+        emitWalletChange('TestWallet', { features: true });
 
         const state = store.getState();
         expect(state.status).toBe('connected');
@@ -1928,7 +1929,7 @@ describe.skipIf(!__BROWSER__)('store wallet events (browser)', () => {
                 name: 'TestWallet',
             }),
         );
-        walletEventHandler!({ accounts: true, features: true });
+        emitWalletChange('TestWallet', { accounts: true, features: true });
 
         // Signer should be created for account2 (the new account), not account1.
         expect(store.getState().connected!.account.address).toBe(account2.address);
@@ -1957,7 +1958,7 @@ describe.skipIf(!__BROWSER__)('store wallet events (browser)', () => {
                 name: 'TestWallet',
             }),
         );
-        walletEventHandler!({ accounts: true });
+        emitWalletChange('TestWallet', { accounts: true });
 
         const state = store.getState();
         expect(state.status).toBe('connected');
@@ -1993,7 +1994,7 @@ describe.skipIf(!__BROWSER__)('store wallet events (browser)', () => {
                 name: 'TestWallet',
             }),
         );
-        walletEventHandler!({ features: true });
+        emitWalletChange('TestWallet', { features: true });
 
         const state = store.getState();
         expect(state.status).toBe('disconnected');
@@ -2319,7 +2320,7 @@ describe.skipIf(!__BROWSER__)('store auto-connect (browser)', () => {
         // wallet events after disposal.
         expect(store.getState().status).not.toBe('connected');
         expect(store.getState().connected).toBeNull();
-        expect(walletEventHandler).toBeNull();
+        expect(walletEventHandlers.has('TestWallet')).toBe(false);
     });
 
     it('does not reconnect when disposed during the auto-connect storage read', async () => {
@@ -2346,7 +2347,7 @@ describe.skipIf(!__BROWSER__)('store auto-connect (browser)', () => {
         // subscription, or report itself connected.
         expect(store.getState().status).not.toBe('connected');
         expect(store.getState().connected).toBeNull();
-        expect(walletEventHandler).toBeNull();
+        expect(walletEventHandlers.has('TestWallet')).toBe(false);
         expect(connectMock).not.toHaveBeenCalled();
     });
 });
@@ -2487,5 +2488,84 @@ describe.skipIf(!__BROWSER__)('store late wallet registration (browser)', () => 
 
         expect(store.getState().status).toBe('disconnected');
         expect(storage.getItem('kit-wallet')).toBeNull();
+    });
+});
+
+// -- All-wallets subscription tests -------------------------------------------
+
+describe.skipIf(!__BROWSER__)('store all-wallets subscription (browser)', () => {
+    it("keeps a non-active wallet's accounts live in the discovered list", async () => {
+        const aAccount = createMockAccount('11111111111111111111111111111111');
+        const walletA = createMockUiWallet({ accounts: [aAccount], name: 'WalletA' });
+        const walletB = createMockUiWallet({ accounts: [], name: 'WalletB' });
+        registerWallet(walletA);
+        registerWallet(walletB);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(walletA);
+        expect(store.getState().connected!.wallet.name).toBe('WalletA');
+
+        // WalletB (non-active) authorizes an account and fires its change event.
+        const bAccount = createMockAccount('3JF3sEqM796hk5WFqA6EtmEwJQ9quALszsfJyvXNQKy3');
+        updateRegisteredWallet(createMockUiWallet({ accounts: [bAccount], name: 'WalletB' }));
+        emitWalletChange('WalletB', { accounts: true });
+
+        // Its accounts must be reflected in `wallets` without switching the active
+        // connection — previously this stayed stale (no subscription for non-active).
+        const state = store.getState();
+        expect(state.connected!.wallet.name).toBe('WalletA');
+        const b = state.wallets.find(w => w.name === 'WalletB')!;
+        expect(b.accounts.length).toBe(1);
+    });
+
+    it('subscribes to wallets registered after store creation', () => {
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        expect(store.getState().wallets.length).toBe(0);
+
+        const account = createMockAccount();
+        lateRegisterWallet(createMockUiWallet({ accounts: [account], name: 'LateWallet' }));
+
+        // A change from the late-registered wallet is observed (it got subscribed).
+        const more = createMockAccount('4Ss5JMkXAD9Z7cktFEdrqeMuT6jGMF1pVozTyPHZ6zT4');
+        updateRegisteredWallet(createMockUiWallet({ accounts: [account, more], name: 'LateWallet' }));
+        emitWalletChange('LateWallet', { accounts: true });
+        expect(store.getState().wallets.find(w => w.name === 'LateWallet')!.accounts.length).toBe(2);
+    });
+
+    it('unsubscribes a wallet when it unregisters', () => {
+        const wallet = createMockUiWallet({ accounts: [createMockAccount()], name: 'Gone' });
+        registerWallet(wallet);
+        createWalletStore({ chain: 'solana:mainnet', storage: null });
+        expect(walletEventHandlers.has('Gone')).toBe(true);
+        unregisterWallet(wallet);
+        expect(walletEventHandlers.has('Gone')).toBe(false);
+    });
+
+    it('tears down all subscriptions on dispose', () => {
+        registerWallet(createMockUiWallet({ accounts: [createMockAccount()], name: 'W1' }));
+        registerWallet(createMockUiWallet({ accounts: [], name: 'W2' }));
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        expect(walletEventHandlers.size).toBe(2);
+        store[Symbol.dispose]();
+        expect(walletEventHandlers.size).toBe(0);
+    });
+
+    it('does not notify listeners for a no-op change on a non-active wallet', async () => {
+        const account = createMockAccount();
+        const walletA = createMockUiWallet({ accounts: [account], name: 'WalletA' });
+        const walletB = createMockUiWallet({
+            accounts: [createMockAccount('5bV6jUfhDHCQVA1WfKBUnXUsboJgoKgkzkKcxr3joew5')],
+            name: 'WalletB',
+        });
+        registerWallet(walletA);
+        registerWallet(walletB);
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(walletA);
+
+        const listener = vi.fn();
+        store.subscribe(listener);
+        // Fire a change that doesn't alter WalletB's visible set (same accounts).
+        emitWalletChange('WalletB', { accounts: true });
+        expect(listener).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Previously we only subscribed to change events for the connected wallet, which meant that if an authorized but not currently active wallet changed eg its account list then we wouldn't be subscribed to those changes.

This also enables adding cross-wallet account selection and disconnecting a non-active wallet, which are current API gaps.