### PR TITLE
Make wallet-plugin `payer`/`identity` getters non-enumerable

### DIFF
--- a/.changeset/quick-spoons-repair.md
+++ b/.changeset/quick-spoons-repair.md
@@ -1,0 +1,7 @@
+---
+'@solana/kit-plugin-wallet': patch
+---
+
+Make the `payer` and `identity` client getters non-enumerable
+
+The dynamic `client.payer` / `client.identity` getters installed by `walletSigner`, `walletPayer`, and `walletIdentity` throw when no signer is connected. They were also enumerable, so any code that enumerates the client and reads its values — an object spread, `Object.entries`, `structuredClone`, or React's dev-mode component-render prop diffing — would invoke them and throw while the client was merely disconnected or still pending. In a React app this surfaced as a hard freeze when the client was rebuilt and briefly published in a disconnected state (for example, switching networks). The getters are now non-enumerable, so enumeration skips them; capability detection via `'payer' in client` and explicit `client.payer` access (which still throws when disconnected, by design) are unchanged.

--- a/packages/kit-plugin-wallet/src/wallet.ts
+++ b/packages/kit-plugin-wallet/src/wallet.ts
@@ -22,7 +22,9 @@ function defineSignerGetter(
 ): void {
     Object.defineProperty(additions, property, {
         configurable: true,
-        enumerable: true,
+        // Non-enumerable on purpose: this getter throws when no signer is connected, so we
+        // don't want things like Object.entries to read it.
+        enumerable: false,
         get() {
             const state = store.getState();
             if (!state.connected) {

--- a/packages/kit-plugin-wallet/test/wallet.test.ts
+++ b/packages/kit-plugin-wallet/test/wallet.test.ts
@@ -142,6 +142,22 @@ describe.skipIf(!__BROWSER__)('walletSigner plugin (browser)', () => {
         expect(() => client.payer).toThrow('No signing wallet connected');
         expect(() => client.identity).toThrow('No signing wallet connected');
     });
+
+    it('does not throw when the disconnected client is enumerated (payer/identity are non-enumerable)', () => {
+        const client = createClient().use(walletSigner({ chain: 'solana:mainnet', storage: null }));
+        // The signer getters throw when disconnected, so they must be non-enumerable — otherwise
+        // any enumeration that reads values (an object spread, `Object.entries`, `structuredClone`,
+        // or React's dev-mode component-render prop diffing) would invoke them and throw while the
+        // client is merely disconnected/pending.
+        expect(() => ({ ...client })).not.toThrow();
+        expect(() => Object.entries(client)).not.toThrow();
+        expect(Object.keys(client)).not.toContain('payer');
+        expect(Object.keys(client)).not.toContain('identity');
+        // They remain detectable as capabilities and still throw on explicit access.
+        expect('payer' in client).toBe(true);
+        expect('identity' in client).toBe(true);
+        expect(() => client.payer).toThrow('No signing wallet connected');
+    });
 });
 
 describe.skipIf(!__BROWSER__)('walletIdentity plugin (browser)', () => {


### PR DESCRIPTION
The dynamic `payer` and `identity` getters that `walletSigner`, `walletPayer`, and `walletIdentity` install on the client throw when no signer is connected. This is by design and allows us to keep the same signature for them. But they were configured as `enumerable: true`, which meant that code like object spread, `Object.entries`, and something deep in React's internals, would throw when they were unset.

Making them non-enumerable means that code like this doesn't throw, but detection like `'payer' in client`, and explicit access (which of course throws) still works.