### PR TITLE
Widen wallet `signMessage` to accept a `ReadonlyUint8Array`

### DIFF
--- a/.changeset/sparkly-nights-stick.md
+++ b/.changeset/sparkly-nights-stick.md
@@ -1,0 +1,7 @@
+---
+'@solana/kit-plugin-wallet': patch
+---
+
+Widen `signMessage` to accept a `ReadonlyUint8Array`
+
+The `signMessage` method on the wallet namespace now accepts a `ReadonlyUint8Array` as well as a `Uint8Array`. The bytes are only read before being passed to the wallet's `solana:signMessage` feature, so callers holding read-only bytes — such as the output of a `@solana/kit` codec — no longer need to cast.

--- a/packages/kit-plugin-wallet/src/store.ts
+++ b/packages/kit-plugin-wallet/src/store.ts
@@ -1,4 +1,5 @@
 import {
+    type ReadonlyUint8Array,
     type SignatureBytes,
     SOLANA_ERROR__WALLET__ACCOUNT_NOT_AVAILABLE,
     SOLANA_ERROR__WALLET__NOT_CONNECTED,
@@ -650,7 +651,7 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
 
     // -- Message signing ---------------------------------------------------
 
-    async function signMessage(message: Uint8Array, options?: WalletActionOptions): Promise<SignatureBytes> {
+    async function signMessage(message: ReadonlyUint8Array, options?: WalletActionOptions): Promise<SignatureBytes> {
         options?.abortSignal?.throwIfAborted();
         const { connectedWallet, account } = state;
         if (!connectedWallet || !account) {
@@ -667,7 +668,9 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
             account,
             SolanaSignMessage,
         ) as SolanaSignMessageFeature[typeof SolanaSignMessage];
-        const [output] = await signMessageFeature.signMessage({ account, message });
+        // The wallet-standard `SolanaSignMessageInput.message` is a mutable `Uint8Array`; signing
+        // only reads the bytes, so coerce the read-only input at this single boundary.
+        const [output] = await signMessageFeature.signMessage({ account, message: message as Uint8Array });
         return output.signature as SignatureBytes;
     }
 

--- a/packages/kit-plugin-wallet/src/types.ts
+++ b/packages/kit-plugin-wallet/src/types.ts
@@ -1,4 +1,4 @@
-import type { MessageSigner, SignatureBytes, TransactionSigner } from '@solana/kit';
+import type { MessageSigner, ReadonlyUint8Array, SignatureBytes, TransactionSigner } from '@solana/kit';
 import type { SolanaChain } from '@solana/wallet-standard-chains';
 import type { SolanaSignInInput, SolanaSignInOutput } from '@solana/wallet-standard-features';
 import type { IdentifierString } from '@wallet-standard/base';
@@ -333,7 +333,7 @@ export type WalletNamespace = {
      *   when the action is called. Aborts after the wallet call has been
      *   dispatched do not take effect.
      */
-    signMessage: (message: Uint8Array, options?: WalletActionOptions) => Promise<SignatureBytes>;
+    signMessage: (message: ReadonlyUint8Array, options?: WalletActionOptions) => Promise<SignatureBytes>;
 
     /**
      * Subscribe to any wallet state change. Compatible with React's


### PR DESCRIPTION
The wallet `signMessage` takes a `Uint8Array`, forcing callers with a Kit `ReadonlyUint8Array` to cast. This PR changes it to accept `ReadonlyUint8Array`.

The wallet-standard feature still uses `Uint8Array` so we cast at that boundary.