### PR TITLE
Update wallet hooks to require the client as the first param

### DIFF
--- a/.changeset/social-peaches-doubt.md
+++ b/.changeset/social-peaches-doubt.md
@@ -1,0 +1,19 @@
+---
+'@solana/kit-plugin-wallet': minor
+---
+
+The React hooks now take the wallet-enabled `client` as their first argument instead of reading it from a `ClientProvider` context. Every hook — `useWalletStatus`, `useConnectedWallet`, `useWallets`, `useIsWalletReady`, `useConnect`, `useDisconnect`, `useSignIn`, `useSignMessage`, `useSelectAccount` — and the `WalletReadyGate` component (via a new `client` prop) now accept `client: ClientWithWallet` directly. Because the client's type already guarantees the wallet plugin is installed, the runtime capability assertion and the provider requirement are gone. This is a breaking change: pass the client into every hook and into `WalletReadyGate`:
+
+```diff
+- const status = useWalletStatus();
+- const { dispatch } = useConnect();
++ const status = useWalletStatus(client);
++ const { dispatch } = useConnect(client);
+```
+
+```diff
+- <WalletReadyGate fallback={<Spinner />}>
++ <WalletReadyGate client={client} fallback={<Spinner />}>
+      <WalletDependentUI />
+  </WalletReadyGate>
+```

--- a/packages/kit-plugin-wallet/README.md
+++ b/packages/kit-plugin-wallet/README.md
@@ -171,7 +171,7 @@ All wallet state is accessed via `client.wallet.getState()`, which returns a ref
 
 ## React hooks
 
