### PR TITLE
Add readiness helpers for the initial auto-reconnect warm-up

### DIFF
--- a/.changeset/major-lilies-roll.md
+++ b/.changeset/major-lilies-roll.md
@@ -1,0 +1,11 @@
+---
+'@solana/kit-plugin-wallet': minor
+---
+
+Add readiness helpers for the initial auto-reconnect warm-up.
+
+A freshly built client runs a silent auto-reconnect that briefly passes through the `'pending'` / `'reconnecting'` statuses before settling. This release adds an imperative and a declarative way to wait for that warm-up, both keyed off the same status set (and both ignoring user-initiated `'connecting'` / `'disconnecting'`, so a normal connect stays interactive):
+
+- `client.wallet.whenReady()` returns a promise that resolves once the warm-up has settled. It's an advanced signal for apps that rebuild the client at runtime — for example, to change chain, since each wallet plugin is bound to a single chain. Awaiting it before swapping the new client in lets you hold the previous UI until the rebuilt client is ready instead of flashing a reconnecting state on every switch. Disposing a client mid-warm-up settles its status to `'disconnected'` and resolves any pending `whenReady()` promise, so a superseded client never leaves an `await` hanging.
+- `useIsWalletReady()` (from `@solana/kit-plugin-wallet/react`) returns `false` during the warm-up and `true` once it settles, and `WalletReadyGate` is a thin `<Suspense fallback>`-shaped wrapper over it. Use them to hold back wallet-dependent UI so a persisted wallet never flashes "disconnected" before it reconnects.
+- `isWalletWarmingUp(status)` is the shared predicate all of the above are built on, now exported for non-React consumers that bind `subscribe` / `getState` to their own framework and want to gate on the warm-up statuses directly.

--- a/packages/kit-plugin-wallet/README.md
+++ b/packages/kit-plugin-wallet/README.md
@@ -175,11 +175,12 @@ The `@solana/kit-plugin-wallet/react` subpath exposes hooks for reading wallet s
 
 The **state** hooks subscribe via `useSyncExternalStore`, each to a single slice of `WalletState`, so a component only re-renders when the slice it reads changes:
 
-| Hook                 | Returns                                                        |
-| -------------------- | -------------------------------------------------------------- |
-| `useWalletStatus`    | The current `WalletStatus`.                                    |
-| `useConnectedWallet` | The active connection (`{ account, signer, wallet }`) or null. |
-| `useWallets`         | The discovered wallets for the client's chain.                 |
+| Hook                 | Returns                                                                          |
+| -------------------- | -------------------------------------------------------------------------------- |
+| `useWalletStatus`    | The current `WalletStatus`.                                                      |
+| `useConnectedWallet` | The active connection (`{ account, signer, wallet }`) or null.                   |
+| `useWallets`         | The discovered wallets for the client's chain.                                   |
+| `useIsWalletReady`   | `false` while the initial warm-up is in progress (`'pending'`/`'reconnecting'`). |
 
 The **action** hooks wrap the async wallet actions with `useAction` from `@solana/react`, returning its result (`dispatch`, `dispatchAsync`, `data`, `error`, `status`, `isRunning`, `reset`, …). The hook manages the `AbortSignal` internally, so an in-flight call is aborted when a newer one is dispatched:
 
