### PR TITLE
wallet plugin: cross-wallet selectAccount and targeted disconnect

### DIFF
--- a/.changeset/fair-kids-shine.md
+++ b/.changeset/fair-kids-shine.md
@@ -1,0 +1,13 @@
+---
+'@solana/kit-plugin-wallet': minor
+---
+
+Add cross-wallet account selection and targeted disconnect.
+
+`selectAccount` now accepts an account belonging to any authorized wallet, not just the active one. When the account belongs to a different authorized wallet, the active connection switches to it synchronously (no reconnect prompt), leaving the previously-active wallet authorized. The owning wallet is resolved from the account handle's identity, so selection is unambiguous even when the same address is authorized in two different wallets.
+
+This also means that we can synchronously transition from `disconnected` to `connected` by calling `selectAccount` with a previously authorized but not currently active account. This would previously throw `WALLET__NOT_CONNECTED`. Now throws `WALLET__ACCOUNT_NOT_AVAILABLE` only when the selected account is not available/not authorized.
+
+`disconnect` now takes an optional leading `wallet` argument — `disconnect(wallet?, options?)`. Passing a non-active authorized wallet deauthorizes just that wallet (calling `standard:disconnect` if supported) while leaving the active connection, status, and persisted account untouched; a wallet that is already gone or lacks `standard:disconnect` is a forgiving no-op. Calling `disconnect()` with no argument still disconnects the active wallet as before.
+
+**Breaking:** `client.wallet.disconnect` gained a leading `wallet` parameter. Callers passing options as the first argument must move them to the second: `disconnect(options)` becomes `disconnect(undefined, options)`.

--- a/packages/kit-plugin-wallet/README.md
+++ b/packages/kit-plugin-wallet/README.md
@@ -149,9 +149,9 @@ All wallet state is accessed via `client.wallet.getState()`, which returns a ref
     }
     ```
 
-- **`disconnect()`** — Disconnect the active wallet.
+- **`disconnect(wallet?)`** — Disconnects an authorized wallet. If `wallet` is not provided, disconnects the active wallet.
 
-- **`selectAccount(account)`** — Switch to a different account within an already-authorized wallet without reconnecting.
+- **`selectAccount(account)`** — Switch to a different account within any already-authorized wallet without reconnecting.
 
     ```ts
     client.wallet.selectAccount(accounts[0]);

--- a/packages/kit-plugin-wallet/src/store.ts
+++ b/packages/kit-plugin-wallet/src/store.ts
@@ -477,17 +477,14 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
         }
     }
 