-The `@solana/kit-plugin-wallet/react` subpath exposes hooks for reading wallet state and driving wallet actions from React components. Install the optional peer dependencies (`react` and [`@solana/react`](https://www.npmjs.com/package/@solana/react)) and render your tree inside a `ClientProvider` whose client has a wallet plugin installed.
+The `@solana/kit-plugin-wallet/react` subpath exposes hooks for reading wallet state and driving wallet actions from React components. Install the optional peer dependencies (`react` and [`@solana/react`](https://www.npmjs.com/package/@solana/react)). Every hook takes your wallet-enabled `client` — a client built with a wallet plugin such as `walletSigner()` — as its first argument.
 
 The **state** hooks subscribe via `useSyncExternalStore`, each to a single slice of `WalletState`, so a component only re-renders when the slice it reads changes:
 
@@ -192,14 +192,17 @@ The **action** hooks wrap the async wallet actions with `useAction` from `@solan
 | `useSignMessage`   | `client.wallet.signMessage` — `dispatch(message)`                         |
 | `useSelectAccount` | `client.wallet.selectAccount` — returns the synchronous callback directly |
 
+Each component receives the `client` and passes it to the hooks it uses:
+
 ```tsx
+import type { ClientWithWallet } from '@solana/kit-plugin-wallet';
 import { useConnect, useConnectedWallet, useWallets, useWalletStatus } from '@solana/kit-plugin-wallet/react';
 
-function WalletButton() {
-    const status = useWalletStatus();
-    const wallets = useWallets();
-    const connected = useConnectedWallet();
-    const { dispatch: connect, isRunning } = useConnect();
+function WalletButton({ client }: { client: ClientWithWallet }) {
+    const status = useWalletStatus(client);
+    const wallets = useWallets(client);
+    const connected = useConnectedWallet(client);
+    const { dispatch: connect, isRunning } = useConnect(client);
 
     if (status === 'pending') return null; // avoid flashing UI before auto-reconnect resolves
 
@@ -218,20 +221,21 @@ function WalletButton() {
 A freshly built client runs a silent auto-reconnect on mount, briefly passing through `'pending'` and `'reconnecting'` before it settles. If you render wallet-dependent UI immediately, a persisted wallet flashes "disconnected" for a frame before it reconnects. `useIsWalletReady` reports `false` for the duration of that warm-up and `true` once it settles, so you can hold back the wallet-dependent parts while painting the rest of the app:
 
 ```tsx
+import type { ClientWithWallet } from '@solana/kit-plugin-wallet';
 import { useIsWalletReady, WalletReadyGate } from '@solana/kit-plugin-wallet/react';
 
 // Hide a whole subtree until the connection settles:
-function App() {
+function App({ client }: { client: ClientWithWallet }) {
     return (
-        <WalletReadyGate fallback={<Spinner />}>
+        <WalletReadyGate client={client} fallback={<Spinner />}>
             <WalletDependentUI />
         </WalletReadyGate>
     );
 }
 
 // Or read the boolean directly for finer control (e.g. disabling a button):
-function ConnectButton() {
-    const isReady = useIsWalletReady();
+function ConnectButton({ client }: { client: ClientWithWallet }) {
+    const isReady = useIsWalletReady(client);
     return <button disabled={!isReady}>Connect</button>;
 }
 ```

--- a/packages/kit-plugin-wallet/src/react/__typetests__/index.ts
+++ b/packages/kit-plugin-wallet/src/react/__typetests__/index.ts
@@ -3,7 +3,7 @@ import type { SolanaSignInInput, SolanaSignInOutput } from '@solana/wallet-stand
 import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui';
 import type { ReactNode } from 'react';
 
-import type { WalletState, WalletStatus } from '../../types';
+import type { ClientWithWallet, WalletState, WalletStatus } from '../../types';
 import {
     useConnect,
     useConnectedWallet,
@@ -20,34 +20,43 @@ import {
 
 // NB: hooks are only type-checked here, never executed.
 
+// Every hook takes the client with a wallet plugin installed as its first argument.
+const client = null as unknown as ClientWithWallet;
+
 // [DESCRIBE] useWalletStatus
 {
-    const status = useWalletStatus();
+    const status = useWalletStatus(client);
     status satisfies WalletStatus;
+    // @ts-expect-error the client argument is required.
+    useWalletStatus();
 }
 
 // [DESCRIBE] useIsWalletReady
 {
-    const isReady = useIsWalletReady();
+    const isReady = useIsWalletReady(client);
     isReady satisfies boolean;
 }
 
 // [DESCRIBE] WalletReadyGate
 {
-    // Both `children` and `fallback` are required `ReactNode` props.
-    ({ children: 'ready', fallback: 'loading' }) satisfies WalletReadyGateProps;
+    // `children`, `client`, and `fallback` are all required props.
+    ({ children: 'ready', client, fallback: 'loading' }) satisfies WalletReadyGateProps;
     // The gate is callable and its return type is assignable to `ReactNode`.
-    const rendered: ReactNode = WalletReadyGate({ children: null, fallback: null });
+    const rendered: ReactNode = WalletReadyGate({ children: null, client, fallback: null });
     void rendered;
 }
 {
+    // @ts-expect-error `client` is required.
+    ({ children: null, fallback: null }) satisfies WalletReadyGateProps;
+}
+{
     // @ts-expect-error `fallback` is required.
-    ({ children: null }) satisfies WalletReadyGateProps;
+    ({ children: null, client }) satisfies WalletReadyGateProps;
 }
 
 // [DESCRIBE] useConnectedWallet
 {
-    const connected = useConnectedWallet();
+    const connected = useConnectedWallet(client);
     connected satisfies WalletState['connected'];
     // The connection is nullable when disconnected.
     connected satisfies { account: UiWalletAccount } | null;
@@ -55,13 +64,13 @@ import {
 
 // [DESCRIBE] useWallets
 {
-    const wallets = useWallets();
+    const wallets = useWallets(client);
     wallets satisfies readonly UiWallet[];
 }
 
 // [DESCRIBE] useConnect
 {
-    const action = useConnect();
+    const action = useConnect(client);
     action.dispatch(null as unknown as UiWallet);
     action.data satisfies readonly UiWalletAccount[] | undefined;
     // @ts-expect-error dispatch requires the wallet argument.
@@ -70,7 +79,7 @@ import {
 
 // [DESCRIBE] useDisconnect
 {
-    const action = useDisconnect();
+    const action = useDisconnect(client);
     // The wallet argument is optional — omit it to disconnect the active wallet.
     action.dispatch();
     // Or pass a specific wallet to deauthorize.
@@ -80,7 +89,7 @@ import {
 
 // [DESCRIBE] useSignIn
 {
-    const action = useSignIn();
+    const action = useSignIn(client);
     action.dispatch(null as unknown as UiWallet, null as unknown as SolanaSignInInput);
     action.data satisfies SolanaSignInOutput | undefined;
     // @ts-expect-error dispatch requires both the wallet and the sign-in input.
@@ -89,19 +98,19 @@ import {
 
 // [DESCRIBE] useSignMessage
 {
-    const action = useSignMessage();
+    const action = useSignMessage(client);
     action.dispatch(new Uint8Array());
     action.data satisfies SignatureBytes | undefined;
 }
 {
     // dispatch accepts a ReadonlyUint8Array (e.g. codec output) without a cast.
-    const action = useSignMessage();
+    const action = useSignMessage(client);
     action.dispatch(null as unknown as ReadonlyUint8Array);
 }
 
 // [DESCRIBE] useSelectAccount
 {
-    const selectAccount = useSelectAccount();
+    const selectAccount = useSelectAccount(client);
     selectAccount(null as unknown as UiWalletAccount) satisfies void;
     // @ts-expect-error selectAccount requires the account argument.
     selectAccount();

--- a/packages/kit-plugin-wallet/src/react/index.ts
+++ b/packages/kit-plugin-wallet/src/react/index.ts
@@ -1,5 +1,5 @@
 import type { ReadonlyUint8Array, SignatureBytes } from '@solana/kit';
-import { type ActionResult, useAction, useClientCapability } from '@solana/react';
+import { type ActionResult, useAction } from '@solana/react';
 import type { SolanaSignInInput, SolanaSignInOutput } from '@solana/wallet-standard-features';
 import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui';
 import type { ReactNode } from 'react';
@@ -8,41 +8,28 @@ import { useSyncExternalStore } from 'react';
 import { isWalletWarmingUp } from '../status';
 import type { ClientWithWallet, WalletNamespace, WalletState, WalletStatus } from '../types';
 
-/**
- * Reads the wallet namespace from the nearest `ClientProvider`, asserting at mount that a wallet
- * plugin is installed. Shared by every hook in this module so the capability check, error hook
- * name, and provider hint stay in one place.
- */
-function useWalletNamespace(hookName: string): WalletNamespace {
-    return useClientCapability<ClientWithWallet>({
-        capability: 'wallet',
-        hookName,
-        providerHint: 'Install a wallet plugin on the client, e.g. `walletSigner()`.',
-    }).wallet;
-}
-
 // -- State hooks ------------------------------------------------------------
 
 /**
  * Subscribes to the wallet connection status from a React component.
  *
  * Wraps `client.wallet.subscribe` / `getState` with `useSyncExternalStore`, re-rendering only when
- * the status changes. Requires a `ClientProvider` whose client has a wallet plugin installed;
- * asserts this at mount with {@link useClientCapability}.
+ * the status changes.
  *
+ * @param client - A client with a wallet plugin installed (e.g. `walletSigner()`).
  * @returns The current {@link WalletStatus} (`'pending'` on the server and in React Native).
  *
  * @example
  * ```tsx
- * const status = useWalletStatus();
+ * const status = useWalletStatus(client);
  * if (status === 'pending') return null; // avoid flashing UI before auto-reconnect resolves
  * ```
  *
  * @see {@link useConnectedWallet}
  * @see {@link useWallets}
  */
-export function useWalletStatus(): WalletStatus {
-    const wallet = useWalletNamespace('useWalletStatus');
+export function useWalletStatus(client: ClientWithWallet): WalletStatus {
+    const { wallet } = client;
     const getStatus = () => wallet.getState().status;
     return useSyncExternalStore(wallet.subscribe, getStatus, getStatus);
 }
@@ -51,23 +38,23 @@ export function useWalletStatus(): WalletStatus {
  * Subscribes to the active wallet connection from a React component.
  *
  * Wraps `client.wallet.subscribe` / `getState` with `useSyncExternalStore`, re-rendering only when
- * the connection changes (connect, disconnect, or account switch). Requires a `ClientProvider`
- * whose client has a wallet plugin installed; asserts this at mount with {@link useClientCapability}.
+ * the connection changes (connect, disconnect, or account switch).
  *
+ * @param client - A client with a wallet plugin installed (e.g. `walletSigner()`).
  * @returns The active connection — `{ account, signer, wallet }` — or `null` when disconnected.
  *   `signer` is `null` for read-only wallets.
  *
  * @example
  * ```tsx
- * const connected = useConnectedWallet();
+ * const connected = useConnectedWallet(client);
  * return connected ? <p>{connected.account.address}</p> : <p>Not connected</p>;
  * ```
  *
  * @see {@link useWalletStatus}
  * @see {@link useWallets}
  */
-export function useConnectedWallet(): WalletState['connected'] {
-    const wallet = useWalletNamespace('useConnectedWallet');
+export function useConnectedWallet(client: ClientWithWallet): WalletState['connected'] {
+    const { wallet } = client;
     const getConnected = () => wallet.getState().connected;
     return useSyncExternalStore(wallet.subscribe, getConnected, getConnected);
 }
@@ -76,24 +63,24 @@ export function useConnectedWallet(): WalletState['connected'] {
  * Subscribes to the list of discovered wallets from a React component.
  *
  * Wraps `client.wallet.subscribe` / `getState` with `useSyncExternalStore`, re-rendering only when
- * the discovered-wallet list changes. Requires a `ClientProvider` whose client has a wallet plugin
- * installed; asserts this at mount with {@link useClientCapability}.
+ * the discovered-wallet list changes.
  *
+ * @param client - A client with a wallet plugin installed (e.g. `walletSigner()`).
  * @returns All discovered wallets matching the client's configured chain and filter (empty on the
  *   server and in React Native).
  *
  * @example
  * ```tsx
- * const wallets = useWallets();
- * const connect = useConnect();
+ * const wallets = useWallets(client);
+ * const connect = useConnect(client);
  * return wallets.map(w => <button key={w.name} onClick={() => connect.dispatch(w)}>{w.name}</button>);
  * ```
  *
  * @see {@link useWalletStatus}
  * @see {@link useConnectedWallet}
  */
-export function useWallets(): readonly UiWallet[] {
-    const wallet = useWalletNamespace('useWallets');
+export function useWallets(client: ClientWithWallet): readonly UiWallet[] {
+    const { wallet } = client;
     const getWallets = () => wallet.getState().wallets;
     return useSyncExternalStore(wallet.subscribe, getWallets, getWallets);
 }
@@ -109,22 +96,22 @@ export function useWallets(): readonly UiWallet[] {
  *
  * Use it to hold back wallet-dependent UI until the connection has settled, so a persisted wallet
  * never flashes "disconnected" before it reconnects. Re-renders only when this readiness boolean
- * flips, not on every status change. Requires a `ClientProvider` whose client has a wallet plugin
- * installed; asserts this at mount with {@link useClientCapability}.
+ * flips, not on every status change.
  *
+ * @param client - A client with a wallet plugin installed (e.g. `walletSigner()`).
  * @returns `true` once the warm-up has settled, otherwise `false`.
  *
  * @example
  * ```tsx
- * const isReady = useIsWalletReady();
+ * const isReady = useIsWalletReady(client);
  * return <button disabled={!isReady}>Connect</button>;
  * ```
  *
  * @see {@link WalletReadyGate}
  * @see {@link useWalletStatus}
  */
-export function useIsWalletReady(): boolean {
-    const wallet = useWalletNamespace('useIsWalletReady');
+export function useIsWalletReady(client: ClientWithWallet): boolean {
+    const { wallet } = client;
     const getIsReady = () => !isWalletWarmingUp(wallet.getState().status);
     return useSyncExternalStore(wallet.subscribe, getIsReady, getIsReady);
 }
@@ -134,40 +121,42 @@ export function useIsWalletReady(): boolean {
 /**
  * Connects to a wallet from a React component.
  *
- * Wraps `client.wallet.connect` with {@link useAction}. Requires a `ClientProvider` whose client
- * has a wallet plugin installed; asserts this at mount with {@link useClientCapability}. An
- * in-flight connect is superseded when a newer one is dispatched.
+ * Wraps `client.wallet.connect` with {@link useAction}. An in-flight connect is superseded when a
+ * newer one is dispatched.
  *
  * `dispatch`/`dispatchAsync` take the {@link UiWallet} to connect to and resolve with the wallet's
  * accounts once connected.
  *
+ * @param client - A client with a wallet plugin installed (e.g. `walletSigner()`).
+ *
  * @example
  * ```tsx
- * const { dispatch, isRunning } = useConnect();
+ * const { dispatch, isRunning } = useConnect(client);
  * <button disabled={isRunning} onClick={() => dispatch(wallet)}>Connect</button>
  * ```
  *
  * @see {@link useDisconnect}
  * @see {@link useSignIn}
  */
-export function useConnect(): ActionResult<[wallet: UiWallet], readonly UiWalletAccount[]> {
-    const wallet = useWalletNamespace('useConnect');
+export function useConnect(client: ClientWithWallet): ActionResult<[wallet: UiWallet], readonly UiWalletAccount[]> {
+    const { wallet } = client;
     return useAction((abortSignal, uiWallet: UiWallet) => wallet.connect(uiWallet, { abortSignal }));
 }
 
 /**
  * Disconnects a wallet from a React component.
  *
- * Wraps `client.wallet.disconnect` with {@link useAction}. Requires a `ClientProvider` whose client
- * has a wallet plugin installed; asserts this at mount with {@link useClientCapability}.
+ * Wraps `client.wallet.disconnect` with {@link useAction}.
  *
  * `dispatch`/`dispatchAsync` take an optional {@link UiWallet}. Called with no argument they
  * disconnect the active wallet; passing a non-active, currently authorized wallet deauthorizes that
  * wallet while leaving the active connection in place.
  *
+ * @param client - A client with a wallet plugin installed (e.g. `walletSigner()`).
+ *
  * @example
  * ```tsx
- * const { dispatch, isRunning } = useDisconnect();
+ * const { dispatch, isRunning } = useDisconnect(client);
  * // Disconnect the active wallet:
  * <button disabled={isRunning} onClick={() => dispatch()}>Disconnect</button>
  * // Or deauthorize a specific wallet:
@@ -176,32 +165,34 @@ export function useConnect(): ActionResult<[wallet: UiWallet], readonly UiWallet
  *
  * @see {@link useConnect}
  */
-export function useDisconnect(): ActionResult<[wallet?: UiWallet], void> {
-    const wallet = useWalletNamespace('useDisconnect');
+export function useDisconnect(client: ClientWithWallet): ActionResult<[wallet?: UiWallet], void> {
+    const { wallet } = client;
     return useAction((abortSignal, uiWallet?: UiWallet) => wallet.disconnect(uiWallet, { abortSignal }));
 }
 
 /**
  * Signs in with a wallet (Sign In With Solana) from a React component.
  *
- * Wraps `client.wallet.signIn` with {@link useAction}. Requires a `ClientProvider` whose client has
- * a wallet plugin installed; asserts this at mount with {@link useClientCapability}. Like
- * {@link useConnect}, this establishes a full connection. An in-flight connect is superseded when a
- * newer one is dispatched.
+ * Wraps `client.wallet.signIn` with {@link useAction}. Like {@link useConnect}, this establishes a
+ * full connection. An in-flight connect is superseded when a newer one is dispatched.
  *
  * `dispatch`/`dispatchAsync` take the {@link UiWallet} and a `SolanaSignInInput` (pass `{}` for no
  * customization) and resolve with the wallet's sign-in output.
  *
+ * @param client - A client with a wallet plugin installed (e.g. `walletSigner()`).
+ *
  * @example
  * ```tsx
- * const { dispatch } = useSignIn();
+ * const { dispatch } = useSignIn(client);
  * dispatch(wallet, { domain: window.location.host });
  * ```
  *
  * @see {@link useConnect}
  */
-export function useSignIn(): ActionResult<[wallet: UiWallet, input: SolanaSignInInput], SolanaSignInOutput> {
-    const wallet = useWalletNamespace('useSignIn');
+export function useSignIn(
+    client: ClientWithWallet,
+): ActionResult<[wallet: UiWallet, input: SolanaSignInInput], SolanaSignInOutput> {
+    const { wallet } = client;
     return useAction((abortSignal, uiWallet: UiWallet, input: SolanaSignInInput) =>
         wallet.signIn(uiWallet, input, { abortSignal }),
     );
@@ -210,37 +201,38 @@ export function useSignIn(): ActionResult<[wallet: UiWallet, input: SolanaSignIn
 /**
  * Signs an arbitrary message with the connected account from a React component.
  *
- * Wraps `client.wallet.signMessage` with {@link useAction}. Requires a `ClientProvider` whose
- * client has a wallet plugin installed; asserts this at mount with {@link useClientCapability}.
- * A stale in-flight dispatch is dropped from the hook's state when a newer one starts (though
- * the wallet may still complete the older request in the background).
+ * Wraps `client.wallet.signMessage` with {@link useAction}. A stale in-flight dispatch is dropped
+ * from the hook's state when a newer one starts (though the wallet may still complete the older
+ * request in the background).
  *
  * `dispatch`/`dispatchAsync` take the message bytes and resolve with the signature. The bytes are
  * only read, never mutated, so a {@link ReadonlyUint8Array} (e.g. the output of a `@solana/kit`
  * codec) is accepted directly without a cast.
  *
+ * @param client - A client with a wallet plugin installed (e.g. `walletSigner()`).
+ *
  * @example
  * ```tsx
- * const { dispatch } = useSignMessage();
+ * const { dispatch } = useSignMessage(client);
  * dispatch(new TextEncoder().encode('Hello'));
  * ```
  */
-export function useSignMessage(): ActionResult<[message: ReadonlyUint8Array], SignatureBytes> {
-    const wallet = useWalletNamespace('useSignMessage');
+export function useSignMessage(client: ClientWithWallet): ActionResult<[message: ReadonlyUint8Array], SignatureBytes> {
+    const { wallet } = client;
     return useAction((abortSignal, message: ReadonlyUint8Array) => wallet.signMessage(message, { abortSignal }));
 }
 
 /**
  * Returns a callback that selects a wallet account.
  *
- * Requires a `ClientProvider` whose client has a wallet plugin installed; asserts this at mount
- * with {@link useClientCapability}. Unlike the other action hooks, `selectAccount` is synchronous —
- * this hook returns the bound function directly rather than an `ActionResult`.
+ * Unlike the other action hooks, `selectAccount` is synchronous — this hook returns the bound
+ * function directly rather than an `ActionResult`.
  *
  * The account may belong to any currently authorized wallet, not only the active one. Selecting an
  * account from a different authorized wallet switches the active connection to that wallet
  * synchronously (no prompt), leaving the previously active wallet authorized.
  *
+ * @param client - A client with a wallet plugin installed (e.g. `walletSigner()`).
  * @returns The `selectAccount` function — call it with a {@link UiWalletAccount} belonging to any
  *   currently authorized wallet. It throws if the account's handle can't be resolved to an
  *   authorized wallet (or isn't among that wallet's accounts), or that wallet is currently
@@ -248,14 +240,14 @@ export function useSignMessage(): ActionResult<[message: ReadonlyUint8Array], Si
  *
  * @example
  * ```tsx
- * const selectAccount = useSelectAccount();
+ * const selectAccount = useSelectAccount(client);
  * <button onClick={() => selectAccount(account)}>Use this account</button>
  * ```
  *
  * @see {@link useConnectedWallet}
  */
-export function useSelectAccount(): WalletNamespace['selectAccount'] {
-    return useWalletNamespace('useSelectAccount').selectAccount;
+export function useSelectAccount(client: ClientWithWallet): WalletNamespace['selectAccount'] {
+    return client.wallet.selectAccount;
 }
 
 // -- Components -------------------------------------------------------------
@@ -266,6 +258,8 @@ export function useSelectAccount(): WalletNamespace['selectAccount'] {
 export type WalletReadyGateProps = Readonly<{
     /** Rendered once the wallet client has finished its initial auto-reconnect warm-up. */
     children: ReactNode;
+    /** A client with a wallet plugin installed (e.g. `walletSigner()`). */
+    client: ClientWithWallet;
     /** Rendered while the client is still warming up (`'pending'` / `'reconnecting'`). */
     fallback: ReactNode;
 }>;
@@ -283,12 +277,9 @@ export type WalletReadyGateProps = Readonly<{
  * {@link useIsWalletReady} directly. To actually suspend a subtree instead, throw the Suspense-safe
  * {@link WalletNamespace.whenReady} promise from your own component.
  *
- * Requires a `ClientProvider` whose client has a wallet plugin installed; asserts this at mount with
- * {@link useClientCapability}.
- *
  * @example
  * ```tsx
- * <WalletReadyGate fallback={<Spinner />}>
+ * <WalletReadyGate client={client} fallback={<Spinner />}>
  *     <WalletDependentApp />
  * </WalletReadyGate>
  * ```
@@ -296,6 +287,6 @@ export type WalletReadyGateProps = Readonly<{
  * @see {@link useIsWalletReady}
  * @see {@link useWalletStatus}
  */
-export function WalletReadyGate({ children, fallback }: WalletReadyGateProps): ReactNode {
-    return useIsWalletReady() ? children : fallback;
+export function WalletReadyGate({ children, client, fallback }: WalletReadyGateProps): ReactNode {
+    return useIsWalletReady(client) ? children : fallback;
 }

--- a/packages/kit-plugin-wallet/test/useWalletActions.react.test.tsx
+++ b/packages/kit-plugin-wallet/test/useWalletActions.react.test.tsx
@@ -1,34 +1,23 @@
-import { ClientProvider } from '@solana/react';
 import { renderHook } from '@testing-library/react';
 import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui';
-import { createElement, type ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { useConnect, useDisconnect, useSelectAccount, useSignIn, useSignMessage } from '../src/react';
+import type { ClientWithWallet } from '../src/types';
 
-function wrapperFor(wallet: object) {
-    return ({ children }: { children: ReactNode }) =>
-        createElement(ClientProvider, { client: { wallet } as never }, children);
+/** Wrap a wallet namespace in a client so it can be passed to a hook. */
+function clientFor(wallet: object): ClientWithWallet {
+    return { wallet } as never;
 }
 
 const uiWallet = {} as UiWallet;
 const account = {} as UiWalletAccount;
 
 describe('useConnect', () => {
-    it('throws at mount when the client lacks a wallet namespace', () => {
-        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-        expect(() =>
-            renderHook(() => useConnect(), {
-                wrapper: ({ children }) => createElement(ClientProvider, { client: {} as never }, children),
-            }),
-        ).toThrow(/useConnect/);
-        consoleError.mockRestore();
-    });
-
     it('dispatches connect with the wallet and a threaded abort signal, returning its result', async () => {
         const accounts = [account];
         const connect = vi.fn().mockResolvedValue(accounts);
-        const { result: hook } = renderHook(() => useConnect(), { wrapper: wrapperFor({ connect }) });
+        const { result: hook } = renderHook(() => useConnect(clientFor({ connect })));
 
         const returned = await hook.current.dispatchAsync(uiWallet);
 
@@ -42,7 +31,7 @@ describe('useConnect', () => {
     it('surfaces a rejecting connect via the returned promise', async () => {
         const error = new Error('declined');
         const connect = vi.fn().mockRejectedValue(error);
-        const { result: hook } = renderHook(() => useConnect(), { wrapper: wrapperFor({ connect }) });
+        const { result: hook } = renderHook(() => useConnect(clientFor({ connect })));
 
         await expect(hook.current.dispatchAsync(uiWallet)).rejects.toBe(error);
     });
@@ -51,7 +40,7 @@ describe('useConnect', () => {
 describe('useDisconnect', () => {
     it('dispatches disconnect for the active wallet with a threaded abort signal', async () => {
         const disconnect = vi.fn().mockResolvedValue(undefined);
-        const { result: hook } = renderHook(() => useDisconnect(), { wrapper: wrapperFor({ disconnect }) });
+        const { result: hook } = renderHook(() => useDisconnect(clientFor({ disconnect })));
 
         await hook.current.dispatchAsync();
 
@@ -63,7 +52,7 @@ describe('useDisconnect', () => {
 
     it('dispatches disconnect for a specific wallet with a threaded abort signal', async () => {
         const disconnect = vi.fn().mockResolvedValue(undefined);
-        const { result: hook } = renderHook(() => useDisconnect(), { wrapper: wrapperFor({ disconnect }) });
+        const { result: hook } = renderHook(() => useDisconnect(clientFor({ disconnect })));
 
         await hook.current.dispatchAsync(uiWallet);
 
@@ -78,7 +67,7 @@ describe('useSignIn', () => {
     it('dispatches signIn with the wallet, input, and a threaded abort signal', async () => {
         const output = { account: {} };
         const signIn = vi.fn().mockResolvedValue(output);
-        const { result: hook } = renderHook(() => useSignIn(), { wrapper: wrapperFor({ signIn }) });
+        const { result: hook } = renderHook(() => useSignIn(clientFor({ signIn })));
 
         const input = { domain: 'example.com' };
         const returned = await hook.current.dispatchAsync(uiWallet, input);
@@ -96,7 +85,7 @@ describe('useSignMessage', () => {
     it('dispatches signMessage with the message and a threaded abort signal', async () => {
         const signature = new Uint8Array(64);
         const signMessage = vi.fn().mockResolvedValue(signature);
-        const { result: hook } = renderHook(() => useSignMessage(), { wrapper: wrapperFor({ signMessage }) });
+        const { result: hook } = renderHook(() => useSignMessage(clientFor({ signMessage })));
 
         const message = new TextEncoder().encode('Hello');
         const returned = await hook.current.dispatchAsync(message);
@@ -112,9 +101,8 @@ describe('useSignMessage', () => {
 describe('useSelectAccount', () => {
     it('returns a callback that forwards to the client, stable across renders', () => {
         const selectAccount = vi.fn();
-        const { result: hook, rerender } = renderHook(() => useSelectAccount(), {
-            wrapper: wrapperFor({ selectAccount }),
-        });
+        const client = clientFor({ selectAccount });
+        const { result: hook, rerender } = renderHook(() => useSelectAccount(client));
 
         const first = hook.current;
         first(account);

--- a/packages/kit-plugin-wallet/test/useWalletState.react.test.tsx
+++ b/packages/kit-plugin-wallet/test/useWalletState.react.test.tsx
@@ -1,11 +1,9 @@
-import { ClientProvider } from '@solana/react';
 import { act, cleanup, renderHook } from '@testing-library/react';
 import type { UiWallet } from '@wallet-standard/ui';
-import { createElement, type ReactNode } from 'react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { useConnectedWallet, useIsWalletReady, useWallets, useWalletStatus } from '../src/react';
-import type { WalletState } from '../src/types';
+import type { ClientWithWallet, WalletState } from '../src/types';
 
 // Unmount rendered trees between tests. This package doesn't enable vitest
 // globals, so @testing-library/react's auto-cleanup isn't registered.
@@ -31,27 +29,17 @@ function createFakeStore(initial: WalletState) {
     };
 }
 
-function wrapperFor(wallet: object) {
-    return ({ children }: { children: ReactNode }) =>
-        createElement(ClientProvider, { client: { wallet } as never }, children);
+/** Wrap a wallet namespace in a client so it can be passed to a hook. */
+function clientFor(wallet: object): ClientWithWallet {
+    return { wallet } as never;
 }
 
 const INITIAL: WalletState = { connected: null, status: 'disconnected', wallets: [] };
 
 describe('useWalletStatus', () => {
-    it('throws at mount when the client lacks a wallet namespace', () => {
-        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-        expect(() =>
-            renderHook(() => useWalletStatus(), {
-                wrapper: ({ children }) => createElement(ClientProvider, { client: {} as never }, children),
-            }),
-        ).toThrow(/useWalletStatus/);
-        consoleError.mockRestore();
-    });
-
     it('returns the current status and updates when it changes', () => {
         const store = createFakeStore(INITIAL);
-        const { result } = renderHook(() => useWalletStatus(), { wrapper: wrapperFor(store) });
+        const { result } = renderHook(() => useWalletStatus(clientFor(store)));
 
         expect(result.current).toBe('disconnected');
 
@@ -63,7 +51,7 @@ describe('useWalletStatus', () => {
 describe('useConnectedWallet', () => {
     it('returns the active connection and updates when it changes', () => {
         const store = createFakeStore(INITIAL);
-        const { result } = renderHook(() => useConnectedWallet(), { wrapper: wrapperFor(store) });
+        const { result } = renderHook(() => useConnectedWallet(clientFor(store)));
 
         expect(result.current).toBeNull();
 
@@ -77,13 +65,10 @@ describe('useIsWalletReady', () => {
     it('reports readiness and re-renders only when the boolean flips', () => {
         const store = createFakeStore({ ...INITIAL, status: 'pending' });
         let renderCount = 0;
-        const { result } = renderHook(
-            () => {
-                renderCount++;
-                return useIsWalletReady();
-            },
-            { wrapper: wrapperFor(store) },
-        );
+        const { result } = renderHook(() => {
+            renderCount++;
+            return useIsWalletReady(clientFor(store));
+        });
 
         expect(result.current).toBe(false);
         const rendersWhileWarmingUp = renderCount;
@@ -105,7 +90,7 @@ describe('useIsWalletReady', () => {
 describe('useWallets', () => {
     it('returns the discovered wallets and updates when the list changes', () => {
         const store = createFakeStore(INITIAL);
-        const { result } = renderHook(() => useWallets(), { wrapper: wrapperFor(store) });
+        const { result } = renderHook(() => useWallets(clientFor(store)));
 
         expect(result.current).toEqual([]);
 


### PR DESCRIPTION
This PR updates all the react hooks in the wallet plugin to take `client: ClientWithWallet` as their first param. This removes the runtime type checking with `useClientCapability`, and moves the responsibility to the app. This allows the app to have proper type checking all the way through plugin hooks. by typing its `useClient` parameter.

This is a breaking change, but this is a more robust and type-safe pattern and it's worth getting it right now instead of repeating the `useClientCapability` pattern through other hooks.

This PR updates the docs in this repo, I'll follow up with a Kit PR that updates the docs there to talk about passing a client type around. We don't currently have these hooks documented in Kit, I've opened an issue to do that separately.

```diff
- const status = useWalletStatus();
- const { dispatch } = useConnect();
+ const status = useWalletStatus(client);
+ const { dispatch } = useConnect(client);
```

```diff
- <WalletReadyGate fallback={<Spinner />}>
+ <WalletReadyGate client={client} fallback={<Spinner />}>
      <WalletDependentUI />
  </WalletReadyGate>
```

Additional context: https://github.com/anza-xyz/kit/pull/1833#discussion_r3572581679 - hooks that use `useClientCapability` limit type safety and undo some of the benefits of plugins. Having the app pass `client` allows the app to maintain type safety. 