@@ -212,9 +213,63 @@ function WalletButton() {
 }
 ```
 
+### Gating UI on the initial warm-up
+
+A freshly built client runs a silent auto-reconnect on mount, briefly passing through `'pending'` and `'reconnecting'` before it settles. If you render wallet-dependent UI immediately, a persisted wallet flashes "disconnected" for a frame before it reconnects. `useIsWalletReady` reports `false` for the duration of that warm-up and `true` once it settles, so you can hold back the wallet-dependent parts while painting the rest of the app:
+
+```tsx
+import { useIsWalletReady, WalletReadyGate } from '@solana/kit-plugin-wallet/react';
+
+// Hide a whole subtree until the connection settles:
+function App() {
+    return (
+        <WalletReadyGate fallback={<Spinner />}>
+            <WalletDependentUI />
+        </WalletReadyGate>
+    );
+}
+
+// Or read the boolean directly for finer control (e.g. disabling a button):
+function ConnectButton() {
+    const isReady = useIsWalletReady();
+    return <button disabled={!isReady}>Connect</button>;
+}
+```
+
+`WalletReadyGate` is a thin wrapper over `useIsWalletReady`. Its props are shaped like React's `<Suspense fallback>`, but it is synchronous — it renders `fallback` directly off the reactive status rather than suspending, so it needs no `<Suspense>` ancestor. Both gate on the same warm-up set as `whenReady()` below, so they stay in sync — and like `whenReady()`, they ignore user-initiated `'connecting'` / `'disconnecting'`. To genuinely suspend a subtree, throw the Suspense-safe `whenReady()` promise from your own component instead.
+
+### Advanced: seamless client swaps with `whenReady()`
+
+> Most apps don't need this. It only matters if you **rebuild the client at runtime** — for example, to change chain — since each wallet plugin is bound to a single chain.
+
+Every freshly built client runs a silent auto-reconnect that briefly passes through the `'pending'` and `'reconnecting'` statuses. If you publish the new client as soon as you build it, the UI may flash that reconnecting state on every switch. `client.wallet.whenReady()` returns a promise that resolves once the status has left `'pending'` / `'reconnecting'`, so you can build the new client, wait for it to settle, and only then swap it in — keeping the previous client live until the new one is ready:
+
+```ts
+import { createClient } from '@solana/kit';
+import { walletSigner } from '@solana/kit-plugin-wallet';
+
+// On a chain switch, hold the previous client until the rebuilt one is ready:
+const next = createClient().use(walletSigner({ chain }));
+await next.wallet.whenReady();
+swapInClient(next); // publish `next`, then dispose the client it replaced
+```
+
+`whenReady()` deliberately does **not** wait for user-initiated `connect` / `disconnect` / `signIn` (those pass through `'connecting'` / `'disconnecting'`), so it only ever blocks on the initial warm-up — a normal connect stays interactive.
+
+Disposing a client mid-warm-up settles its status to `'disconnected'` and resolves any pending `whenReady()` promise — a superseded client never leaves an `await` hanging. Check `getState()` after awaiting if you need to tell a ready connection from a disposed (or never-connected) client.
+
 ## Framework integration
 
-The plugin exposes `subscribe` and `getState` for binding wallet state to any UI framework.
+The plugin exposes `subscribe` and `getState` for binding wallet state to any UI framework. To gate UI on the initial auto-reconnect warm-up without React, pass `getState().status` through `isWalletWarmingUp` — the same predicate that backs `whenReady()` and the [React readiness helpers](#gating-ui-on-the-initial-warm-up), so all three stay in sync:
+
+```ts
+import { isWalletWarmingUp } from '@solana/kit-plugin-wallet';
+
+client.wallet.subscribe(() => {
+    const { status } = client.wallet.getState();
+    setLoading(isWalletWarmingUp(status)); // true while 'pending' / 'reconnecting'
+});
+```
 
 **React** — prefer the ready-made [React hooks](#react-hooks) above; they wrap the pattern below. To bind state manually (e.g. to read the whole snapshot at once), use `useSyncExternalStore` for concurrent-mode-safe rendering:
 

--- a/packages/kit-plugin-wallet/src/__typetests__/wallet-typetest.ts
+++ b/packages/kit-plugin-wallet/src/__typetests__/wallet-typetest.ts
@@ -7,6 +7,7 @@ import {
     TransactionSigner,
 } from '@solana/kit';
 
+import { isWalletWarmingUp, type WalletStatus } from '../index';
 import { ClientWithWallet } from '../types';
 import { walletIdentity, walletPayer, walletSigner, walletWithoutSigner } from '../wallet';
 
@@ -94,6 +95,20 @@ const signer = null as unknown as TransactionSigner;
         const result = walletWithoutSigner(config)(base);
         result.payer satisfies TransactionSigner;
         result.identity satisfies TransactionSigner;
+    }
+}
+
+// [DESCRIBE] isWalletWarmingUp
+{
+    // It is exported from the root entry and narrows a status to a boolean.
+    {
+        const status = null as unknown as WalletStatus;
+        isWalletWarmingUp(status) satisfies boolean;
+    }
+    // It requires a WalletStatus argument.
+    {
+        // @ts-expect-error isWalletWarmingUp requires a status argument.
+        isWalletWarmingUp();
     }
 }
 

--- a/packages/kit-plugin-wallet/src/index.ts
+++ b/packages/kit-plugin-wallet/src/index.ts
@@ -1,2 +1,3 @@
+export * from './status';
 export * from './types';
 export * from './wallet';

--- a/packages/kit-plugin-wallet/src/react/__typetests__/index.ts
+++ b/packages/kit-plugin-wallet/src/react/__typetests__/index.ts
@@ -1,16 +1,20 @@
 import type { ReadonlyUint8Array, SignatureBytes } from '@solana/kit';
 import type { SolanaSignInInput, SolanaSignInOutput } from '@solana/wallet-standard-features';
 import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui';
+import type { ReactNode } from 'react';
 
 import type { WalletState, WalletStatus } from '../../types';
 import {
     useConnect,
     useConnectedWallet,
     useDisconnect,
+    useIsWalletReady,
     useSelectAccount,
     useSignIn,
     useSignMessage,
     useWallets,
+    WalletReadyGate,
+    type WalletReadyGateProps,
     useWalletStatus,
 } from '../index';
 
@@ -20,6 +24,25 @@ import {
 {
     const status = useWalletStatus();
     status satisfies WalletStatus;
+}
+
+// [DESCRIBE] useIsWalletReady
+{
+    const isReady = useIsWalletReady();
+    isReady satisfies boolean;
+}
+
+// [DESCRIBE] WalletReadyGate
+{
+    // Both `children` and `fallback` are required `ReactNode` props.
+    ({ children: 'ready', fallback: 'loading' }) satisfies WalletReadyGateProps;
+    // The gate is callable and its return type is assignable to `ReactNode`.
+    const rendered: ReactNode = WalletReadyGate({ children: null, fallback: null });
+    void rendered;
+}
+{
+    // @ts-expect-error `fallback` is required.
+    ({ children: null }) satisfies WalletReadyGateProps;
 }
 
 // [DESCRIBE] useConnectedWallet

--- a/packages/kit-plugin-wallet/src/react/index.ts
+++ b/packages/kit-plugin-wallet/src/react/index.ts
@@ -2,8 +2,10 @@ import type { ReadonlyUint8Array, SignatureBytes } from '@solana/kit';
 import { type ActionResult, useAction, useClientCapability } from '@solana/react';
 import type { SolanaSignInInput, SolanaSignInOutput } from '@solana/wallet-standard-features';
 import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui';
+import type { ReactNode } from 'react';
 import { useSyncExternalStore } from 'react';
 
+import { isWalletWarmingUp } from '../status';
 import type { ClientWithWallet, WalletNamespace, WalletState, WalletStatus } from '../types';
 
 /**
@@ -94,6 +96,37 @@ export function useWallets(): readonly UiWallet[] {
     const wallet = useWalletNamespace('useWallets');
     const getWallets = () => wallet.getState().wallets;
     return useSyncExternalStore(wallet.subscribe, getWallets, getWallets);
+}
+
+/**
+ * Reports whether the wallet client has finished its initial auto-reconnect "warm-up".
+ *
+ * Returns `false` while the status is `'pending'` or `'reconnecting'` — the transient states a
+ * freshly built client passes through while it silently re-establishes a persisted connection — and
+ * `true` once it settles into any stable state (`'connected'`, `'disconnected'`, or a user-initiated
+ * `'connecting'` / `'disconnecting'`). This is the declarative, render-time counterpart to the
+ * store's imperative `whenReady()`, gating on the exact same set of statuses.
+ *
+ * Use it to hold back wallet-dependent UI until the connection has settled, so a persisted wallet
+ * never flashes "disconnected" before it reconnects. Re-renders only when this readiness boolean
+ * flips, not on every status change. Requires a `ClientProvider` whose client has a wallet plugin
+ * installed; asserts this at mount with {@link useClientCapability}.
+ *
+ * @returns `true` once the warm-up has settled, otherwise `false`.
+ *
+ * @example
+ * ```tsx
+ * const isReady = useIsWalletReady();
+ * return <button disabled={!isReady}>Connect</button>;
+ * ```
+ *
+ * @see {@link WalletReadyGate}
+ * @see {@link useWalletStatus}
+ */
+export function useIsWalletReady(): boolean {
+    const wallet = useWalletNamespace('useIsWalletReady');
+    const getIsReady = () => !isWalletWarmingUp(wallet.getState().status);
+    return useSyncExternalStore(wallet.subscribe, getIsReady, getIsReady);
 }
 
 // -- Action hooks -----------------------------------------------------------
@@ -223,4 +256,46 @@ export function useSignMessage(): ActionResult<[message: ReadonlyUint8Array], Si
  */
 export function useSelectAccount(): WalletNamespace['selectAccount'] {
     return useWalletNamespace('useSelectAccount').selectAccount;
+}
+
+// -- Components -------------------------------------------------------------
+
+/**
+ * Props for {@link WalletReadyGate}.
+ */
+export type WalletReadyGateProps = Readonly<{
+    /** Rendered once the wallet client has finished its initial auto-reconnect warm-up. */
+    children: ReactNode;
+    /** Rendered while the client is still warming up (`'pending'` / `'reconnecting'`). */
+    fallback: ReactNode;
+}>;
+
+/**
+ * Renders `fallback` while the wallet client is still in its initial auto-reconnect warm-up
+ * (`'pending'` / `'reconnecting'`), then reveals `children` once the connection has settled.
+ *
+ * A declarative wrapper over {@link useIsWalletReady} for the common case of holding back a whole
+ * wallet-dependent subtree. Its props are shaped like React's `<Suspense fallback>`, but it is
+ * synchronous — it renders `fallback` directly off the reactive status rather than suspending, so it
+ * needs no `<Suspense>` ancestor. It lets an app paint its chrome immediately while gating only the
+ * wallet-dependent UI, so a persisted wallet never flashes "disconnected" before it silently
+ * reconnects. For finer control (disabling a button, showing an inline spinner) read the boolean from
+ * {@link useIsWalletReady} directly. To actually suspend a subtree instead, throw the Suspense-safe
+ * {@link WalletNamespace.whenReady} promise from your own component.
+ *
+ * Requires a `ClientProvider` whose client has a wallet plugin installed; asserts this at mount with
+ * {@link useClientCapability}.
+ *
+ * @example
+ * ```tsx
+ * <WalletReadyGate fallback={<Spinner />}>
+ *     <WalletDependentApp />
+ * </WalletReadyGate>
+ * ```
+ *
+ * @see {@link useIsWalletReady}
+ * @see {@link useWalletStatus}
+ */
+export function WalletReadyGate({ children, fallback }: WalletReadyGateProps): ReactNode {
+    return useIsWalletReady() ? children : fallback;
 }

--- a/packages/kit-plugin-wallet/src/status.ts
+++ b/packages/kit-plugin-wallet/src/status.ts
@@ -1,0 +1,33 @@
+import type { WalletStatus } from './types';
+
+/**
+ * Reports whether a {@link WalletStatus} belongs to the initial auto-reconnect
+ * "warm-up": `'pending'` (before auto-reconnect has resolved) and
+ * `'reconnecting'` (silently re-establishing a persisted connection). During
+ * this window a persisted wallet is on its way back, so wallet-dependent UI
+ * should usually hold rather than flash a "disconnected" state.
+ *
+ * User-initiated `'connecting'` / `'disconnecting'` are deliberately excluded —
+ * a normal connect or disconnect is not a warm-up and must stay interactive.
+ *
+ * This is the single source of truth for "warm-up" across the plugin: the
+ * store's {@link WalletNamespace.whenReady} waits for the status to leave this set, and the
+ * React `useIsWalletReady` hook and `WalletReadyGate` component gate on its
+ * negation. Use it directly to gate on warm-up from a non-React consumer.
+ *
+ * @param status - A status from `client.wallet.getState().status`.
+ * @returns `true` while the client is warming up, otherwise `false`.
+ *
+ * @example
+ * ```ts
+ * client.wallet.subscribe(() => {
+ *     const { status } = client.wallet.getState();
+ *     setLoading(isWalletWarmingUp(status));
+ * });
+ * ```
+ *
+ * @see {@link WalletNamespace.whenReady} — the imperative (promise-based) counterpart.
+ */
+export function isWalletWarmingUp(status: WalletStatus): boolean {
+    return status === 'pending' || status === 'reconnecting';
+}

--- a/packages/kit-plugin-wallet/src/store.ts
+++ b/packages/kit-plugin-wallet/src/store.ts
@@ -27,6 +27,7 @@ import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui';
 import { getWalletAccountFeature, getWalletFeature } from '@wallet-standard/ui-features';
 import { getOrCreateUiWalletForStandardWallet, getWalletForHandle } from '@wallet-standard/ui-registry';
 
+import { isWalletWarmingUp } from './status';
 import type {
     WalletActionOptions,
     WalletNamespace,
@@ -86,6 +87,7 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
                 Promise.reject(new SolanaError(SOLANA_ERROR__WALLET__NOT_CONNECTED, { operation: 'signMessage' })),
             subscribe: () => () => {},
             subscribeSigner: () => () => {},
+            whenReady: () => Promise.resolve(),
             [Symbol.dispose]: () => {},
         };
     }
@@ -113,6 +115,11 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
     let disposed = false;
     // Wallet that is in the process of disconnecting, stored to guard against re-connecting to it if a future connect fails
     let disconnectingWalletName: string | null = null;
+    // Deferred backing `whenReady`. Created lazily while the status is transient
+    // (see `isWalletWarmingUp`) and resolved by `updateState` once the status
+    // settles, so `whenReady` can hand out a stable promise for the duration of
+    // one warm-up episode (required by React Suspense).
+    let readyDeferred: PromiseWithResolvers<void> | null = null;
 
     // Resolve storage: default to localStorage in browser, null to disable.
     // Merely *accessing* `localStorage` throws a `SecurityError` in sandboxed
@@ -160,6 +167,15 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
         const prev = state;
         state = { ...state, ...updates };
 
+        // Resolve `whenReady` the moment the status leaves the transient
+        // warm-up set. `readyDeferred` is only ever created while transient (in
+        // `whenReady`), so clearing it here lets the next transient episode arm
+        // a fresh one.
+        if (isWalletWarmingUp(prev.status) && !isWalletWarmingUp(state.status)) {
+            readyDeferred?.resolve();
+            readyDeferred = null;
+        }
+
         if (state.wallets !== prev.wallets) {
             syncWalletEventSubscriptions(state.wallets);
         }
@@ -182,6 +198,18 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
         if (signerChanged) {
             signerListeners.forEach(l => l());
         }
+    }
+
+    // Advanced: see the `whenReady` docblock on `WalletNamespace`. Returns a
+    // stable, already-resolved promise once the initial warm-up has settled;
+    // while transient, returns the same pending promise on every call so it is
+    // safe to throw for React Suspense.
+    function whenReady(): Promise<void> {
+        if (!isWalletWarmingUp(state.status)) {
+            return Promise.resolve();
+        }
+        readyDeferred ??= Promise.withResolvers<void>();
+        return readyDeferred.promise;
     }
 
     // -- Signer creation ---------------------------------------------------
@@ -931,6 +959,7 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
                 signerListeners.delete(listener);
             };
         },
+        whenReady,
         [Symbol.dispose]: () => {
             // Invalidate any in-flight connect/signIn/silent-reconnect so they
             // bail instead of resuming after disposal (which would re-subscribe
@@ -949,6 +978,13 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
             cancelReconnect();
             listeners.clear();
             signerListeners.clear();
+            // A store disposed mid-warm-up will never finish warming up, so
+            // settle the status to 'disconnected'.
+            // Runs after the listener sets are cleared, so no one is notified of
+            // the final transition.
+            if (isWalletWarmingUp(state.status)) {
+                updateState({ status: 'disconnected' });
+            }
         },
     };
 }

--- a/packages/kit-plugin-wallet/src/types.ts
+++ b/packages/kit-plugin-wallet/src/types.ts
@@ -347,6 +347,43 @@ export type WalletNamespace = {
      * ```
      */
     subscribe: (listener: () => void) => () => void;
