### PR TITLE
Add configurable compute unit buffer and resource limit estimation controls

### DIFF
--- a/.changeset/beige-rockets-trade.md
+++ b/.changeset/beige-rockets-trade.md
@@ -1,0 +1,13 @@
+---
+'@solana/kit-plugin-rpc': minor
+'@solana/kit-plugin-litesvm': minor
+'@solana/kit-plugins': minor
+---
+
+Add resource limit estimation controls and a configurable compute unit buffer to the RPC transaction plan executor, and reshape the transaction planner config for version 1 support.
+
+Resource limit estimation on the RPC plugin can now be turned off via `estimateResourceLimits: false`, which is useful for transactions close to the message size limit where adding a compute budget instruction would make an otherwise valid transaction too large. This flag applies to both the planner and the executor, and `solanaRpc` reads it from a single location (`transactionConfig`). Disabling estimation does not disable preflight; set `skipPreflight: true` as well to avoid all simulation.
+
+The compute unit buffer applied to estimates is now configurable via a new `getComputeUnitLimitFromEstimate` option on `rpcTransactionPlanExecutor` (also surfaced on `solanaRpc`). The previous flat 10% buffer is replaced by a default function that adds a buffer on top of the estimate of at least 300 compute units, or a margin that decays linearly from 10% at low estimates to 2% at 500,000 compute units and above, whichever is greater. The buffer is applied on both successful estimation and the `skipPreflight` recovery path, and the resulting compute unit limit is always capped at 1,400,000 (the per-transaction maximum).
+
+The transaction planner config (`TransactionPlannerConfig`) on both the RPC and LiteSVM plugins is now a version-discriminated union in preparation for version 1 transactions, which store resource limits and priority fees in a structured resource header rather than compute budget instructions. Version 1 is defined at the type level but is not yet buildable by `@solana/kit`, so passing `version: 1` currently throws.

--- a/packages/kit-plugin-litesvm/README.md
+++ b/packages/kit-plugin-litesvm/README.md
@@ -153,10 +153,16 @@ const client = await createClient()
 
 ### Options
 
-All options are provided via a `TransactionPlannerConfig` object:
+All options are provided via a `TransactionPlannerConfig` object. Its shape is discriminated by the transaction `version`.
+
+For legacy and version 0 transactions:
 
 - `version`: The transaction message version to use. Accepts `0` or `'legacy'`. Defaults to `0`.
-- `microLamportsPerComputeUnit`: Priority fees in micro lamports per compute unit. Defaults to no priority fees.
+- `microLamportsPerComputeUnit`: The priority fee in micro-lamports per compute unit, added as a `setComputeUnitPrice` instruction. Defaults to no priority fees.
+
+Unlike the RPC planner, the LiteSVM planner does not estimate resource limits, since LiteSVM executes transactions locally without a simulation-based estimation step.
+
+Version 1 transactions are defined for forward compatibility but are not yet buildable by `@solana/kit`; passing `version: 1` currently throws. When available, version 1 will accept `priorityFeeLamports` (a flat total in lamports) instead of `microLamportsPerComputeUnit`.
 
 ### Features
 

