### PR TITLE
[kit-plugin-litesvm] Add `GetProgramAccountsApi` support to litesvm Rpc

### DIFF
--- a/.changeset/slick-eels-judge.md
+++ b/.changeset/slick-eels-judge.md
@@ -1,0 +1,7 @@
+---
+'@solana/kit-plugin-litesvm': minor
+---
+
+Add `GetProgramAccountsApi` support to litesvm Rpc
+
+The LiteSVM-backed `Rpc` now implements `getProgramAccounts`, supporting `dataSize`/`memcmp` filters, `dataSlice`, and `withContext`. Account data is returned as `base64`, consistent with the other supported methods; requesting any other encoding throws.

--- a/packages/kit-plugin-litesvm/README.md
+++ b/packages/kit-plugin-litesvm/README.md
@@ -73,7 +73,7 @@ const client = createClient().use(litesvmConnection());
     client.svm.setAccount(myAccount);
     client.svm.addProgramFromFile(myProgramAddress, 'my_program.so');
     ```
-- `rpc`: Call a subset of Solana RPC methods against the LiteSVM instance. Currently supported methods are: `getAccountInfo`, `getBalance`, `getEpochSchedule`, `getLatestBlockhash`, `getMinimumBalanceForRentExemption`, `getMultipleAccounts`, `getSlot`, and `requestAirdrop`.
+- `rpc`: Call a subset of Solana RPC methods against the LiteSVM instance. Currently supported methods are: `getAccountInfo`, `getBalance`, `getEpochSchedule`, `getLatestBlockhash`, `getMinimumBalanceForRentExemption`, `getMultipleAccounts`, `getProgramAccounts`, `getSlot`, and `requestAirdrop`.
     ```ts
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send();
     ```

--- a/packages/kit-plugin-litesvm/src/litesvm-to-rpc.ts
+++ b/packages/kit-plugin-litesvm/src/litesvm-to-rpc.ts
@@ -3,20 +3,29 @@ import {
     AccountInfoWithBase64EncodedData,
     Address,
     Base64EncodedBytes,
+    containsBytes,
     createJsonRpcApi,
     createRpc,
+    DataSlice,
+    EncodedAccount,
     GetAccountInfoApi,
     GetBalanceApi,
     getBase58Decoder,
+    getBase58Encoder,
     getBase64Decoder,
+    getBase64Encoder,
     GetEpochScheduleApi,
     GetLatestBlockhashApi,
     GetMinimumBalanceForRentExemptionApi,
     GetMultipleAccountsApi,
+    GetProgramAccountsApi,
+    GetProgramAccountsDatasizeFilter,
+    GetProgramAccountsMemcmpFilter,
     GetSlotApi,
     Lamports,
     lamports,
     MaybeEncodedAccount,
+    ReadonlyUint8Array,
     RequestAirdropApi,
     Rpc,
     RpcResponse,
@@ -52,6 +61,7 @@ export type LiteSvmRpcApi = GetAccountInfoApi &
     GetLatestBlockhashApi &
     GetMinimumBalanceForRentExemptionApi &
     GetMultipleAccountsApi &
+    GetProgramAccountsApi &
     GetSlotApi &
     RequestAirdropApi;
 
@@ -81,17 +91,23 @@ type Encoding = 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
 export function createRpcFromSvm(svm: LiteSVM): Rpc<LiteSvmRpcApi> {
     const base58Decoder = getBase58Decoder();
     const base64Decoder = getBase64Decoder();
-    const convertMaybeEncodedAccount = (
-        account: MaybeEncodedAccount,
-    ): (AccountInfoBase & AccountInfoWithBase64EncodedData) | null => {
-        if (!account.exists) return null;
+    const encodeAccountBase64 = (
+        account: EncodedAccount,
+        dataSlice?: DataSlice,
+    ): AccountInfoBase & AccountInfoWithBase64EncodedData => {
+        const data = dataSlice ? sliceData(account.data, dataSlice) : account.data;
         return {
-            data: [base64Decoder.decode(account.data) as Base64EncodedBytes, 'base64'] as const,
+            data: [base64Decoder.decode(data) as Base64EncodedBytes, 'base64'] as const,
             executable: account.executable,
             lamports: account.lamports,
             owner: account.programAddress,
             space: account.space,
         };
+    };
+    const convertMaybeEncodedAccount = (
+        account: MaybeEncodedAccount,
+    ): (AccountInfoBase & AccountInfoWithBase64EncodedData) | null => {
+        return account.exists ? encodeAccountBase64(account) : null;
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -126,6 +142,18 @@ export function createRpcFromSvm(svm: LiteSVM): Rpc<LiteSvmRpcApi> {
             assertEncodingIsBase64(config?.encoding);
             const response = addresses.map(address => convertMaybeEncodedAccount(svm.getAccount(address)));
             return withContext(response, svm.getClock().slot);
+        },
+        getProgramAccounts: (programId: Address, config?: GetProgramAccountsConfig) => {
+            assertEncodingIsBase64(config?.encoding);
+            const filters = config?.filters ?? [];
+            const value = svm
+                .getProgramAccounts(programId)
+                .filter(account => matchesGetProgramAccountsFilters(account.data, filters))
+                .map(account => ({
+                    account: encodeAccountBase64(account, config?.dataSlice),
+                    pubkey: account.address,
+                }));
+            return config?.withContext ? withContext(value, svm.getClock().slot) : value;
         },
         getSlot: () => {
             return svm.getClock().slot;
@@ -165,4 +193,36 @@ function assertEncodingIsBase64(encoding: Encoding | undefined) {
     if (encoding && encoding !== 'base64') {
         throw new Error(`Please use 'base64' encoding when using LiteSVM RPC. Requested encoding: ${encoding}`);
     }
+}
+
+type GetProgramAccountsConfig = {
+    dataSlice?: DataSlice;
+    encoding?: Encoding;
+    filters?: readonly (GetProgramAccountsDatasizeFilter | GetProgramAccountsMemcmpFilter)[];
+    withContext?: boolean;
+};
+
+/**
+ * Applies the `getProgramAccounts` `dataSize`/`memcmp` filters to an account's
+ * data buffer, matching the semantics of the Solana JSON-RPC API. All filters
+ * must match (logical AND).
+ */
+function matchesGetProgramAccountsFilters(
+    data: ReadonlyUint8Array,
+    filters: readonly (GetProgramAccountsDatasizeFilter | GetProgramAccountsMemcmpFilter)[],
+): boolean {
+    const base58Encoder = getBase58Encoder();
+    const base64Encoder = getBase64Encoder();
+    return filters.every(filter => {
+        if ('dataSize' in filter) {
+            return BigInt(data.length) === filter.dataSize;
+        }
+        const { offset, bytes, encoding } = filter.memcmp;
+        const needle = encoding === 'base58' ? base58Encoder.encode(bytes) : base64Encoder.encode(bytes);
+        return containsBytes(data, needle, Number(offset));
+    });
+}
+
+function sliceData(data: ReadonlyUint8Array, { offset, length }: DataSlice): ReadonlyUint8Array {
+    return data.slice(offset, offset + length);
 }

--- a/packages/kit-plugin-litesvm/test/litesvm-connection.test.ts
+++ b/packages/kit-plugin-litesvm/test/litesvm-connection.test.ts
@@ -6,6 +6,7 @@ import {
     GetLatestBlockhashApi,
     GetMinimumBalanceForRentExemptionApi,
     GetMultipleAccountsApi,
+    GetProgramAccountsApi,
     GetSlotApi,
     RequestAirdropApi,
     Rpc,
@@ -41,6 +42,7 @@ describe('litesvm', () => {
         expect(client.rpc.getLatestBlockhash).toBeTypeOf('function');
         expect(client.rpc.getMinimumBalanceForRentExemption).toBeTypeOf('function');
         expect(client.rpc.getMultipleAccounts).toBeTypeOf('function');
+        expect(client.rpc.getProgramAccounts).toBeTypeOf('function');
         expect(client.rpc.getSlot).toBeTypeOf('function');
         expect(client.rpc.requestAirdrop).toBeTypeOf('function');
         expectTypeOf(client.rpc).toEqualTypeOf<
@@ -51,6 +53,7 @@ describe('litesvm', () => {
                     GetLatestBlockhashApi &
                     GetMinimumBalanceForRentExemptionApi &
                     GetMultipleAccountsApi &
+                    GetProgramAccountsApi &
                     GetSlotApi &
                     RequestAirdropApi
             >

--- a/packages/kit-plugin-litesvm/test/litesvm-to-rpc.test.ts
+++ b/packages/kit-plugin-litesvm/test/litesvm-to-rpc.test.ts
@@ -1,4 +1,14 @@
-import { address, createClient, generateKeyPairSigner, lamports, Rpc } from '@solana/kit';
+import {
+    address,
+    Address,
+    Base58EncodedBytes,
+    createClient,
+    EncodedAccount,
+    generateKeyPairSigner,
+    getBase58Decoder,
+    lamports,
+    Rpc,
+} from '@solana/kit';
 import { describe, expect, it } from 'vitest';
 
 import { litesvmConnection as nodeLitesvm } from '../src/index';
@@ -165,6 +175,115 @@ describe('createRpcFromSvm', () => {
         expect(balance).toBe(lamports(1_000_000_000n));
     });
 
+    it('can fetch the accounts owned by a program', async () => {
+        const client = createClient().use(litesvm());
+        const [ownedA, ownedB, ownedOther] = await Promise.all([
+            generateKeyPairSigner().then(signer => signer.address),
+            generateKeyPairSigner().then(signer => signer.address),
+            generateKeyPairSigner().then(signer => signer.address),
+        ]);
+        const programAddress = address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+        const otherProgram = address('11111111111111111111111111111111');
+
+        client.svm.setAccount(makeAccount(ownedA, new Uint8Array([1, 2, 3, 4]), programAddress));
+        client.svm.setAccount(makeAccount(ownedB, new Uint8Array([5, 6]), programAddress));
+        client.svm.setAccount(makeAccount(ownedOther, new Uint8Array([9]), otherProgram));
+
+        const accounts = await client.rpc.getProgramAccounts(programAddress, { encoding: 'base64' }).send();
+        expect(new Set(accounts.map(a => a.pubkey))).toStrictEqual(new Set([ownedA, ownedB]));
+        for (const { account } of accounts) {
+            expect(account.owner).toBe(programAddress);
+            expect(account.data[1]).toBe('base64');
+        }
+    });
+
+    it('applies a dataSize filter to the accounts owned by a program', async () => {
+        const client = createClient().use(litesvm());
+        const [addressA, addressB] = await Promise.all([
+            generateKeyPairSigner().then(signer => signer.address),
+            generateKeyPairSigner().then(signer => signer.address),
+        ]);
+        const programAddress = address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+
+        client.svm.setAccount(makeAccount(addressA, new Uint8Array([1, 2, 3, 4]), programAddress));
+        client.svm.setAccount(makeAccount(addressB, new Uint8Array([1, 2]), programAddress));
+
+        const accounts = await client.rpc
+            .getProgramAccounts(programAddress, { encoding: 'base64', filters: [{ dataSize: 4n }] })
+            .send();
+        expect(accounts).toHaveLength(1);
+        expect(accounts[0].pubkey).toBe(addressA);
+    });
+
+    it('applies a memcmp filter to the accounts owned by a program', async () => {
+        const client = createClient().use(litesvm());
+        const [addressA, addressB] = await Promise.all([
+            generateKeyPairSigner().then(signer => signer.address),
+            generateKeyPairSigner().then(signer => signer.address),
+        ]);
+        const programAddress = address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+
+        client.svm.setAccount(makeAccount(addressA, new Uint8Array([7, 8, 9, 10]), programAddress));
+        client.svm.setAccount(makeAccount(addressB, new Uint8Array([0, 0, 9, 10]), programAddress));
+
+        const bytes = getBase58Decoder().decode(new Uint8Array([9, 10])) as Base58EncodedBytes;
+        const accounts = await client.rpc
+            .getProgramAccounts(programAddress, {
+                encoding: 'base64',
+                filters: [{ memcmp: { bytes, encoding: 'base58', offset: 2n } }],
+            })
+            .send();
+        expect(new Set(accounts.map(a => a.pubkey))).toStrictEqual(new Set([addressA, addressB]));
+
+        const noMatch = await client.rpc
+            .getProgramAccounts(programAddress, {
+                encoding: 'base64',
+                filters: [{ memcmp: { bytes, encoding: 'base58', offset: 0n } }],
+            })
+            .send();
+        expect(noMatch).toHaveLength(0);
+    });
+
+    it('slices the data of the accounts owned by a program while preserving the full account space', async () => {
+        const client = createClient().use(litesvm());
+        const accountAddress = await generateKeyPairSigner().then(signer => signer.address);
+        const programAddress = address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+
+        client.svm.setAccount(makeAccount(accountAddress, new Uint8Array([10, 20, 30, 40]), programAddress));
+
+        const accounts = await client.rpc
+            .getProgramAccounts(programAddress, { dataSlice: { length: 2, offset: 1 }, encoding: 'base64' })
+            .send();
+        expect(accounts).toHaveLength(1);
+        expect(accounts[0].account.data).toStrictEqual(['FB4=', 'base64']);
+        expect(accounts[0].account.space).toBe(4n);
+    });
+
+    it('throws when requesting a non-base64 encoding for the accounts owned by a program', async () => {
+        const client = createClient().use(litesvm());
+        const accountAddress = await generateKeyPairSigner().then(signer => signer.address);
+        const programAddress = address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+
+        client.svm.setAccount(makeAccount(accountAddress, new Uint8Array([1, 2, 3, 4]), programAddress));
+
+        const promise = client.rpc.getProgramAccounts(programAddress, { encoding: 'base58' }).send();
+        await expect(promise).rejects.toThrow("Please use 'base64' encoding when using LiteSVM RPC");
+    });
+
+    it('wraps the accounts owned by a program result in a context when withContext is true', async () => {
+        const client = createClient().use(litesvm());
+        const accountAddress = await generateKeyPairSigner().then(signer => signer.address);
+        const programAddress = address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+
+        client.svm.setAccount(makeAccount(accountAddress, new Uint8Array([1]), programAddress));
+
+        const response = await client.rpc
+            .getProgramAccounts(programAddress, { encoding: 'base64', withContext: true })
+            .send();
+        expect(typeof response.context.slot).toBe('bigint');
+        expect(response.value).toHaveLength(1);
+    });
+
     it('throws when calling an unsupported RPC method', async () => {
         const client = createClient().use(litesvm());
         const rpc = client.rpc as unknown as Rpc<{ unsupportedMethod: () => unknown }>;
@@ -172,3 +291,14 @@ describe('createRpcFromSvm', () => {
         await expect(promise).rejects.toThrow('Unsupported RPC method for LiteSVM client: unsupportedMethod');
     });
 });
+
+function makeAccount(address: Address, data: Uint8Array, programAddress: Address): EncodedAccount {
+    return {
+        address,
+        data,
+        executable: false,
+        lamports: lamports(1_000_000n),
+        programAddress,
+        space: BigInt(data.length),
+    };
+}


### PR DESCRIPTION
litesvm now exposes a `get_program_accounts` API (https://github.com/LiteSVM/litesvm/pull/370), which we can use to implement `GetProgramAccountsApi` on the LiteSVM-backed Rpc.                                                                       
                                                                                                                                                                                                                                                    
The implementation supports `dataSize`/`memcmp` filters, `dataSlice`, and `withContext`. Account data is returned as base64 only - consistent with the existing `getAccountInfo`/`getMultipleAccounts` methods, which reject other encodings.  