+
+    /**
+     * **Advanced.** Resolves once the initial connection attempt has settled —
+     * i.e. {@link getState}'s `status` is no longer `'pending'` or
+     * `'reconnecting'`.
+     *
+     * You only need this if your app **rebuilds the client at runtime** (for
+     * example, to change chain). Each freshly built client runs a silent
+     * auto-reconnect that briefly passes through `'pending'`/`'reconnecting'`;
+     * awaiting this lets you hold the previous UI until the new client is ready
+     * instead of flashing a "reconnecting" state on every swap. Most apps never
+     * call it — subscribe to `status` with {@link subscribe} instead.
+     *
+     * Does **not** wait for user-initiated `connect`/`disconnect`/`signIn`
+     * (those pass through `'connecting'`/`'disconnecting'`, which count as
+     * ready), so a normal connect never makes this block. While transient it
+     * returns the **same** promise reference on every call, so successive
+     * awaits during one warm-up share a single settlement.
+     *
+     * Disposing the client mid-warm-up settles the status to `'disconnected'`,
+     * so a pending `whenReady()` resolves rather than hanging. Check
+     * {@link getState} after awaiting if you need to distinguish a ready
+     * connection from a disposed (or never-connected) client.
+     *
+     * @returns A promise that resolves with no value once the wallet is past its
+     *   initial `'pending'`/`'reconnecting'` warm-up. Already resolved when the
+     *   status is not transient.
+     *
+     * @example
+     * ```ts
+     * // On a chain switch, hold the old UI until the rebuilt client is ready:
+     * const next = createClient().use(walletSigner({ chain }));
+     * await next.wallet.whenReady();
+     * setClient(next);
+     * ```
+     */
+    whenReady: () => Promise<void>;
 };
 
 /**

--- a/packages/kit-plugin-wallet/test/store.test.ts
+++ b/packages/kit-plugin-wallet/test/store.test.ts
@@ -78,6 +78,11 @@ describe.skipIf(__BROWSER__)('store (SSR / non-browser)', () => {
         const store = createWalletStore({ chain: 'solana:mainnet' });
         expect(() => store[Symbol.dispose]()).not.toThrow();
     });
+
+    it('whenReady resolves immediately on server', async () => {
+        const store = createWalletStore({ chain: 'solana:mainnet' });
+        await expect(store.whenReady()).resolves.toBeUndefined();
+    });
 });
 
 describe.skipIf(!__BROWSER__)('store (browser)', () => {
@@ -2960,5 +2965,115 @@ describe.skipIf(!__BROWSER__)('store disconnect targeting (browser)', () => {
 
         pendingDisconnect.resolve();
         await disconnectPromise;
+    });
+});
+
+// -- whenReady tests ----------------------------------------------------------
+
+describe.skipIf(!__BROWSER__)('store whenReady (browser)', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('resolves immediately when the status has already settled', async () => {
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        expect(store.getState().status).toBe('disconnected');
+        await expect(store.whenReady()).resolves.toBeUndefined();
+    });
+
+    it('stays pending through the warm-up, hands out a stable reference, and resolves once connected', async () => {
+        const account = createMockAccount();
+        const mockWallet = createMockUiWallet({ accounts: [account], name: 'TestWallet' });
+        registerWallet(mockWallet);
+
+        // Hold the silent reconnect so the store lingers in 'reconnecting'.
+        const reconnect = Promise.withResolvers<void>();
+        connectMock.mockReturnValueOnce(reconnect.promise);
+
+        const storage = createMockStorage({ 'kit-wallet': `TestWallet:${account.address}` });
+        const store = createWalletStore({ chain: 'solana:mainnet', storage });
+
+        // 'pending' before the reconnect fires: not resolved, and stable across calls.
+        expect(store.getState().status).toBe('pending');
+        const p = store.whenReady();
+        expect(store.whenReady()).toBe(p);
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(store.getState().status).toBe('reconnecting');
+        // Same transient episode — still the same promise.
+        expect(store.whenReady()).toBe(p);
+        // If `p` were already resolved the race would pick 'ready'; it is still pending.
+        await expect(Promise.race([p.then(() => 'ready'), Promise.resolve('pending')])).resolves.toBe('pending');
+
+        // Let the reconnect complete.
+        reconnect.resolve();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(store.getState().status).toBe('connected');
+        await expect(p).resolves.toBeUndefined();
+
+        // After settling, a fresh call returns an already-resolved promise, not the old one.
+        const after = store.whenReady();
+        expect(after).not.toBe(p);
+        await expect(after).resolves.toBeUndefined();
+    });
+
+    it('resolves when the warm-up settles to disconnected', async () => {
+        const account = createMockAccount();
+        const mockWallet = createMockUiWallet({ accounts: [account], name: 'TestWallet' });
+        registerWallet(mockWallet);
+        connectMock.mockRejectedValueOnce(new Error('Silent connect failed'));
+
+        const storage = createMockStorage({ 'kit-wallet': `TestWallet:${account.address}` });
+        const store = createWalletStore({ chain: 'solana:mainnet', storage });
+
+        expect(store.getState().status).toBe('pending');
+        const p = store.whenReady();
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(store.getState().status).toBe('disconnected');
+        await expect(p).resolves.toBeUndefined();
+    });
+
+    it('resolves when the store is disposed mid warm-up, settling the status to disconnected', async () => {
+        const account = createMockAccount();
+        const mockWallet = createMockUiWallet({ accounts: [account], name: 'TestWallet' });
+        registerWallet(mockWallet);
+
+        // Hold the silent reconnect open so the store lingers in 'reconnecting'.
+        const reconnect = Promise.withResolvers<void>();
+        connectMock.mockReturnValueOnce(reconnect.promise);
+
+        const storage = createMockStorage({ 'kit-wallet': `TestWallet:${account.address}` });
+        const store = createWalletStore({ chain: 'solana:mainnet', storage });
+
+        // Grab a pending `whenReady()` while still warming up.
+        const p = store.whenReady();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(store.getState().status).toBe('reconnecting');
+
+        // Disposal is the warm-up's final settlement: the pending promise
+        // resolves instead of hanging forever, and the status leaves the
+        // transient set so `isWalletWarmingUp` and `whenReady` agree.
+        store[Symbol.dispose]();
+        await expect(p).resolves.toBeUndefined();
+        expect(store.getState().status).toBe('disconnected');
+
+        // Calls made after disposal resolve immediately off the settled status.
+        await expect(store.whenReady()).resolves.toBeUndefined();
+
+        // The reconnect resuming after disposal must not revive the store.
+        reconnect.resolve();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(store.getState().status).toBe('disconnected');
+        expect(store.getState().connected).toBeNull();
+    });
+
+    it('leaves an already-settled status untouched on dispose', async () => {
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(store.getState().status).toBe('disconnected');
+
+        store[Symbol.dispose]();
+        expect(store.getState().status).toBe('disconnected');
+        await expect(store.whenReady()).resolves.toBeUndefined();
     });
 });

--- a/packages/kit-plugin-wallet/test/useWalletState.react.test.tsx
+++ b/packages/kit-plugin-wallet/test/useWalletState.react.test.tsx
@@ -4,7 +4,7 @@ import type { UiWallet } from '@wallet-standard/ui';
 import { createElement, type ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { useConnectedWallet, useWallets, useWalletStatus } from '../src/react';
+import { useConnectedWallet, useIsWalletReady, useWallets, useWalletStatus } from '../src/react';
 import type { WalletState } from '../src/types';
 
 // Unmount rendered trees between tests. This package doesn't enable vitest
@@ -70,6 +70,35 @@ describe('useConnectedWallet', () => {
         const connected = { account: {}, signer: null, wallet: {} } as WalletState['connected'];
         act(() => store.setState({ ...INITIAL, connected, status: 'connected' }));
         expect(result.current).toBe(connected);
+    });
+});
+
+describe('useIsWalletReady', () => {
+    it('reports readiness and re-renders only when the boolean flips', () => {
+        const store = createFakeStore({ ...INITIAL, status: 'pending' });
+        let renderCount = 0;
+        const { result } = renderHook(
+            () => {
+                renderCount++;
+                return useIsWalletReady();
+            },
+            { wrapper: wrapperFor(store) },
+        );
+
+        expect(result.current).toBe(false);
+        const rendersWhileWarmingUp = renderCount;
+
+        // Still warming up (pending -> reconnecting): the boolean stays `false`, so despite the
+        // status changing the hook must not re-render.
+        act(() => store.setState({ ...INITIAL, status: 'reconnecting' }));
+        expect(result.current).toBe(false);
+        expect(renderCount).toBe(rendersWhileWarmingUp);
+
+        // Warm-up settles (reconnecting -> connected): the boolean flips to `true`, triggering a
+        // single re-render.
+        act(() => store.setState({ ...INITIAL, connected: null, status: 'connected' }));
+        expect(result.current).toBe(true);
+        expect(renderCount).toBe(rendersWhileWarmingUp + 1);
     });
 });
 


### PR DESCRIPTION
When the wallet plugin is first created, it has a `pending` state. If it runs auto-reconnect then it uses a `reconnecting` state for this. Then it settles to disconnected/connected. These are intentionally different states to the action-initiated connecting/disconnecting.

This PR adds helpers that allow apps to wait for the plugin to settle to a ready state before rendering it. This is useful to avoid flashing a 'reconnecting' state either on first load or when the Kit client changes, for example when changing chain.

- `client.wallet.whenReady()` returns a promise that resolves after the status settles. This is primarily for apps that are swapping the client, they can await this promise before rendering with the new client. This promise never rejects.
- `isWalletWarmingUp(status)` is a simple predicate, true if the status is `pending` or `reconnecting`, else false. Exported so apps don't need to worry about this plugin implementation detail if they just want a simple ready check for the current status.

In the new `/react` subpath:
- `useIsWalletReady()` is a hook to check if the wallet is ready 
- `<WalletReadyGate fallback={...}>{wallet UI}</WalletReadyGate>` is a React component that can be used to gate rendering UI until the wallet is ready. Useful for eg a wallet connect button, or anything rendering based on the connected state. 

Note that I plan to generalise the `client.wallet.whenReady` pattern into a composable plugin feature similar to dispose, so plugins can just register their `whenReady`, and apps can await a single `whenReady` promise at the client level without knowing which plugins implement it. That is primarily work in the Kit repo, and would just use `client.wallet.whenReady` as the wallet plugin's implementation. So all of this is still required - it'll just get easier to use for apps later.