--- a/packages/kit-plugin-litesvm/src/transaction-planner.ts
+++ b/packages/kit-plugin-litesvm/src/transaction-planner.ts
@@ -3,6 +3,7 @@ import {
     createTransactionMessage,
     createTransactionPlanner,
     extendClient,
+    Lamports,
     MicroLamports,
     pipe,
     setTransactionMessageComputeUnitPrice,
@@ -15,6 +16,10 @@ import {
  * The planner creates transaction messages with:
  * - The configured fee payer.
  * - Optional priority fees.
+ *
+ * Unlike the RPC planner, the LiteSVM planner does not estimate resource limits,
+ * since LiteSVM executes transactions locally without a simulation-based
+ * estimation step.
  *
  * @param config - Optional configuration for the planner.
  * @returns A plugin that adds `transactionPlanner` to the client.
@@ -34,15 +39,28 @@ import {
  */
 export function litesvmTransactionPlanner(config: TransactionPlannerConfig = {}) {
     return <T extends ClientWithPayer>(client: T) => {
+        if (config.version === 1) {
+            // The v1 transaction path is defined at the type level for forward
+            // compatibility, but `createTransactionMessage` cannot yet build v1
+            // messages, so we fail loudly rather than silently misbehave.
+            throw new Error(
+                'Version 1 transactions are not yet supported by `litesvmTransactionPlanner`. ' +
+                    'Use version 0 or legacy transactions for now.',
+            );
+        }
+
+        const version = config.version ?? 0;
+        const microLamportsPerComputeUnit = config.microLamportsPerComputeUnit;
+
         const transactionPlanner = createTransactionPlanner({
             createTransactionMessage: () => {
                 return pipe(
-                    createTransactionMessage({ version: config.version ?? 0 }),
+                    createTransactionMessage({ version }),
                     tx => setTransactionMessageFeePayerSigner(client.payer, tx),
                     tx =>
-                        config.microLamportsPerComputeUnit
-                            ? setTransactionMessageComputeUnitPrice(config.microLamportsPerComputeUnit, tx)
-                            : tx,
+                        microLamportsPerComputeUnit === undefined
+                            ? tx
+                            : setTransactionMessageComputeUnitPrice(microLamportsPerComputeUnit, tx),
                 );
             },
         });
@@ -52,18 +70,17 @@ export function litesvmTransactionPlanner(config: TransactionPlannerConfig = {})
 }
 
 /**
- * Configuration options for the transaction planner.
+ * Configuration options for the transaction planner when creating legacy or
+ * version 0 transaction messages.
  *
- * The `version` field is used to determine the transaction version
- * to use when creating transaction messages and determines the shape
- * of the rest of the configuration options, as some options are only
- * applicable to certain transaction versions.
+ * For these versions, priority fees are expressed as a `setComputeUnitPrice`
+ * compute budget instruction appended to the transaction.
  */
-// TODO(loris): Add support for v1 transactions when LiteSVM supports them.
-// This includes: `version: 1` and `priorityFees?: Lamports` in a new union variant.
-export type TransactionPlannerConfig = {
+export type TransactionPlannerConfigLegacy = {
     /**
-     * The priority fees to be set on the transaction in micro lamports per compute unit.
+     * The priority fee to set on the transaction, in micro-lamports per compute
+     * unit, added as a `setComputeUnitPrice` instruction.
+     *
      * Defaults to using no priority fees.
      */
     microLamportsPerComputeUnit?: MicroLamports;
@@ -73,3 +90,42 @@ export type TransactionPlannerConfig = {
      */
     version?: 'legacy' | 0;
 };
+
+/**
+ * Configuration options for the transaction planner when creating version 1
+ * transaction messages.
+ *
+ * For version 1, priority fees live in a structured resource header rather than
+ * a compute budget instruction, and are expressed as a total amount in lamports
+ * rather than a per-compute-unit price.
+ *
+ * @remarks
+ * Version 1 transactions are not yet buildable by `@solana/kit`, so this branch
+ * is currently inert: passing `version: 1` throws at runtime. The shape is
+ * defined now so that enabling version 1 later is not a breaking change.
+ */
+export type TransactionPlannerConfigV1 = {
+    /**
+     * The total priority fee to set on the transaction, in lamports, written to
+     * the version 1 resource header.
+     *
+     * Defaults to using no priority fees.
+     */
+    priorityFeeLamports?: Lamports;
+    /**
+     * The transaction message version to use when creating transaction messages.
+     */
+    version: 1;
+};
+
+/**
+ * Configuration options for the transaction planner.
+ *
+ * The `version` field determines the transaction version to use when creating
+ * transaction messages and discriminates the shape of the rest of the
+ * configuration, as some options are only applicable to certain versions.
+ *
+ * @see {@link TransactionPlannerConfigLegacy}
+ * @see {@link TransactionPlannerConfigV1}
+ */
+export type TransactionPlannerConfig = TransactionPlannerConfigLegacy | TransactionPlannerConfigV1;

--- a/packages/kit-plugin-litesvm/test/transaction-planner.test.ts
+++ b/packages/kit-plugin-litesvm/test/transaction-planner.test.ts
@@ -3,15 +3,16 @@ import {
     createClient,
     generateKeyPairSigner,
     getTransactionMessageComputeUnitPrice,
+    Lamports,
     MicroLamports,
     singleInstructionPlan,
     SingleTransactionPlan,
     TransactionMessage,
     TransactionSigner,
 } from '@solana/kit';
-import { describe, expect, it } from 'vitest';
+import { assertType, describe, expect, it } from 'vitest';
 
-import { litesvmTransactionPlanner } from '../src';
+import { litesvmTransactionPlanner, TransactionPlannerConfig } from '../src';
 
 const MOCK_INSTRUCTION = {
     programAddress: '11111111111111111111111111111111' as Address,
@@ -84,8 +85,29 @@ describe('litesvmTransactionPlanner', () => {
         expect(getTransactionMessageComputeUnitPrice(message)).toBe(100n);
     });
 
+    it('throws when configured with version 1 transactions', () => {
+        const payer = {} as TransactionSigner;
+        expect(() =>
+            createClient()
+                .use(() => ({ payer }))
+                .use(litesvmTransactionPlanner({ version: 1 })),
+        ).toThrow(/Version 1 transactions are not yet supported/);
+    });
+
     it('requires a payer on the client', () => {
         // @ts-expect-error TypeScript fails but we don't throw an error at runtime.
         expect(() => createClient().use(litesvmTransactionPlanner())).not.toThrow();
+    });
+
+    it('discriminates the config shape on the transaction version', () => {
+        // Legacy and version 0 accept `microLamportsPerComputeUnit` but not `priorityFeeLamports`.
+        assertType<TransactionPlannerConfig>({ microLamportsPerComputeUnit: 1n as MicroLamports, version: 0 });
+        // @ts-expect-error `priorityFeeLamports` is only valid for version 1.
+        assertType<TransactionPlannerConfig>({ priorityFeeLamports: 1n as Lamports, version: 0 });
+
+        // Version 1 accepts `priorityFeeLamports` but not `microLamportsPerComputeUnit`.
+        assertType<TransactionPlannerConfig>({ priorityFeeLamports: 1n as Lamports, version: 1 });
+        // @ts-expect-error `microLamportsPerComputeUnit` is only valid for legacy and version 0.
+        assertType<TransactionPlannerConfig>({ microLamportsPerComputeUnit: 1n as MicroLamports, version: 1 });
     });
 });

--- a/packages/kit-plugin-rpc/README.md
+++ b/packages/kit-plugin-rpc/README.md
@@ -242,10 +242,15 @@ const client = await createClient()
 
 ### Options
 
-All options are provided via a `TransactionPlannerConfig` object:
+All options are provided via a `TransactionPlannerConfig` object. Its shape is discriminated by the transaction `version`.
+
+For legacy and version 0 transactions:
 
 - `version`: The transaction message version to use. Accepts `0` or `'legacy'`. Defaults to `0`.
-- `microLamportsPerComputeUnit`: Priority fees in micro lamports per compute unit. Defaults to no priority fees.
+- `microLamportsPerComputeUnit`: The priority fee in micro-lamports per compute unit, added as a `setComputeUnitPrice` instruction. Defaults to no priority fees.
+- `estimateResourceLimits`: Whether to estimate and set resource limits by simulating before sending. Set to `false` to skip estimation and reserve no provisory limits, which is useful for transactions close to the message size limit. Defaults to `true`.
+
+Version 1 transactions are defined for forward compatibility but are not yet buildable by `@solana/kit`; passing `version: 1` currently throws. When available, version 1 will accept `priorityFeeLamports` (a flat total in lamports) instead of `microLamportsPerComputeUnit`, alongside the shared `estimateResourceLimits` option.
 
 ### Features
 
@@ -276,6 +281,8 @@ const client = await createClient()
 
 ### Options
 
+- `estimateResourceLimits`: Whether to estimate and set resource limits by simulating before sending (default: `true`). This should match the `estimateResourceLimits` option on the planner; `solanaRpc` keeps them in sync automatically.
+- `getComputeUnitLimitFromEstimate`: A `(estimatedComputeUnits: number) => number` function that maps the estimated compute unit consumption to the compute unit limit to set, adding headroom for variation between simulation and execution. Defaults to a function that adds a buffer on top of the estimate of at least 300 compute units, or a margin that decays linearly from 10% at low estimates to 2% at 500,000 compute units and above, whichever is greater. The result is always capped at 1,400,000 (the per-transaction maximum).
 - `maxConcurrency`: Maximum number of concurrent executions (default: 10).
 - `skipPreflight`: Whether to skip the preflight simulation when sending transactions (default: `false`).
 
@@ -293,13 +300,49 @@ By default, the executor estimates resource limits by simulating the transaction
 Setting `skipPreflight: true` changes the behavior:
 
 - Preflight is always skipped regardless of whether estimation was performed.
-- If the resource limit estimation simulation fails, the consumed resources from the failed simulation are used to set the limits (with a 10% buffer on compute units) so the transaction still reaches the validator. This is useful for debugging failed transactions in an explorer.
+- If the resource limit estimation simulation fails, the consumed resources from the failed simulation are used to set the limits (with the compute unit buffer from `getComputeUnitLimitFromEstimate` applied) so the transaction still reaches the validator. This is useful for debugging failed transactions in an explorer.
 
 | Scenario            | `skipPreflight: false` (default) | `skipPreflight: true`                  |
 | ------------------- | -------------------------------- | -------------------------------------- |
 | Estimation succeeds | Set limits, skip preflight       | Set limits, skip preflight             |
 | Estimation fails    | Throw                            | Use consumed resources, skip preflight |
 | Explicit limits set | Run preflight                    | Skip preflight                         |
+
+Set `estimateResourceLimits: false` to opt out of resource limit estimation entirely. The planner then reserves no provisory resource limits and the executor does not simulate to estimate or inject any; any explicit resource limits already present on the message are preserved. This is useful for transactions close to the message size limit, where adding a compute budget instruction would make an otherwise valid transaction too large.
+
+Note that disabling estimation does not disable preflight. When `estimateResourceLimits: false` and `skipPreflight` is left at its default `false`, the executor still runs a preflight simulation when sending — this becomes the only simulation. To avoid all simulation overhead, set `skipPreflight: true` as well.
+
+When using `solanaRpc`, both the planner and executor read `estimateResourceLimits` from a single place: `transactionConfig`.
+
+```ts
+const client = createClient()
+    .use(payer(myPayer))
+    .use(
+        solanaRpc({
+            rpcUrl: 'https://api.mainnet-beta.solana.com',
+            skipPreflight: true,
+            transactionConfig: { estimateResourceLimits: false },
+        }),
+    );
+```
+
+#### Compute unit buffer
+
+Because a transaction can consume slightly more compute units at execution time than during simulation, the executor adds a buffer to the estimated compute unit limit. By default this buffer is the greater of a fixed minimum of 300 compute units and a margin that decays linearly from 10% at low estimates to 2% at 500,000 compute units and above, added on top of the estimate.
+
+Override this by passing a `getComputeUnitLimitFromEstimate` function that maps the raw estimate to the limit to set. It is applied on both successful estimation and the `skipPreflight` recovery path. The resulting limit is always capped at 1,400,000, the maximum number of compute units allowed per transaction, including for custom functions.
+
+```ts
+const client = createClient()
+    .use(payer(myPayer))
+    .use(
+        solanaRpc({
+            rpcUrl: 'https://api.mainnet-beta.solana.com',
+            // Add a flat 20% buffer instead of the default curve.
+            getComputeUnitLimitFromEstimate: estimatedComputeUnits => Math.ceil(estimatedComputeUnits * 1.2),
+        }),
+    );
+```
 
 ## Deprecated plugins
 

--- a/packages/kit-plugin-rpc/src/solana-rpc.ts
+++ b/packages/kit-plugin-rpc/src/solana-rpc.ts
@@ -60,6 +60,20 @@ export type SolanaRpcConnectionConfig<TClusterUrl extends ClusterUrl = ClusterUr
  */
 export type SolanaRpcConfig<TClusterUrl extends ClusterUrl = ClusterUrl> = SolanaRpcConnectionConfig<TClusterUrl> & {
     /**
+     * Maps the estimated compute unit consumption from simulation to the compute
+     * unit limit to set on the transaction, adding headroom to account for
+     * variation between simulation and execution.
+     *
+     * By default, a function is used that adds a buffer on top of the estimate
+     * of at least 300 compute units, or a margin that decays linearly from 10%
+     * at low estimates to 2% at 500,000 compute units and above, whichever is
+     * greater.
+     *
+     * The returned value is always capped at 1,400,000, the maximum number of
+     * compute units allowed per transaction.
+     */
+    getComputeUnitLimitFromEstimate?: (estimatedComputeUnits: number) => number;
+    /**
      * The maximum number of concurrent transaction executions allowed.
      * Defaults to 10.
      */
@@ -67,18 +81,25 @@ export type SolanaRpcConfig<TClusterUrl extends ClusterUrl = ClusterUrl> = Solan
     /**
      * Whether to skip the preflight simulation when sending transactions.
      *
-     * When `false` (default), preflight is skipped only if a compute unit
+     * When `false` (default), preflight is skipped only if a resource limit
      * estimation simulation was already performed for that transaction.
      *
      * When `true`, preflight is always skipped and the transaction is sent
      * directly to the validator.
      *
+     * This is independent of `transactionConfig.estimateResourceLimits`:
+     * disabling estimation does not disable preflight. Set both to send a
+     * transaction with no simulation at all.
+     *
      * Defaults to `false`.
      */
     skipPreflight?: boolean;
     /**
-     * Options to configure how transaction messages are created such as
-     * choosing a transaction version or setting priority fees.
+     * Options to configure how transaction messages are created, such as
+     * choosing a transaction version, configuring priority fees, or toggling
+     * resource limit estimation. This is the single source for
+     * `estimateResourceLimits`, which is applied to both the planner and the
+     * executor.
      */
     transactionConfig?: TransactionPlannerConfig;
 };
@@ -117,7 +138,12 @@ export function solanaRpc<TClusterUrl extends ClusterUrl>(config: SolanaRpcConfi
             solanaRpcConnection<TClusterUrl>(config),
             rpcGetMinimumBalance(),
             rpcTransactionPlanner(config.transactionConfig),
-            rpcTransactionPlanExecutor({ maxConcurrency: config.maxConcurrency, skipPreflight: config.skipPreflight }),
+            rpcTransactionPlanExecutor({
+                estimateResourceLimits: config.transactionConfig?.estimateResourceLimits,
+                getComputeUnitLimitFromEstimate: config.getComputeUnitLimitFromEstimate,
+                maxConcurrency: config.maxConcurrency,
+                skipPreflight: config.skipPreflight,
+            }),
             planAndSendTransactions(),
         );
 }

--- a/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
+++ b/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
@@ -50,6 +50,43 @@ import {
 export function rpcTransactionPlanExecutor(
     config: {
         /**
+         * Whether to estimate and set resource limits (the compute unit limit
+         * and, for version 1 transactions, the loaded accounts data size limit)
+         * by simulating the transaction before sending.
+         *
+         * When `true` (default), any resource limit that is still provisory or
+         * unset is estimated via a simulation and replaced with the estimated
+         * value (with a compute unit buffer applied via
+         * `getComputeUnitLimitFromEstimate`). When `false`, no estimation
+         * simulation is performed and the message is sent with exactly the
+         * resource limits it already carries.
+         *
+         * This should match the `estimateResourceLimits` option passed to
+         * {@link rpcTransactionPlanner}, which controls whether provisory limits
+         * are reserved in the first place. {@link solanaRpc} keeps them in sync
+         * automatically.
+         *
+         * Defaults to `true`.
+         */
+        estimateResourceLimits?: boolean;
+        /**
+         * Maps the estimated compute unit consumption from simulation to the
+         * compute unit limit to set on the transaction, adding headroom to
+         * account for variation between simulation and execution.
+         *
+         * By default, a function is used that adds a buffer on top of the
+         * estimate of at least 300 compute units, or a margin that decays
+         * linearly from 10% at low estimates to 2% at 500,000 compute units and
+         * above, whichever is greater.
+         *
+         * The returned value is always capped at 1,400,000, the maximum number of
+         * compute units allowed per transaction.
+         *
+         * @param estimatedComputeUnits - The compute units consumed during simulation.
+         * @returns The compute unit limit to set on the transaction.
+         */
+        getComputeUnitLimitFromEstimate?: (estimatedComputeUnits: number) => number;
+        /**
          * The maximum number of concurrent executions allowed.
          * Defaults to 10.
          */
@@ -60,7 +97,8 @@ export function rpcTransactionPlanExecutor(
          * When `false` (default), preflight is skipped only if a resource limit
          * estimation simulation was already performed for that transaction.
          * If every applicable resource limit is already explicitly set (i.e. no
-         * estimation was needed), preflight runs as the only simulation.
+         * estimation was needed) or estimation is disabled, preflight runs as the
+         * only simulation.
          *
          * When `true`, preflight is always skipped and the transaction is sent
          * directly to the validator. Additionally, if the resource limit estimation
@@ -97,6 +135,9 @@ export function rpcTransactionPlanExecutor(
             rpcSubscriptions: client.rpcSubscriptions,
         });
         const estimateResourceLimits = estimateResourceLimitsFactory({ rpc: client.rpc });
+        const shouldEstimateResourceLimits = config.estimateResourceLimits ?? true;
+        const getComputeUnitLimitFromEstimate =
+            config.getComputeUnitLimitFromEstimate ?? getDefaultComputeUnitLimitFromEstimate;
         const skipPreflight = config.skipPreflight ?? false;
 
         const transactionPlanExecutor = createTransactionPlanExecutor({
@@ -109,16 +150,24 @@ export function rpcTransactionPlanExecutor(
                 // skip the redundant preflight simulation while sending.
                 let didSimulateToEstimate = false;
                 const estimateAndSetResourceLimits = estimateAndSetResourceLimitsFactory(
-                    bufferAndRecoverResourceLimits(estimateResourceLimits, skipPreflight, () => {
-                        didSimulateToEstimate = true;
-                    }),
+                    bufferAndRecoverResourceLimits(
+                        estimateResourceLimits,
+                        getComputeUnitLimitFromEstimate,
+                        skipPreflight,
+                        () => {
+                            didSimulateToEstimate = true;
+                        },
+                    ),
                 );
 
                 const signedTransaction = await pipe(
                     transactionMessage,
                     tx => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
                     tx => (context.message = tx),
-                    async tx => await estimateAndSetResourceLimits(tx, executorConfig),
+                    // Skip the estimation step entirely when disabled, so the
+                    // message is sent with exactly the resource limits it carries.
+                    async tx =>
+                        shouldEstimateResourceLimits ? await estimateAndSetResourceLimits(tx, executorConfig) : tx,
                     async tx => (context.message = await tx),
                     async tx => await signTransactionMessageWithSigners(await tx, executorConfig),
                     async tx => (context.transaction = await tx),
@@ -138,8 +187,50 @@ export function rpcTransactionPlanExecutor(
 }
 
 /**
- * Wraps a resource limit estimator to add a 10% compute unit buffer and,
- * optionally, recover from failed estimation simulations.
+ * The minimum compute unit buffer added on top of the estimate by
+ * {@link getDefaultComputeUnitLimitFromEstimate}.
+ *
+ * This value (300) reserves headroom that covers, at minimum, the two Compute
+ * Budget instructions the executor prepends to the transaction (a
+ * `SetComputeUnitLimit` and a `SetComputeUnitPrice`), each of which consumes a
+ * fixed 150 compute units as builtin instructions.
+ */
+const MIN_COMPUTE_UNIT_BUFFER = 300;
+/** The maximum compute unit limit allowed per transaction. */
+const MAX_COMPUTE_UNIT_LIMIT = 1_400_000;
+/** The estimated compute units at which the default margin reaches its floor. */
+const COMPUTE_UNIT_MARGIN_CAP = 500_000;
+/** The margin added to low compute unit estimates (10%). */
+const MAX_COMPUTE_UNIT_MARGIN = 0.1;
+/** The margin added to compute unit estimates at or above the cap (2%). */
+const MIN_COMPUTE_UNIT_MARGIN = 0.02;
+
+/**
+ * The default function used to derive a compute unit limit from an estimate.
+ *
+ * It adds a buffer on top of the estimate that is the greater of a fixed
+ * minimum ({@link MIN_COMPUTE_UNIT_BUFFER}) and a margin that decays linearly
+ * from {@link MAX_COMPUTE_UNIT_MARGIN} at low estimates to
+ * {@link MIN_COMPUTE_UNIT_MARGIN} at {@link COMPUTE_UNIT_MARGIN_CAP} compute
+ * units and above. This guarantees a meaningful cushion for cheap transactions
+ * while keeping the overhead small for expensive ones, accounting for variation
+ * between simulation and execution.
+ *
+ * @param estimatedComputeUnits - The compute units consumed during simulation.
+ * @returns The compute unit limit to set on the transaction.
+ */
+function getDefaultComputeUnitLimitFromEstimate(estimatedComputeUnits: number): number {
+    const progress = Math.min(estimatedComputeUnits / COMPUTE_UNIT_MARGIN_CAP, 1);
+    const margin = MAX_COMPUTE_UNIT_MARGIN - (MAX_COMPUTE_UNIT_MARGIN - MIN_COMPUTE_UNIT_MARGIN) * progress;
+    // Compute the extra units separately and round them up before adding, so we
+    // avoid floating-point artefacts from multiplying by `1 + margin` directly.
+    const extraComputeUnits = Math.ceil(estimatedComputeUnits * margin);
+    return estimatedComputeUnits + Math.max(MIN_COMPUTE_UNIT_BUFFER, extraComputeUnits);
+}
+
+/**
+ * Wraps a resource limit estimator to buffer the estimated compute unit limit
+ * and, optionally, recover from failed estimation simulations.
  *
  * The returned estimator is intended to be passed to
  * {@link estimateAndSetResourceLimitsFactory}, which only calls it when a
@@ -147,8 +238,11 @@ export function rpcTransactionPlanExecutor(
  * therefore invoked exactly once an estimation simulation has been performed
  * and we are proceeding to send (i.e. not on a non-recoverable failure).
  *
- * A 10% buffer is applied to the compute unit limit only, to account for
- * variations between simulation and execution.
+ * The `getComputeUnitLimitFromEstimate` function is applied to the compute unit
+ * limit only, to account for variations between simulation and execution. It is
+ * applied on both the success path and the recovery path, and its result is
+ * rounded up to an integer and capped at {@link MAX_COMPUTE_UNIT_LIMIT} (the
+ * per-transaction maximum).
  *
  * When `skipPreflight` is `true` and the estimation simulation fails, the
  * consumed resources from the failed simulation are used so the transaction
@@ -156,12 +250,14 @@ export function rpcTransactionPlanExecutor(
  *
  * @param estimateResourceLimits - The underlying estimator, typically created by
  *   {@link estimateResourceLimitsFactory}.
+ * @param getComputeUnitLimitFromEstimate - Maps the estimated compute units to the limit to set.
  * @param skipPreflight - Whether to recover from failed simulations using consumed resources.
  * @param onSimulate - Called once a simulation has been performed and an estimate produced.
  * @returns An estimator that applies a compute unit buffer and recovery behaviour.
  */
 function bufferAndRecoverResourceLimits(
     estimateResourceLimits: ReturnType<typeof estimateResourceLimitsFactory>,
+    getComputeUnitLimitFromEstimate: (estimatedComputeUnits: number) => number,
     skipPreflight: boolean,
     onSimulate: () => void,
 ): ReturnType<typeof estimateResourceLimitsFactory> {
@@ -196,10 +292,14 @@ function bufferAndRecoverResourceLimits(
         // above and never gets here.
         onSimulate();
 
-        // Multiply the estimated compute unit limit by 1.1 to add a 10% buffer.
+        // Apply the compute unit buffer to the estimated compute unit limit,
+        // rounding up to an integer and capping at the per-transaction maximum.
         return {
             ...estimate,
-            computeUnitLimit: Math.ceil(estimate.computeUnitLimit * 1.1),
+            computeUnitLimit: Math.min(
+                MAX_COMPUTE_UNIT_LIMIT,
+                Math.ceil(getComputeUnitLimitFromEstimate(estimate.computeUnitLimit)),
+            ),
         } as ResourceLimitsEstimate<typeof transactionMessage>;
     };
 }

--- a/packages/kit-plugin-rpc/src/transaction-planner.ts
+++ b/packages/kit-plugin-rpc/src/transaction-planner.ts
@@ -4,6 +4,7 @@ import {
     createTransactionPlanner,
     extendClient,
     fillTransactionMessageProvisoryResourceLimits,
+    Lamports,
     MicroLamports,
     pipe,
     setTransactionMessageComputeUnitPrice,
@@ -16,7 +17,8 @@ import {
  * The planner creates transaction messages with:
  * - The configured fee payer.
  * - Provisory resource limits (a compute unit limit, plus a loaded accounts data
- *   size limit for version 1 transactions) to be estimated later by the executor.
+ *   size limit for version 1 transactions) to be estimated later by the executor,
+ *   unless `estimateResourceLimits` is `false`.
  * - Optional priority fees.
  *
  * @param config - Optional configuration for the planner.
@@ -34,19 +36,41 @@ import {
  *     .use(rpcTransactionPlanner())
  *     .use(rpcTransactionPlanExecutor());
  * ```
+ *
+ * @example
+ * Disabling resource limit estimation, for transactions that are close to the
+ * message size limit.
+ *
+ * ```ts
+ * rpcTransactionPlanner({ estimateResourceLimits: false });
+ * ```
  */
 export function rpcTransactionPlanner(config: TransactionPlannerConfig = {}) {
     return <T extends ClientWithPayer>(client: T) => {
+        if (config.version === 1) {
+            // The v1 transaction path is defined at the type level for forward
+            // compatibility, but `createTransactionMessage` cannot yet build v1
+            // messages, so we fail loudly rather than silently misbehave.
+            throw new Error(
+                'Version 1 transactions are not yet supported by `rpcTransactionPlanner`. ' +
+                    'Use version 0 or legacy transactions for now.',
+            );
+        }
+
+        const version = config.version ?? 0;
+        const estimateResourceLimits = config.estimateResourceLimits ?? true;
+        const microLamportsPerComputeUnit = config.microLamportsPerComputeUnit;
+
         const transactionPlanner = createTransactionPlanner({
             createTransactionMessage: () => {
                 return pipe(
-                    createTransactionMessage({ version: config.version ?? 0 }),
+                    createTransactionMessage({ version }),
                     tx => setTransactionMessageFeePayerSigner(client.payer, tx),
-                    tx => fillTransactionMessageProvisoryResourceLimits(tx),
+                    tx => (estimateResourceLimits ? fillTransactionMessageProvisoryResourceLimits(tx) : tx),
                     tx =>
-                        config.microLamportsPerComputeUnit
-                            ? setTransactionMessageComputeUnitPrice(config.microLamportsPerComputeUnit, tx)
-                            : tx,
+                        microLamportsPerComputeUnit === undefined
+                            ? tx
+                            : setTransactionMessageComputeUnitPrice(microLamportsPerComputeUnit, tx),
                 );
             },
         });
@@ -56,18 +80,44 @@ export function rpcTransactionPlanner(config: TransactionPlannerConfig = {}) {
 }
 
 /**
- * Configuration options for the transaction planner.
- *
- * The `version` field is used to determine the transaction version
- * to use when creating transaction messages and determines the shape
- * of the rest of the configuration options, as some options are only
- * applicable to certain transaction versions.
+ * Configuration options shared by all transaction versions.
  */
-// TODO(loris): Add support for v1 transactions when `createTransactionMessage` supports them.
-// This includes: `version: 1` and `priorityFees?: Lamports` in a new union variant.
-export type TransactionPlannerConfig = {
+type SharedTransactionPlannerConfig = {
     /**
-     * The priority fees to be set on the transaction in micro lamports per compute unit.
+     * Whether to estimate and set resource limits (the compute unit limit and,
+     * for version 1 transactions, the loaded accounts data size limit) by
+     * simulating the transaction before sending.
+     *
+     * When `true` (default), the planner reserves provisory resource limits that
+     * the executor replaces with estimated values. When `false`, no provisory
+     * limits are reserved and the executor does not simulate to estimate them;
+     * any explicit resource limits already present on the message are preserved.
+     * This is useful for transactions that are close to the message size limit,
+     * where adding a compute budget instruction would make an otherwise valid
+     * transaction too large.
+     *
+     * Note that this does not affect preflight. When estimation is disabled and
+     * `skipPreflight` is left at its default `false`, the executor still runs a
+     * preflight simulation when sending. Set `skipPreflight: true` on the
+     * executor to skip all simulation.
+     *
+     * Defaults to `true`.
+     */
+    estimateResourceLimits?: boolean;
+};
+
+/**
+ * Configuration options for the transaction planner when creating legacy or
+ * version 0 transaction messages.
+ *
+ * For these versions, resource limits and priority fees are expressed as compute
+ * budget instructions appended to the transaction, which cost message bytes.
+ */
+export type TransactionPlannerConfigLegacy = SharedTransactionPlannerConfig & {
+    /**
+     * The priority fee to set on the transaction, in micro-lamports per compute
+     * unit, added as a `setComputeUnitPrice` instruction.
+     *
      * Defaults to using no priority fees.
      */
     microLamportsPerComputeUnit?: MicroLamports;
@@ -77,3 +127,42 @@ export type TransactionPlannerConfig = {
      */
     version?: 'legacy' | 0;
 };
+
+/**
+ * Configuration options for the transaction planner when creating version 1
+ * transaction messages.
+ *
+ * For version 1, resource limits and priority fees live in a structured resource
+ * header rather than compute budget instructions, and the priority fee is
+ * expressed as a total amount in lamports rather than a per-compute-unit price.
+ *
+ * @remarks
+ * Version 1 transactions are not yet buildable by `@solana/kit`, so this branch
+ * is currently inert: passing `version: 1` throws at runtime. The shape is
+ * defined now so that enabling version 1 later is not a breaking change.
+ */
+export type TransactionPlannerConfigV1 = SharedTransactionPlannerConfig & {
+    /**
+     * The total priority fee to set on the transaction, in lamports, written to
+     * the version 1 resource header.
+     *
+     * Defaults to using no priority fees.
+     */
+    priorityFeeLamports?: Lamports;
+    /**
+     * The transaction message version to use when creating transaction messages.
+     */
+    version: 1;
+};
+
+/**
+ * Configuration options for the transaction planner.
+ *
+ * The `version` field determines the transaction version to use when creating
+ * transaction messages and discriminates the shape of the rest of the
+ * configuration, as some options are only applicable to certain versions.
+ *
+ * @see {@link TransactionPlannerConfigLegacy}
+ * @see {@link TransactionPlannerConfigV1}
+ */
+export type TransactionPlannerConfig = TransactionPlannerConfigLegacy | TransactionPlannerConfigV1;

--- a/packages/kit-plugin-rpc/test/transaction-plan-executor.test.ts
+++ b/packages/kit-plugin-rpc/test/transaction-plan-executor.test.ts
@@ -3,6 +3,7 @@ import {
     createClient,
     createTransactionMessage,
     generateKeyPairSigner,
+    getTransactionMessageComputeUnitLimit,
     parallelTransactionPlan,
     pipe,
     Rpc,
@@ -358,6 +359,249 @@ describe('rpcTransactionPlanExecutor', () => {
             commitment: 'confirmed',
             skipPreflight: false,
         });
+    });
+
+    it('does not simulate to estimate when resource limit estimation is disabled', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        const simulateTransaction = vi.fn();
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
+        (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
+
+        const client = createClient()
+            .use(() => ({ payer, rpc, rpcSubscriptions }))
+            .use(rpcTransactionPlanner({ estimateResourceLimits: false }))
+            .use(rpcTransactionPlanExecutor({ estimateResourceLimits: false }));
+
+        const transactionPlan = await client.transactionPlanner(singleInstructionPlan(MOCK_INSTRUCTION));
+        await client.transactionPlanExecutor(transactionPlan);
+
+        // No estimation simulation should have been performed.
+        expect(simulateTransaction).not.toHaveBeenCalled();
+
+        // Preflight runs as the only simulation, so it is not skipped.
+        expect(sendAndConfirmTransaction).toHaveBeenCalledExactlyOnceWith(expect.anything(), {
+            commitment: 'confirmed',
+            skipPreflight: false,
+        });
+    });
+
+    it('performs no simulation when estimation is disabled and preflight is skipped', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        const simulateTransaction = vi.fn();
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
+        (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
+
+        const client = createClient()
+            .use(() => ({ payer, rpc, rpcSubscriptions }))
+            .use(rpcTransactionPlanner({ estimateResourceLimits: false }))
+            .use(rpcTransactionPlanExecutor({ estimateResourceLimits: false, skipPreflight: true }));
+
+        const transactionPlan = await client.transactionPlanner(singleInstructionPlan(MOCK_INSTRUCTION));
+        await client.transactionPlanExecutor(transactionPlan);
+
+        // No estimation simulation and no preflight: zero simulations overall.
+        expect(simulateTransaction).not.toHaveBeenCalled();
+        expect(sendAndConfirmTransaction).toHaveBeenCalledExactlyOnceWith(expect.anything(), {
+            commitment: 'confirmed',
+            skipPreflight: true,
+        });
+    });
+
+    it('adds the minimum compute unit buffer of 300 to a small estimate', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        // A tiny estimate whose percentage margin (42 * ~0.1 = 5) is below the
+        // 300 buffer floor, so the flat 300 buffer is added instead: 42 + 300.
+        const simulateTransaction = vi.fn().mockResolvedValue({ value: { unitsConsumed: 42n } });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
+        (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
+
+        const client = createClient()
+            .use(() => ({ payer, rpc, rpcSubscriptions }))
+            .use(rpcTransactionPlanExecutor());
+
+        const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
+        const result = (await client.transactionPlanExecutor(
+            singleTransactionPlan(txMessage),
+        )) as SingleTransactionPlanResult;
+
+        expect(getTransactionMessageComputeUnitLimit(result.context.message!)).toBe(342);
+    });
+
+    it('adds the minimum compute unit buffer when the percentage margin is below 300', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        // 1,000 CU sits in the decaying region but its margin (1,000 * ~0.09984
+        // = 100) is below the 300 buffer floor, so the flat 300 buffer wins:
+        // 1,000 + 300 = 1,300.
+        const simulateTransaction = vi.fn().mockResolvedValue({ value: { unitsConsumed: 1_000n } });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
+        (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
+
+        const client = createClient()
+            .use(() => ({ payer, rpc, rpcSubscriptions }))
+            .use(rpcTransactionPlanExecutor());
+
+        const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
+        const result = (await client.transactionPlanExecutor(
+            singleTransactionPlan(txMessage),
+        )) as SingleTransactionPlanResult;
+
+        expect(getTransactionMessageComputeUnitLimit(result.context.message!)).toBe(1_300);
+    });
+
+    it('applies the default compute unit buffer to a mid-range estimate', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        // 50,000 CU sits in the decaying region: margin = 0.1 - 0.08 * (50000 / 500000) = 0.092.
+        // The percentage buffer (50,000 * 0.092 = 4,600) exceeds the 300 floor,
+        // so it wins: 50,000 + 4,600 = 54,600.
+        const simulateTransaction = vi.fn().mockResolvedValue({ value: { unitsConsumed: 50_000n } });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
+        (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
+
+        const client = createClient()
+            .use(() => ({ payer, rpc, rpcSubscriptions }))
+            .use(rpcTransactionPlanExecutor());
+
+        const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
+        const result = (await client.transactionPlanExecutor(
+            singleTransactionPlan(txMessage),
+        )) as SingleTransactionPlanResult;
+
+        expect(getTransactionMessageComputeUnitLimit(result.context.message!)).toBe(54_600);
+    });
+
+    it('uses a custom getComputeUnitLimitFromEstimate function when provided', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        const simulateTransaction = vi.fn().mockResolvedValue({ value: { unitsConsumed: 1_000n } });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
+        (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
+
+        const getComputeUnitLimitFromEstimate = vi.fn((estimatedComputeUnits: number) => estimatedComputeUnits * 2);
+        const client = createClient()
+            .use(() => ({ payer, rpc, rpcSubscriptions }))
+            .use(rpcTransactionPlanExecutor({ getComputeUnitLimitFromEstimate }));
+
+        const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
+        const result = (await client.transactionPlanExecutor(
+            singleTransactionPlan(txMessage),
+        )) as SingleTransactionPlanResult;
+
+        // The custom function receives the raw estimate and its result is used verbatim.
+        expect(getComputeUnitLimitFromEstimate).toHaveBeenCalledWith(1_000);
+        expect(getTransactionMessageComputeUnitLimit(result.context.message!)).toBe(2_000);
+    });
+
+    it('applies the compute unit buffer on the recovery path when estimation fails and skipPreflight is true', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        // The estimation simulation fails but reports the consumed units.
+        const simulateTransaction = vi
+            .fn()
+            .mockResolvedValue({ value: { err: 'AccountNotFound', unitsConsumed: 50_000n } });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
+        (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
+
+        const client = createClient()
+            .use(() => ({ payer, rpc, rpcSubscriptions }))
+            .use(rpcTransactionPlanExecutor({ skipPreflight: true }));
+
+        const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
+        const result = (await client.transactionPlanExecutor(
+            singleTransactionPlan(txMessage),
+        )) as SingleTransactionPlanResult;
+
+        // The recovered 50,000 CU is buffered the same way as a successful estimate.
+        expect(getTransactionMessageComputeUnitLimit(result.context.message!)).toBe(54_600);
+    });
+
+    it('caps the default buffered compute unit limit at the per-transaction maximum', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        // 1,390,000 CU buffered by 2% would be ~1,417,800, above the 1,400,000 max.
+        const simulateTransaction = vi.fn().mockResolvedValue({ value: { unitsConsumed: 1_390_000n } });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
+        (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
+
+        const client = createClient()
+            .use(() => ({ payer, rpc, rpcSubscriptions }))
+            .use(rpcTransactionPlanExecutor());
+
+        const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
+        const result = (await client.transactionPlanExecutor(
+            singleTransactionPlan(txMessage),
+        )) as SingleTransactionPlanResult;
+
+        expect(getTransactionMessageComputeUnitLimit(result.context.message!)).toBe(1_400_000);
+    });
+
+    it('caps a custom getComputeUnitLimitFromEstimate result at the per-transaction maximum', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        const simulateTransaction = vi.fn().mockResolvedValue({ value: { unitsConsumed: 1_000n } });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        const sendAndConfirmTransaction = vi.fn().mockResolvedValue('MockTransactionSignature');
+        (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
+
+        const client = createClient()
+            .use(() => ({ payer, rpc, rpcSubscriptions }))
+            // A custom function that returns an out-of-range value must still be capped.
+            .use(rpcTransactionPlanExecutor({ getComputeUnitLimitFromEstimate: () => 2_000_000 }));
+
+        const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
+        const result = (await client.transactionPlanExecutor(
+            singleTransactionPlan(txMessage),
+        )) as SingleTransactionPlanResult;
+
+        expect(getTransactionMessageComputeUnitLimit(result.context.message!)).toBe(1_400_000);
     });
 
     it('limits the number of concurrent executions for parallel transaction plans', async () => {

--- a/packages/kit-plugin-rpc/test/transaction-planner.test.ts
+++ b/packages/kit-plugin-rpc/test/transaction-planner.test.ts
@@ -2,16 +2,18 @@ import {
     Address,
     createClient,
     generateKeyPairSigner,
+    getTransactionMessageComputeUnitLimit,
     getTransactionMessageComputeUnitPrice,
+    Lamports,
     MicroLamports,
     singleInstructionPlan,
     SingleTransactionPlan,
     TransactionMessage,
     TransactionSigner,
 } from '@solana/kit';
-import { describe, expect, it } from 'vitest';
+import { assertType, describe, expect, it } from 'vitest';
 
-import { rpcTransactionPlanner } from '../src';
+import { rpcTransactionPlanner, TransactionPlannerConfig } from '../src';
 
 const MOCK_INSTRUCTION = {
     programAddress: '11111111111111111111111111111111' as Address,
@@ -84,8 +86,60 @@ describe('rpcTransactionPlanner', () => {
         expect(getTransactionMessageComputeUnitPrice(message)).toBe(100n);
     });
 
+    it('fills provisory resource limits by default', async () => {
+        const payer = await generateKeyPairSigner();
+        const client = createClient()
+            .use(() => ({ payer }))
+            .use(rpcTransactionPlanner());
+
+        const instructionPlan = singleInstructionPlan(MOCK_INSTRUCTION);
+        const transactionPlan = (await client.transactionPlanner(instructionPlan)) as SingleTransactionPlan;
+        // A provisory compute unit limit of 0 is reserved for the executor to estimate.
+        expect(getTransactionMessageComputeUnitLimit(transactionPlan.message)).toBe(0);
+    });
+
+    it('does not fill provisory resource limits when estimation is disabled', async () => {
+        const payer = await generateKeyPairSigner();
+        const client = createClient()
+            .use(() => ({ payer }))
+            .use(rpcTransactionPlanner({ estimateResourceLimits: false }));
+
+        const instructionPlan = singleInstructionPlan(MOCK_INSTRUCTION);
+        const transactionPlan = (await client.transactionPlanner(instructionPlan)) as SingleTransactionPlan;
+        expect(getTransactionMessageComputeUnitLimit(transactionPlan.message)).toBeUndefined();
+    });
+
+    it('throws when configured with version 1 transactions', () => {
+        const payer = {} as TransactionSigner;
+        expect(() =>
+            createClient()
+                .use(() => ({ payer }))
+                .use(rpcTransactionPlanner({ version: 1 })),
+        ).toThrow(/Version 1 transactions are not yet supported/);
+    });
+
     it('requires a payer on the client', () => {
         // @ts-expect-error TypeScript fails but we don't throw an error at runtime.
         expect(() => createClient().use(rpcTransactionPlanner())).not.toThrow();
+    });
+
+    it('discriminates the config shape on the transaction version', () => {
+        // Legacy and version 0 accept `microLamportsPerComputeUnit` but not `priorityFeeLamports`.
+        assertType<TransactionPlannerConfig>({ microLamportsPerComputeUnit: 1n as MicroLamports, version: 0 });
+        // @ts-expect-error `priorityFeeLamports` is only valid for version 1.
+        assertType<TransactionPlannerConfig>({ priorityFeeLamports: 1n as Lamports, version: 0 });
+
+        // Version 1 accepts `priorityFeeLamports` but not `microLamportsPerComputeUnit`.
+        assertType<TransactionPlannerConfig>({ priorityFeeLamports: 1n as Lamports, version: 1 });
+        // @ts-expect-error `microLamportsPerComputeUnit` is only valid for legacy and version 0.
+        assertType<TransactionPlannerConfig>({ microLamportsPerComputeUnit: 1n as MicroLamports, version: 1 });
+
+        // `estimateResourceLimits` is shared across all versions.
+        assertType<TransactionPlannerConfig>({ estimateResourceLimits: false });
+        assertType<TransactionPlannerConfig>({
+            estimateResourceLimits: false,
+            priorityFeeLamports: 1n as Lamports,
+            version: 1,
+        });
     });
 });

--- a/packages/kit-plugins/src/index.ts
+++ b/packages/kit-plugins/src/index.ts
@@ -3,9 +3,14 @@ export * from '@solana/kit-plugin-instruction-plan';
 export * from '@solana/kit-plugin-litesvm';
 export * from '@solana/kit-plugin-payer';
 export * from '@solana/kit-plugin-rpc';
-// Resolve the ambiguous `TransactionPlannerConfig` re-export. Both
-// `@solana/kit-plugin-litesvm` and `@solana/kit-plugin-rpc` export a
-// type with the same name and shape.
-export type { TransactionPlannerConfig } from '@solana/kit-plugin-rpc';
+// Resolve ambiguous re-exports. Both `@solana/kit-plugin-litesvm` and
+// `@solana/kit-plugin-rpc` export these types with the same name. We re-export
+// the `@solana/kit-plugin-rpc` variants, which are supersets of the LiteSVM
+// ones (they additionally support resource limit estimation).
+export type {
+    TransactionPlannerConfig,
+    TransactionPlannerConfigLegacy,
+    TransactionPlannerConfigV1,
+} from '@solana/kit-plugin-rpc';
 
 export * from './defaults';


### PR DESCRIPTION
This PR reworks resource limit estimation for the RPC plugin and prepares the transaction planner config for version 1 transactions.

The compute unit buffer applied to simulation estimates is now configurable through a new `getComputeUnitLimitFromEstimate` option on `rpcTransactionPlanExecutor` (surfaced on `solanaRpc`). The previous flat 10% buffer is replaced by a default that enforces a 300 CU floor and a margin decaying linearly from 10% to 2% by 500,000 CU, with the result always capped at the 1,400,000 per-transaction maximum. Resource limit estimation can now be disabled with `estimateResourceLimits: false` for size-sensitive transactions.

`TransactionPlannerConfig` on both the RPC and LiteSVM plugins becomes a version-discriminated union so that version 1 support (structured resource headers) can land later without a breaking change; passing `version: 1` throws for now since `@solana/kit` cannot yet build v1 messages.