### PR TITLE
Fix publish: disable ESM splitting between root and react subpath

### DIFF
--- a/.changeset/free-ways-win.md
+++ b/.changeset/free-ways-win.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-wallet': patch
+---
+
+Fix the published package being unusable from any ESM consumer. Because the package builds two entry points (`.` and `./react`) in a single tsup build, tsup's default ESM code-splitting hoisted their shared code into `chunk-*.mjs` files. The package's `files` allow-list only matches the entry files (`dist/index.*`, `dist/react/index.*`), so those chunks were never included in the published tarball, and every entry point's `import './chunk-*.mjs'` failed to resolve (`UNRESOLVED_IMPORT` / `ERR_MODULE_NOT_FOUND`). Code-splitting is now disabled in the shared build config so each entry point is self-contained and the published `files` set is complete.

--- a/packages/kit-plugin-wallet/package.json
+++ b/packages/kit-plugin-wallet/package.json
@@ -64,7 +64,8 @@
     "scripts": {
         "build": "rimraf dist && tsup && tsc -p ./tsconfig.declarations.json",
         "dev": "vitest --project node",
-        "test": "pnpm test:types && pnpm test:treeshakability && pnpm test:unit",
+        "test": "pnpm test:types && pnpm test:treeshakability && pnpm test:packaging && pnpm test:unit",
+        "test:packaging": "node ../../scripts/assert-publishable-dist.mjs",
         "test:treeshakability": "for file in dist/index.*.mjs dist/react/index.*.mjs; do agadoo $file; done",
         "test:types": "tsc --noEmit",
         "test:unit": "vitest run"

--- a/scripts/assert-publishable-dist.mjs
+++ b/scripts/assert-publishable-dist.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// Guards against publishing a package whose built entry points import files that
+// were not included in the npm tarball. This happens when a build emits shared
+// chunks (e.g. tsup code-splitting across multiple entries) but the package's
+// `files` allow-list only matches the entry files, so the chunks silently drop
+// out of the published tarball and every ESM consumer fails to resolve them.
+// @see https://github.com/anza-xyz/kit-plugins — the `@solana/kit-plugin-wallet@0.13.0` incident.
+//
+// Usage: node scripts/assert-publishable-dist.mjs [packageDir]
+// Runs against the current working directory by default.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, posix, relative, resolve } from 'node:path';
+import { argv, cwd, exit } from 'node:process';
+
+const packageDir = resolve(argv[2] ?? cwd());
+
+/** Ask npm which files this package would actually publish. */
+function getPublishedFiles() {
+    const output = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+        cwd: packageDir,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    // `npm pack --json` paths are package-root-relative, POSIX-separated, no `package/` prefix.
+    return new Set(JSON.parse(output)[0].files.map(f => f.path));
+}
+
+/** Extract every relative (`./` or `../`) module specifier referenced by a JS module. */
+function getRelativeSpecifiers(code) {
+    const specifiers = new Set();
+    // Matches: import/export ... from '…', bare `import '…'`, dynamic import('…'), and require('…').
+    const patterns = [
+        /(?:\bimport\b|\bexport\b)[^;'"]*?\bfrom\s*['"]([^'"]+)['"]/g,
+        /\bimport\s*['"]([^'"]+)['"]/g,
+        /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+        /\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+    ];
+    for (const pattern of patterns) {
+        for (const [, specifier] of code.matchAll(pattern)) {
+            if (specifier.startsWith('.')) {
+                specifiers.add(specifier);
+            }
+        }
+    }
+    return specifiers;
+}
+
+/** Resolve a relative specifier (from `fromFile`) to a package-root-relative POSIX path, or null. */
+function resolveSpecifier(fromFile, specifier) {
+    const base = resolve(packageDir, dirname(fromFile), specifier);
+    // tsup emits explicit extensions, but tolerate extensionless specifiers just in case.
+    const candidates = [
+        base,
+        `${base}.mjs`,
+        `${base}.cjs`,
+        `${base}.js`,
+        join(base, 'index.mjs'),
+        join(base, 'index.cjs'),
+        join(base, 'index.js'),
+    ];
+    for (const candidate of candidates) {
+        if (existsSync(candidate)) {
+            return relative(packageDir, candidate).split(/[\\/]/).join(posix.sep);
+        }
+    }
+    return null;
+}
+
+const published = getPublishedFiles();
+const jsEntryPoints = [...published].filter(p => /\.(mjs|cjs|js)$/.test(p));
+
+const problems = [];
+for (const entry of jsEntryPoints) {
+    const absEntry = join(packageDir, entry);
+    if (!existsSync(absEntry)) {
+        continue; // published but not on disk — a separate `files`/build mismatch, not our concern here
+    }
+    const code = readFileSync(absEntry, 'utf8');
+    for (const specifier of getRelativeSpecifiers(code)) {
+        const resolved = resolveSpecifier(entry, specifier);
+        if (resolved == null) {
+            problems.push(`${entry} imports "${specifier}", which does not resolve to any file on disk`);
+        } else if (!published.has(resolved)) {
+            problems.push(`${entry} imports "${specifier}" (→ ${resolved}), which is NOT in the published tarball`);
+        }
+    }
+}
+
+if (problems.length > 0) {
+    console.error(`✗ ${relative(cwd(), packageDir) || '.'}: published entry points reference unpublished files:\n`);
+    for (const problem of problems) {
+        console.error(`  - ${problem}`);
+    }
+    console.error(`\nEvery relative import in a published entry point must itself be published. Check the`);
+    console.error(`package's "files" field and the build's code-splitting settings.`);
+    exit(1);
+}
+
+console.log(
+    `✓ ${relative(cwd(), packageDir) || '.'}: all ${jsEntryPoints.length} published entry points are self-contained.`,
+);

--- a/tsup.config.base.ts
+++ b/tsup.config.base.ts
@@ -38,6 +38,12 @@ export function getBuildConfig(options: BuildOptions): TsupConfig {
         publicDir: true,
         pure: ['process'],
         sourcemap: true,
+        // Keep every entry point self-contained. tsup defaults ESM `splitting` to `true`, which
+        // hoists code shared between entries (e.g. `./index` and `./react`) into `chunk-*` files.
+        // Those chunks are not matched by packages' `files` allow-lists, so they silently drop out
+        // of the published tarball.
+        // @see scripts/assert-publishable-dist.mjs
+        splitting: false,
         treeshake: {
             moduleSideEffects: id => {
                 // This prevents tsup/Rollup from keeping bare `import 'fs'` in browser/RN builds.

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,9 @@
         "test:react-native": {
             "dependsOn": ["^build"]
         },
+        "test:packaging": {
+            "dependsOn": ["build"]
+        },
         "test:treeshakability": {
             "dependsOn": ["build"]
         },


### PR DESCRIPTION
The version of the wallet plugin with the /react subpath does not currently work correctly, because it imports files from `chunk-` files that have not been published.

This is because `tsup` defaults ESM code splitting to true, which creates those chunks, and the `files` in our package.json does not include them.

This PR fixes the package by turning off this splitting. This works for the wallet plugin because the two paths mostly do not share code, only types. One caveat: the `isWalletWarmingUp` function is shared, and is now duplicated between both paths. Crucially they don't share any state, so there's no dual package hazard.

The alternative would be to extend `files` to include the chunks, but I think this is the cleaner option for this plugin.

For this plugin package only, a new test is added which checks for this issue on a dist/ directory.

Note that this only affects the latest version of the wallet plugin, because it's the only plugin with a subpath (in this case `/react`). 