-    async function disconnect(options?: WalletActionOptions): Promise<void> {
+    async function disconnect(wallet?: UiWallet, options?: WalletActionOptions): Promise<void> {
         options?.abortSignal?.throwIfAborted();
 
-        // No connected wallet, but an auto-reconnect may still be in flight:
-        // during 'reconnecting' a silent reconnect or the late-registration
-        // listener can complete and connect, overriding this explicit
-        // disconnect. Record the user's intent so auto-connect won't re-arm,
-        // tear down the late-registration listener, and bump the generation so
-        // any in-flight connect/signIn/silent-reconnect bails at its guard
-        // instead of resuming.
-        if (!state.connectedWallet) {
+        const target = wallet ?? state.connectedWallet;
+
+        // Nothing to disconnect (no arg, nothing active): cancel any pending reconnect, and
+        // supersede in-flight attempts.
+        if (!target) {
             userHasSelected = true;
             cancelReconnect();
             connectGeneration++;
@@ -496,32 +493,63 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
             return;
         }
 
-        const currentWallet = state.connectedWallet;
-        // Bump the generation so this disconnect supersedes any connect/signIn
-        // that was already in flight (its prompt opened before the user chose to
-        // disconnect): that attempt captured an earlier generation, so it will
-        // bail at its guard rather than establishing a connection the user has
-        // since dismissed. Mirrors the not-connected branch above — newest action
-        // wins. A connect/signIn started *after* this disconnect bumps the
-        // generation again, so the `finally` guard skips `disconnectLocally` and
-        // leaves the newer connection intact.
-        const generation = ++connectGeneration;
-        // Mark this wallet as disconnecting
-        disconnectingWalletName = currentWallet.name;
-        updateState({ status: 'disconnecting' });
+        const isActive = state.connectedWallet != null && state.connectedWallet.name === target.name;
 
-        try {
-            if (currentWallet.features.includes(StandardDisconnect)) {
-                const disconnectFeature = getWalletFeature(
-                    currentWallet,
-                    StandardDisconnect,
-                ) as StandardDisconnectFeature[typeof StandardDisconnect];
-                await disconnectFeature.disconnect();
+        if (isActive) {
+            const currentWallet = state.connectedWallet!;
+            // Bump generation so this disconnect supersedes any in-flight connect/signIn.
+            const generation = ++connectGeneration;
+            disconnectingWalletName = currentWallet.name;
+            updateState({ status: 'disconnecting' });
+            try {
+                if (currentWallet.features.includes(StandardDisconnect)) {
+                    const disconnectFeature = getWalletFeature(
+                        currentWallet,
+                        StandardDisconnect,
+                    ) as StandardDisconnectFeature[typeof StandardDisconnect];
+                    await disconnectFeature.disconnect();
+                }
+            } finally {
+                if (generation === connectGeneration) {
+                    disconnectLocally();
+                }
             }
+            return;
+        }
+
+        // targeted disconnect but wallet gone: leave the active connection, status,
+        // and persisted key untouched.
+        if (!isWalletStillAvailable(target)) {
+            return; // already gone / not authorized — forgiving no-op
+        }
+        const refreshedTarget = refreshUiWallet(target);
+        if (!refreshedTarget.features.includes(StandardDisconnect)) {
+            return; // can't deauthorize without standard:disconnect — no-op
+        }
+        // Guard against a concurrent select/connect into this wallet for the await;
+        // restore the prior marker afterward (it may belong to an active disconnect).
+        const prevDisconnecting = disconnectingWalletName;
+        disconnectingWalletName = refreshedTarget.name;
+        try {
+            const disconnectFeature = getWalletFeature(
+                refreshedTarget,
+                StandardDisconnect,
+            ) as StandardDisconnectFeature[typeof StandardDisconnect];
+            await disconnectFeature.disconnect();
         } finally {
-            // Only clean up if no new connect/signIn started while we were awaiting.
-            if (generation === connectGeneration) {
-                disconnectLocally();
+            if (disconnectingWalletName === refreshedTarget.name) {
+                disconnectingWalletName = prevDisconnecting;
+            }
+            // Reflect the now-empty accounts immediately — but only if the store
+            // is still live. If it was disposed while `standard:disconnect`
+            // awaited, the disposer has already torn down every wallet-event
+            // subscription and cleared the map; deauthorizing the target
+            // regenerated its handle, so `reconcileWalletList` returns a fresh
+            // array, and letting `updateState` run here would re-invoke
+            // `syncWalletEventSubscriptions` and re-subscribe every wallet into
+            // the cleared map — listeners the disposer can no longer clean up.
+            if (!disposed) {
+                updateState({ wallets: reconcileWalletList() });
             }
         }
     }
@@ -566,14 +594,34 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
     }
 
     function selectAccount(account: UiWalletAccount): void {
-        if (!state.connectedWallet) {
+        // Derive the owning wallet from the account handle. `getWalletForHandle`
+        // keys a WeakMap on handle identity, so this is unambiguous even when the
+        // same address is authorized in two wallets. A stale/unregistered handle
+        // throws — surface it as ACCOUNT_NOT_AVAILABLE.
+        let owner: UiWallet;
+        try {
+            owner = getOrCreateUiWalletForStandardWallet(getWalletForHandle(account));
+        } catch {
+            throw new SolanaError(SOLANA_ERROR__WALLET__ACCOUNT_NOT_AVAILABLE, {
+                account: account.address,
+                operation: 'selectAccount',
+            });
+        }
+
+        // The owner must be currently authorized (discovered + passes the filter).
+        if (!isWalletStillAvailable(owner)) {
+            throw new SolanaError(SOLANA_ERROR__WALLET__ACCOUNT_NOT_AVAILABLE, {
+                account: account.address,
+                operation: 'selectAccount',
+            });
+        }
+
+        // Reject selecting into a wallet that is mid-disconnect.
+        if (owner.name === disconnectingWalletName) {
             throw new SolanaError(SOLANA_ERROR__WALLET__NOT_CONNECTED, { operation: 'selectAccount' });
         }
-        // Reject if this wallet is disconnecting
-        if (state.connectedWallet.name === disconnectingWalletName) {
-            throw new SolanaError(SOLANA_ERROR__WALLET__NOT_CONNECTED, { operation: 'selectAccount' });
-        }
-        const refreshed = refreshUiWallet(state.connectedWallet);
+
+        const refreshed = refreshUiWallet(owner);
         const selectedAccount = refreshed.accounts.find(a => a.address === account.address);
         if (!selectedAccount) {
             throw new SolanaError(SOLANA_ERROR__WALLET__ACCOUNT_NOT_AVAILABLE, {
@@ -581,16 +629,20 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
                 operation: 'selectAccount',
             });
         }
+
         userHasSelected = true;
-        // Bump the generation so this selection supersedes any in-flight
-        // connect/signIn
+        // Supersede any in-flight connect/signIn.
         ++connectGeneration;
-        // Change status back to `connected` if something in-flight changed it
-        // But skip recreating the signer if account is the same as before
+
+        // No-op fast path: the same account is already active.
         if (selectedAccount === state.account && refreshed === state.connectedWallet) {
             updateState({ status: 'connected' });
             return;
         }
+
+        // Switch the active connection (owner may differ from the current one). The
+        // previously-active wallet is left authorized — we never disconnect it. Its
+        // event subscription persists, so switching back stays live.
         const signer = tryCreateSigner(selectedAccount);
         updateState({ account: selectedAccount, connectedWallet: refreshed, signer, status: 'connected' });
         persistAccount(selectedAccount, refreshed);

--- a/packages/kit-plugin-wallet/src/types.ts
+++ b/packages/kit-plugin-wallet/src/types.ts
@@ -244,13 +244,19 @@ export type WalletNamespace = {
     connect: (wallet: UiWallet, options?: WalletActionOptions) => Promise<readonly UiWalletAccount[]>;
 
     /**
-     * Disconnect the active wallet. Calls `standard:disconnect` if supported.
+     * Disconnect a wallet. Calls `standard:disconnect` if supported.
+     *
+     * `wallet` defaults to the active wallet. Passing a non-active, currently
+     * authorized wallet deauthorizes it (calling `standard:disconnect` if
+     * supported) while leaving the active connection untouched. A `wallet`
+     * that doesn't support `standard:disconnect`, or one that is already
+     * unauthorized/unregistered, is a forgiving no-op.
      *
      * @throws `options.abortSignal.reason` if the signal is already aborted
      *   when the action is called. Aborts after the wallet call has been
      *   dispatched do not take effect.
      */
-    disconnect: (options?: WalletActionOptions) => Promise<void>;
+    disconnect: (wallet?: UiWallet, options?: WalletActionOptions) => Promise<void>;
 
     // -- State --
     /**
@@ -263,13 +269,19 @@ export type WalletNamespace = {
     getState: () => WalletState;
 
     /**
-     * Switch to a different account within the connected wallet. Creates and
-     * caches a new signer for the selected account.
+     * Select an account, creating and caching a new signer for it.
      *
-     * @throws `SolanaError(SOLANA_ERROR__WALLET__NOT_CONNECTED)` if no wallet is
-     *   connected, or the connected wallet is currently disconnecting.
+     * The account may belong to any currently authorized wallet, not only the
+     * active one. When it belongs to a different authorized wallet, the active
+     * connection switches to that wallet synchronously (no prompt), leaving the
+     * previously active wallet authorized. If the store is currently 'disconnected',
+     * this allows transitioning to 'connected' synchronously.
+     *
      * @throws `SolanaError(SOLANA_ERROR__WALLET__ACCOUNT_NOT_AVAILABLE)` if the
-     *   specified account is not among the connected wallet's accounts.
+     *   account's handle cannot be resolved to a currently authorized wallet, or
+     *   the account is not among that wallet's accounts.
+     * @throws `SolanaError(SOLANA_ERROR__WALLET__NOT_CONNECTED)` if the account's
+     *   wallet is currently disconnecting.
      */
     selectAccount: (account: UiWalletAccount) => void;
 

--- a/packages/kit-plugin-wallet/test/store.test.ts
+++ b/packages/kit-plugin-wallet/test/store.test.ts
@@ -1,4 +1,8 @@
-import { SOLANA_ERROR__WALLET__NOT_CONNECTED, SolanaError } from '@solana/kit';
+import {
+    SOLANA_ERROR__WALLET__ACCOUNT_NOT_AVAILABLE,
+    SOLANA_ERROR__WALLET__NOT_CONNECTED,
+    SolanaError,
+} from '@solana/kit';
 import { isWalletStandardError } from '@wallet-standard/errors';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -456,11 +460,14 @@ describe.skipIf(!__BROWSER__)('store (browser)', () => {
         expect(listener).not.toHaveBeenCalled();
     });
 
-    it('selectAccount throws when not connected', () => {
+    it('selectAccount throws for an unauthorized account when not connected', () => {
         const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
         const account = createMockAccount();
         expect(() => store.selectAccount(account)).toThrow(
-            new SolanaError(SOLANA_ERROR__WALLET__NOT_CONNECTED, { operation: 'selectAccount' }),
+            new SolanaError(SOLANA_ERROR__WALLET__ACCOUNT_NOT_AVAILABLE, {
+                account: account.address,
+                operation: 'selectAccount',
+            }),
         );
     });
 
@@ -531,6 +538,16 @@ describe.skipIf(!__BROWSER__)('store (browser)', () => {
         const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
         await store.connect(mockWallet);
 
+        // Register `staleAccount2` as a real (if short-lived) handle for this
+        // address before the wallet regenerates it again as `refreshedAccount2` —
+        // otherwise handle-based resolution has nothing to resolve `staleAccount2`
+        // against (it was never a handle the registry ever handed out).
+        updateRegisteredWallet(
+            createMockUiWallet({
+                accounts: [account1, staleAccount2],
+                name: 'TestWallet',
+            }),
+        );
         updateRegisteredWallet(
             createMockUiWallet({
                 accounts: [account1, refreshedAccount2],
@@ -1593,7 +1610,9 @@ describe.skipIf(!__BROWSER__)('store action abort signals (browser)', () => {
 
         // disconnect bails before calling the wallet's disconnect feature, so the
         // existing connection is left untouched.
-        await expect(store.disconnect({ abortSignal: controller.signal })).rejects.toThrow('aborted by caller');
+        await expect(store.disconnect(undefined, { abortSignal: controller.signal })).rejects.toThrow(
+            'aborted by caller',
+        );
         expect(disconnectMock).not.toHaveBeenCalled();
         expect(store.getState().status).toBe('connected');
     });
@@ -2567,5 +2586,379 @@ describe.skipIf(!__BROWSER__)('store all-wallets subscription (browser)', () => 
         // Fire a change that doesn't alter WalletB's visible set (same accounts).
         emitWalletChange('WalletB', { accounts: true });
         expect(listener).not.toHaveBeenCalled();
+    });
+});
+
+describe.skipIf(!__BROWSER__)('store selectAccount cross-wallet (browser)', () => {
+    it('switches the active connection to an account of another authorized wallet', async () => {
+        const aAccount = createMockAccount('11111111111111111111111111111111');
+        const bAccount = createMockAccount('3JF3sEqM796hk5WFqA6EtmEwJQ9quALszsfJyvXNQKy3');
+        const walletA = createMockUiWallet({ accounts: [aAccount], name: 'WalletA' });
+        const walletB = createMockUiWallet({ accounts: [bAccount], name: 'WalletB' });
+        registerWallet(walletA);
+        registerWallet(walletB);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(walletA);
+        connectMock.mockClear();
+
+        store.selectAccount(bAccount);
+
+        const state = store.getState();
+        expect(state.connected!.wallet.name).toBe('WalletB');
+        expect(state.connected!.account.address).toBe(bAccount.address);
+        expect(connectMock).not.toHaveBeenCalled(); // synchronous switch, no prompt
+        // WalletA stays authorized in the discovered list.
+        expect(state.wallets.find(w => w.name === 'WalletA')!.accounts.length).toBe(1);
+    });
+
+    it('resolves the owning wallet by account handle, not address', async () => {
+        // Same address authorized in two different wallets — distinct handles.
+        const shared = '4Ss5JMkXAD9Z7cktFEdrqeMuT6jGMF1pVozTyPHZ6zT4';
+        const aAccount = createMockAccount(shared);
+        const bAccount = createMockAccount(shared);
+        const walletA = createMockUiWallet({ accounts: [aAccount], name: 'WalletA' });
+        const walletB = createMockUiWallet({ accounts: [bAccount], name: 'WalletB' });
+        registerWallet(walletA);
+        registerWallet(walletB);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(walletA);
+
+        store.selectAccount(bAccount);
+        expect(store.getState().connected!.wallet.name).toBe('WalletB');
+    });
+
+    it('throws ACCOUNT_NOT_AVAILABLE for an account whose wallet is not authorized', async () => {
+        const walletA = createMockUiWallet({
+            accounts: [createMockAccount('11111111111111111111111111111111')],
+            name: 'WalletA',
+        });
+        registerWallet(walletA);
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(walletA);
+
+        // An account handle never registered in the store.
+        const orphan = createMockAccount('5bV6jUfhDHCQVA1WfKBUnXUsboJgoKgkzkKcxr3joew5');
+        expect(() => store.selectAccount(orphan)).toThrow(
+            new SolanaError(SOLANA_ERROR__WALLET__ACCOUNT_NOT_AVAILABLE, {
+                account: orphan.address,
+                operation: 'selectAccount',
+            }),
+        );
+    });
+
+    it('still selects within the connected wallet', async () => {
+        const a1 = createMockAccount('11111111111111111111111111111111');
+        const a2 = createMockAccount('3JF3sEqM796hk5WFqA6EtmEwJQ9quALszsfJyvXNQKy3');
+        const walletA = createMockUiWallet({ accounts: [a1, a2], name: 'WalletA' });
+        registerWallet(walletA);
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(walletA);
+
+        store.selectAccount(a2);
+        expect(store.getState().connected!.account.address).toBe(a2.address);
+    });
+
+    it('adopts a connection when selecting an authorized account while disconnected', () => {
+        // No prior connect: status is 'disconnected', but WalletA is discovered
+        // and authorized. The old `if (!state.connectedWallet) throw NOT_CONNECTED`
+        // guard is gone, so this is a valid synchronous adopt (no reconnect prompt).
+        const aAccount = createMockAccount('11111111111111111111111111111111');
+        const walletA = createMockUiWallet({ accounts: [aAccount], name: 'WalletA' });
+        registerWallet(walletA);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        expect(store.getState().status).toBe('disconnected');
+
+        store.selectAccount(aAccount);
+
+        const state = store.getState();
+        expect(state.status).toBe('connected');
+        expect(state.connected!.wallet.name).toBe('WalletA');
+        expect(state.connected!.account.address).toBe(aAccount.address);
+        expect(connectMock).not.toHaveBeenCalled(); // synchronous adopt, no prompt
+    });
+});
+
+describe.skipIf(!__BROWSER__)('store disconnect targeting (browser)', () => {
+    it('disconnects a non-active wallet without touching the active connection', async () => {
+        const aAccount = createMockAccount('11111111111111111111111111111111');
+        const bAccount = createMockAccount('3JF3sEqM796hk5WFqA6EtmEwJQ9quALszsfJyvXNQKy3');
+        const walletA = createMockUiWallet({
+            accounts: [aAccount],
+            features: ['standard:connect', 'standard:disconnect', 'standard:events'],
+            name: 'WalletA',
+        });
+        const walletB = createMockUiWallet({
+            accounts: [bAccount],
+            features: ['standard:connect', 'standard:disconnect', 'standard:events'],
+            name: 'WalletB',
+        });
+        registerWallet(walletA);
+        registerWallet(walletB);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(walletA); // A is active
+
+        // Disconnecting B empties its accounts on the underlying wallet.
+        disconnectMock.mockImplementationOnce(() => {
+            updateRegisteredWallet(
+                createMockUiWallet({
+                    accounts: [],
+                    features: ['standard:connect', 'standard:disconnect', 'standard:events'],
+                    name: 'WalletB',
+                }),
+            );
+            return Promise.resolve();
+        });
+
+        await store.disconnect(walletB);
+
+        const state = store.getState();
+        expect(disconnectMock).toHaveBeenCalledTimes(1);
+        expect(state.status).toBe('connected'); // A untouched
+        expect(state.connected!.wallet.name).toBe('WalletA');
+        expect(state.wallets.find(w => w.name === 'WalletB')!.accounts.length).toBe(0);
+    });
+
+    it('disconnect() with no argument still disconnects the active wallet', async () => {
+        const walletA = createMockUiWallet({
+            accounts: [createMockAccount()],
+            features: ['standard:connect', 'standard:disconnect', 'standard:events'],
+            name: 'WalletA',
+        });
+        registerWallet(walletA);
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(walletA);
+
+        await store.disconnect();
+        expect(store.getState().status).toBe('disconnected');
+        expect(store.getState().connected).toBeNull();
+    });
+
+    it('disconnect(activeWallet) behaves like disconnect()', async () => {
+        const walletA = createMockUiWallet({
+            accounts: [createMockAccount()],
+            features: ['standard:connect', 'standard:disconnect', 'standard:events'],
+            name: 'WalletA',
+        });
+        registerWallet(walletA);
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(walletA);
+        const active = store.getState().connected!.wallet;
+
+        await store.disconnect(active);
+        expect(store.getState().status).toBe('disconnected');
+        expect(store.getState().connected).toBeNull();
+    });
+
+    it('is a no-op for a non-active wallet lacking standard:disconnect', async () => {
+        const walletA = createMockUiWallet({
+            accounts: [createMockAccount('11111111111111111111111111111111')],
+            features: ['standard:connect', 'standard:disconnect', 'standard:events'],
+            name: 'WalletA',
+        });
+        const walletB = createMockUiWallet({
+            accounts: [createMockAccount('3JF3sEqM796hk5WFqA6EtmEwJQ9quALszsfJyvXNQKy3')],
+            features: ['standard:connect', 'standard:events'], // no disconnect
+            name: 'WalletB',
+        });
+        registerWallet(walletA);
+        registerWallet(walletB);
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(walletA);
+
+        await store.disconnect(walletB);
+        expect(disconnectMock).not.toHaveBeenCalled();
+        expect(store.getState().connected!.wallet.name).toBe('WalletA');
+    });
+
+    it('does not re-subscribe wallet events when disposed during an in-flight non-active disconnect', async () => {
+        const walletA = createMockUiWallet({
+            accounts: [createMockAccount('11111111111111111111111111111111')],
+            features: ['standard:connect', 'standard:disconnect', 'standard:events'],
+            name: 'WalletA',
+        });
+        const walletB = createMockUiWallet({
+            accounts: [createMockAccount('3JF3sEqM796hk5WFqA6EtmEwJQ9quALszsfJyvXNQKy3')],
+            features: ['standard:connect', 'standard:disconnect', 'standard:events'],
+            name: 'WalletB',
+        });
+        registerWallet(walletA);
+        registerWallet(walletB);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(walletA); // A active; both A and B subscribed
+        expect(walletEventHandlers.size).toBe(2);
+
+        // B's disconnect hangs until we resolve the gate, then empties B's accounts
+        // — regenerating B's handle so the `finally`'s `reconcileWalletList` returns
+        // a fresh array (which would otherwise re-run `syncWalletEventSubscriptions`).
+        const gate = Promise.withResolvers<void>();
+        disconnectMock.mockImplementationOnce(() =>
+            gate.promise.then(() => {
+                updateRegisteredWallet(
+                    createMockUiWallet({
+                        accounts: [],
+                        features: ['standard:connect', 'standard:disconnect', 'standard:events'],
+                        name: 'WalletB',
+                    }),
+                );
+            }),
+        );
+
+        const pending = store.disconnect(walletB); // suspends at the awaited disconnect
+        store[Symbol.dispose](); // dispose mid-await tears down every subscription
+        expect(walletEventHandlers.size).toBe(0);
+
+        gate.resolve();
+        await pending; // finally runs — must not re-subscribe into the cleared map
+
+        expect(walletEventHandlers.size).toBe(0);
+    });
+
+    it('rejects a targeted non-active disconnect with the signal reason and mutates nothing when already aborted', async () => {
+        const aAccount = createMockAccount('11111111111111111111111111111111');
+        const bAccount = createMockAccount('3JF3sEqM796hk5WFqA6EtmEwJQ9quALszsfJyvXNQKy3');
+        const walletA = createMockUiWallet({
+            accounts: [aAccount],
+            features: ['standard:connect', 'standard:disconnect', 'standard:events'],
+            name: 'WalletA',
+        });
+        const walletB = createMockUiWallet({
+            accounts: [bAccount],
+            features: ['standard:connect', 'standard:disconnect', 'standard:events'],
+            name: 'WalletB',
+        });
+        registerWallet(walletA);
+        registerWallet(walletB);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(walletA); // A is active
+
+        const controller = new AbortController();
+        controller.abort(new Error('aborted by caller'));
+
+        // The pre-await throwIfAborted() is the first thing disconnect does, so the
+        // non-active branch bails before invoking the wallet's disconnect feature or
+        // marking B as the wallet mid-disconnect.
+        await expect(store.disconnect(walletB, { abortSignal: controller.signal })).rejects.toThrow(
+            'aborted by caller',
+        );
+        expect(disconnectMock).not.toHaveBeenCalled();
+
+        // No `disconnectingWalletName` mutation leaked: selecting into B still
+        // succeeds. Had the abort fired after marking B mid-disconnect, this would
+        // throw NOT_CONNECTED via selectAccount's mid-disconnect guard.
+        store.selectAccount(bAccount);
+        expect(store.getState().connected!.wallet.name).toBe('WalletB');
+    });
+
+    it('does not cancel a pending reconnect when disconnecting a non-active wallet', async () => {
+        vi.useFakeTimers();
+
+        const savedAccount = createMockAccount('11111111111111111111111111111111');
+        const otherAccount = createMockAccount('3JF3sEqM796hk5WFqA6EtmEwJQ9quALszsfJyvXNQKy3');
+        // The saved wallet is never registered, so the store stays parked in the
+        // reconnect-wait path. A different wallet is authorized alongside it.
+        const otherWallet = createMockUiWallet({
+            accounts: [otherAccount],
+            features: ['standard:connect', 'standard:disconnect', 'standard:events'],
+            name: 'OtherWallet',
+        });
+        registerWallet(otherWallet);
+
+        const storage = createMockStorage({ 'kit-wallet': `SavedWallet:${savedAccount.address}` });
+        const store = createWalletStore({ chain: 'solana:mainnet', storage });
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(store.getState().status).toBe('reconnecting');
+
+        // Only a no-target disconnect() cancels the pending reconnect. A targeted
+        // disconnect of some other authorized wallet must leave it armed.
+        await store.disconnect(otherWallet);
+        expect(disconnectMock).toHaveBeenCalledTimes(1);
+        expect(store.getState().status).toBe('reconnecting');
+
+        // Prove the reconnect listener genuinely survived: the saved wallet
+        // registering late still triggers the silent reconnect. Were a refactor
+        // to "tidy up" by calling cancelReconnect() here, this register would go
+        // unheard and the store would never leave 'reconnecting'.
+        lateRegisterWallet(createMockUiWallet({ accounts: [savedAccount], name: 'SavedWallet' }));
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(store.getState().status).toBe('connected');
+        expect(store.getState().connected!.wallet.name).toBe('SavedWallet');
+
+        vi.useRealTimers();
+    });
+
+    it('selectAccount on the active account throws while that wallet is mid-disconnect', async () => {
+        const aAccount = createMockAccount('11111111111111111111111111111111');
+        const walletA = createMockUiWallet({
+            accounts: [aAccount],
+            features: ['standard:connect', 'standard:disconnect', 'standard:events'],
+            name: 'WalletA',
+        });
+        registerWallet(walletA);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(walletA);
+
+        // Hold the wallet-side disconnect pending so WalletA stays marked mid-disconnect.
+        const pendingDisconnect = Promise.withResolvers<void>();
+        disconnectMock.mockReturnValueOnce(pendingDisconnect.promise);
+        const disconnectPromise = store.disconnect(); // active disconnect
+        expect(store.getState().status).toBe('disconnecting');
+
+        // Re-selecting the very account being torn down must reject via the
+        // mid-disconnect guard rather than slip through selectAccount's
+        // same-account no-op fast path. This is the one selectAccount path that
+        // still surfaces NOT_CONNECTED instead of ACCOUNT_NOT_AVAILABLE.
+        expect(() => store.selectAccount(aAccount)).toThrow(
+            new SolanaError(SOLANA_ERROR__WALLET__NOT_CONNECTED, { operation: 'selectAccount' }),
+        );
+
+        pendingDisconnect.resolve();
+        await disconnectPromise;
+    });
+
+    it('selectAccount into a non-active wallet throws while that wallet is mid-disconnect', async () => {
+        const aAccount = createMockAccount('11111111111111111111111111111111');
+        const bAccount = createMockAccount('3JF3sEqM796hk5WFqA6EtmEwJQ9quALszsfJyvXNQKy3');
+        const walletA = createMockUiWallet({
+            accounts: [aAccount],
+            features: ['standard:connect', 'standard:disconnect', 'standard:events'],
+            name: 'WalletA',
+        });
+        const walletB = createMockUiWallet({
+            accounts: [bAccount],
+            features: ['standard:connect', 'standard:disconnect', 'standard:events'],
+            name: 'WalletB',
+        });
+        registerWallet(walletA);
+        registerWallet(walletB);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(walletA); // A active, B authorized but non-active
+
+        // Hold B's disconnect pending so B is marked mid-disconnect while A stays live.
+        const pendingDisconnect = Promise.withResolvers<void>();
+        disconnectMock.mockReturnValueOnce(pendingDisconnect.promise);
+        const disconnectPromise = store.disconnect(walletB);
+
+        // Switching into an account of the wallet being deauthorized must reject.
+        // The guard keys off the owner derived from the account handle (B), not the
+        // active connection (A) — so this throws even though A is what's connected.
+        expect(() => store.selectAccount(bAccount)).toThrow(
+            new SolanaError(SOLANA_ERROR__WALLET__NOT_CONNECTED, { operation: 'selectAccount' }),
+        );
+
+        // A was never touched by the rejected switch.
+        expect(store.getState().connected!.wallet.name).toBe('WalletA');
+
+        pendingDisconnect.resolve();
+        await disconnectPromise;
     });
 });


### PR DESCRIPTION
`selectAccount(account)` now accepts an authorized account from any wallet, not only the currently active one. This enables the ability to switch between accounts in different wallets in the Kit example app, which the non-plugin implementation has. It is still synchronous, as it is only for already authorized accounts and doesn't need to communicate with the wallet.

`disconnect()` now has an optional first argument `wallet`, which allows disconnecting a wallet that is not currently active. This is a capability the react example app had, and means you don't need to switch to an account in wallet A to disconnect wallet A from the app. If the  `wallet` arg is omitted, or is the currently active wallet, then the existing behaviour is retained - the active wallet is disconnected, and the wallet state reflects no active connection.

This is a breaking change, as there was already an optional `options` argument which now needs to be the second arg.