### PR TITLE
Refactor plan and send transaction plugin functions

### DIFF
--- a/.changeset/warm-windows-clap.md
+++ b/.changeset/warm-windows-clap.md
@@ -1,0 +1,13 @@
+---
+'@solana/kit-plugin-instruction-plan': minor
+'@solana/kit-plugin-litesvm': minor
+'@solana/kit-plugin-rpc': minor
+---
+
+Plugins that install a transaction planner or executor now also install the client functions that use them.
+
+The `transactionPlanner` plugin now adds `planTransaction` and `planTransactions` to the client, and a new `transactionPlanSendingExecutor` plugin adds `sendTransaction` and `sendTransactions`, planning through the client's planning functions. As a result, `planAndSendTransactions` is no longer needed and is deprecated, along with the `transactionPlanExecutor` plugin and the `client.transactionPlanner` and `client.transactionPlanExecutor` fields.
+
+`@solana/kit-plugin-rpc` and `@solana/kit-plugin-litesvm` keep their `rpcTransactionPlanner` and `litesvmTransactionPlanner` plugins, which now install `planTransaction` and `planTransactions` rather than just the planner field. They also gain `rpcTransactionPlanSendingExecutor` and `litesvmTransactionPlanSendingExecutor`, which install `sendTransaction` and `sendTransactions` and must therefore be applied after a transaction planner. The previous `rpcTransactionPlanExecutor` and `litesvmTransactionPlanExecutor` plugins are deprecated in their favour and keep their existing behaviour of only setting the `transactionPlanExecutor` field.
+
+All deprecated exports keep working unchanged.

--- a/README.md
+++ b/README.md
@@ -100,18 +100,16 @@ import {
     solanaRpcConnection,
     rpcAirdrop,
     rpcTransactionPlanner,
-    rpcTransactionPlanExecutor,
+    rpcTransactionPlanSendingExecutor,
 } from '@solana/kit-plugin-rpc';
 import { payerFromFile } from '@solana/kit-plugin-signer';
-import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
 
 const client = await createClient()
     .use(payerFromFile('path/to/keypair.json')) // Adds `client.payer` using a local keypair file.
     .use(solanaRpcConnection({ rpcUrl: 'https://api.devnet.solana.com' })) // Adds `client.rpc` and `client.rpcSubscriptions`.
     .use(rpcAirdrop()) // Adds `client.airdrop` to request SOL from faucets.
-    .use(rpcTransactionPlanner()) // Adds `client.transactionPlanner`.
-    .use(rpcTransactionPlanExecutor()) // Adds `client.transactionPlanExecutor`.
-    .use(planAndSendTransactions()); // Adds `client.planTransaction(s)` and `client.sendTransaction(s)`.
+    .use(rpcTransactionPlanner()) // Adds `client.planTransaction` and `client.planTransactions`.
+    .use(rpcTransactionPlanSendingExecutor()); // Adds `client.sendTransaction` and `client.sendTransactions`.
 ```
 
 Note that since core plugin interfaces are defined in `@solana/kit` itself, you're not limited to the plugins in this repo! You can use [community plugins](#community-plugins) or even [create your own](#create-your-own-plugins).
@@ -122,10 +120,10 @@ This repo provides the following individual plugin packages. You can learn more 
 
 | Package                                                                         | Version                                                                                                                                                      | Description                         | Plugins                                                                                                                                                                                                                                                                           |
 | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`@solana/kit-plugin-rpc`](./packages/kit-plugin-rpc)                           | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-rpc.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-rpc)                           | Connect to Solana clusters          | `solanaRpc`, `solanaMainnetRpc`, `solanaDevnetRpc`, `solanaTestnetRpc`, `solanaLocalRpc`, `solanaRpcConnection`, `rpcAirdrop`, `rpcGetMinimumBalance`, `rpcTransactionPlanner`, `rpcTransactionPlanExecutor`                                                                      |
+| [`@solana/kit-plugin-rpc`](./packages/kit-plugin-rpc)                           | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-rpc.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-rpc)                           | Connect to Solana clusters          | `solanaRpc`, `solanaMainnetRpc`, `solanaDevnetRpc`, `solanaTestnetRpc`, `solanaLocalRpc`, `solanaRpcConnection`, `rpcAirdrop`, `rpcGetMinimumBalance`, `rpcTransactionPlanner`, `rpcTransactionPlanSendingExecutor`                                                               |
 | [`@solana/kit-plugin-signer`](./packages/kit-plugin-signer)                     | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-signer.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-signer)                     | Signer, payer, and identity plugins | `signer`, `payer`, `identity`, `signerFromFile`, `payerFromFile`, `identityFromFile`, `generatedSigner`, `generatedPayer`, `generatedIdentity`, `generatedSignerWithSol`, `generatedPayerWithSol`, `generatedIdentityWithSol`, `airdropSigner`, `airdropPayer`, `airdropIdentity` |
-| [`@solana/kit-plugin-litesvm`](./packages/kit-plugin-litesvm)                   | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-litesvm.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-litesvm)                   | LiteSVM support                     | `litesvm`, `litesvmConnection`, `litesvmAirdrop`, `litesvmGetMinimumBalance`, `litesvmTransactionPlanner`, `litesvmTransactionPlanExecutor`                                                                                                                                       |
-| [`@solana/kit-plugin-instruction-plan`](./packages/kit-plugin-instruction-plan) | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-instruction-plan.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-instruction-plan) | Transaction planning and execution  | `transactionPlanner`, `transactionPlanExecutor`, `planAndSendTransactions`                                                                                                                                                                                                        |
+| [`@solana/kit-plugin-litesvm`](./packages/kit-plugin-litesvm)                   | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-litesvm.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-litesvm)                   | LiteSVM support                     | `litesvm`, `litesvmConnection`, `litesvmAirdrop`, `litesvmGetMinimumBalance`, `litesvmTransactionPlanner`, `litesvmTransactionPlanSendingExecutor`                                                                                                                                |
+| [`@solana/kit-plugin-instruction-plan`](./packages/kit-plugin-instruction-plan) | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-instruction-plan.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-instruction-plan) | Transaction planning and execution  | `transactionPlanner`, `transactionPlanSendingExecutor`, `transactionPlanExecutor`, `planAndSendTransactions`                                                                                                                                                                      |
 | [`@solana/kit-plugin-wallet`](./packages/kit-plugin-wallet)                     | [![npm](https://img.shields.io/npm/v/@solana/kit-plugin-wallet.svg?style=flat)](https://www.npmjs.com/package/@solana/kit-plugin-wallet)                     | Browser wallet support              | `walletSigner`, `walletIdentity`, `walletPayer`, `walletWithoutSigner`                                                                                                                                                                                                            |
 
 ## Community Plugins

--- a/packages/kit-plugin-instruction-plan/README.md
+++ b/packages/kit-plugin-instruction-plan/README.md
@@ -15,9 +15,26 @@ This package provides plugins that add transaction planning and execution to you
 pnpm install @solana/kit-plugin-instruction-plan
 ```
 
+## Quick start
+
+```ts
+import { createClient } from '@solana/kit';
+import { transactionPlanner, transactionPlanSendingExecutor } from '@solana/kit-plugin-instruction-plan';
+
+const client = createClient()
+    .use(transactionPlanner(myTransactionPlanner))
+    .use(transactionPlanSendingExecutor(myTransactionPlanExecutor));
+
+// Plan without executing.
+const transactionPlan = await client.planTransactions(myInstructionPlan);
+
+// Plan and execute in one call.
+const result = await client.sendTransactions(myInstructionPlan);
+```
+
 ## `transactionPlanner` plugin
 
-The `transactionPlanner` plugin sets a custom transaction planner on the client.
+The `transactionPlanner` plugin adds `planTransaction` and `planTransactions` to the client, using the provided transaction planner.
 
 ### Installation
 
@@ -27,56 +44,6 @@ import { transactionPlanner } from '@solana/kit-plugin-instruction-plan';
 
 const myTransactionPlanner = createTransactionPlanner(/* ... */);
 const client = createClient().use(transactionPlanner(myTransactionPlanner));
-```
-
-### Features
-
-- `transactionPlanner`: A function that plans instructions into transaction messages.
-    ```ts
-    const transactionPlan = await client.transactionPlanner(myInstructionPlan);
-    ```
-
-## `transactionPlanExecutor` plugin
-
-The `transactionPlanExecutor` plugin sets a custom transaction plan executor on the client.
-
-### Installation
-
-```ts
-import { createClient, createTransactionPlanExecutor } from '@solana/kit';
-import { transactionPlanExecutor } from '@solana/kit-plugin-instruction-plan';
-
-const myTransactionPlanExecutor = createTransactionPlanExecutor(/* ... */);
-const client = createClient().use(transactionPlanExecutor(myTransactionPlanExecutor));
-```
-
-### Features
-
-- `transactionPlanExecutor`: A function that executes planned transactions.
-    ```ts
-    const transactionPlanResult = await client.transactionPlanExecutor(myTransactionPlan);
-    ```
-
-## `planAndSendTransactions` plugin
-
-The `planAndSendTransactions` plugin adds helper functions for planning and sending transactions. They accept transaction messages, instructions or instruction plans as input.
-
-### Installation
-
-This plugin requires both `transactionPlanner` and `transactionPlanExecutor` to be installed on the client.
-
-```ts
-import { createClient } from '@solana/kit';
-import {
-    transactionPlanner,
-    transactionPlanExecutor,
-    planAndSendTransactions,
-} from '@solana/kit-plugin-instruction-plan';
-
-const client = createClient()
-    .use(transactionPlanner(myTransactionPlanner))
-    .use(transactionPlanExecutor(myTransactionPlanExecutor))
-    .use(planAndSendTransactions());
 ```
 
 ### Features
@@ -93,6 +60,27 @@ const client = createClient()
     const transactionMessage = await client.planTransaction(myInstructionPlan);
     ```
 
+For backward compatibility this plugin also sets a `client.transactionPlanner` field, but that field is deprecated in favour of the two functions above.
+
+## `transactionPlanSendingExecutor` plugin
+
+The `transactionPlanSendingExecutor` plugin adds `sendTransaction` and `sendTransactions` to the client, using the client's planning functions and the provided transaction plan executor. Both functions accept transaction messages, instructions, instruction plans or transaction plans as input, planning the input first when it is not already a transaction plan.
+
+Planning goes through the client's `planTransaction` and `planTransactions` functions, so the `transactionPlanner` plugin must be installed first — otherwise the plugin throws when applied. Note that installing another `transactionPlanner` afterwards does not affect sending: `sendTransaction` and `sendTransactions` keep using the planning functions that were on the client when they were installed.
+
+### Installation
+
+```ts
+import { createClient } from '@solana/kit';
+import { transactionPlanner, transactionPlanSendingExecutor } from '@solana/kit-plugin-instruction-plan';
+
+const client = createClient()
+    .use(transactionPlanner(myTransactionPlanner))
+    .use(transactionPlanSendingExecutor(myTransactionPlanExecutor));
+```
+
+### Features
+
 - `sendTransactions`: Plans and executes transaction messages, instructions or instruction plans in one call.
 
     ```ts
@@ -105,9 +93,31 @@ const client = createClient()
     const transactionPlanResult = await client.sendTransaction(myInstructionPlan);
     ```
 
+For backward compatibility this plugin also sets a `client.transactionPlanExecutor` field, but that field is deprecated in favour of the two functions above.
+
+## Deprecated plugins
+
+The following plugins are still exported for backward compatibility but are deprecated.
+
+- **`transactionPlanExecutor(executor)`**: Only sets the deprecated `client.transactionPlanExecutor` field. Use `transactionPlanSendingExecutor` instead, which installs `sendTransaction` and `sendTransactions` alongside the executor.
+- **`planAndSendTransactions()`**: No longer needed. `transactionPlanner` now installs `planTransaction` and `planTransactions`, and `transactionPlanSendingExecutor` installs `sendTransaction` and `sendTransactions`.
+
+```ts
+// Before
+const client = createClient()
+    .use(transactionPlanner(myTransactionPlanner))
+    .use(transactionPlanExecutor(myTransactionPlanExecutor))
+    .use(planAndSendTransactions());
+
+// After
+const client = createClient()
+    .use(transactionPlanner(myTransactionPlanner))
+    .use(transactionPlanSendingExecutor(myTransactionPlanExecutor));
+```
+
 ## Default Planner and Executor Implementations
 
 For ready-to-use transaction planner and executor implementations, see:
 
-- [`@solana/kit-plugin-rpc`](https://www.npmjs.com/package/@solana/kit-plugin-rpc) — provides `rpcTransactionPlanner` and `rpcTransactionPlanExecutor` for RPC-based transaction planning and execution.
-- [`@solana/kit-plugin-litesvm`](https://www.npmjs.com/package/@solana/kit-plugin-litesvm) — provides `litesvmTransactionPlanner` and `litesvmTransactionPlanExecutor` for LiteSVM-based transaction planning and execution.
+- [`@solana/kit-plugin-rpc`](https://www.npmjs.com/package/@solana/kit-plugin-rpc) — provides the `rpcTransactionPlanner` and `rpcTransactionPlanSendingExecutor` plugins for RPC-based transaction planning and execution.
+- [`@solana/kit-plugin-litesvm`](https://www.npmjs.com/package/@solana/kit-plugin-litesvm) — provides the `litesvmTransactionPlanner` and `litesvmTransactionPlanSendingExecutor` plugins for LiteSVM-based transaction planning and execution.

--- a/packages/kit-plugin-instruction-plan/src/core.ts
+++ b/packages/kit-plugin-instruction-plan/src/core.ts
@@ -18,26 +18,114 @@ import {
     TransactionPlanExecutor,
     TransactionPlanner,
     TransactionPlanResult,
+    TransactionPlanResultContext,
 } from '@solana/kit';
 
 /**
- * A plugin that sets the transactionPlanner on the client.
+ * A plugin that adds `planTransaction` and `planTransactions` functions to the
+ * client, using the provided transaction planner.
+ *
+ * The `planTransactions` function plans instructions, instruction plans or
+ * transaction messages into a transaction plan. The `planTransaction` function
+ * does the same but asserts that the resulting plan contains a single
+ * transaction message, and returns that message.
+ *
+ * For backwards compatibility this plugin also sets a `transactionPlanner`
+ * field on the client, but that field is deprecated in favour of the two
+ * functions above.
+ *
+ * @param transactionPlanner - The transaction planner to plan instructions with.
+ * @returns A plugin that adds `client.planTransaction` and `client.planTransactions`.
  *
  * @example
  * ```ts
  * import { createClient, createTransactionPlanner } from '@solana/kit';
  * import { transactionPlanner } from '@solana/kit-plugin-instruction-plan';
  *
- * // Install the transactionPlanner plugin using a custom transaction planner.
- * const client = createClient()
- *     .use(transactionPlanner(createTransactionPlanner(...)));
+ * const client = createClient().use(transactionPlanner(createTransactionPlanner(...)));
  *
- * // Use the transaction planner.
- * const transactionPlan = await client.transactionPlanner(myInstructionPlan);
+ * const transactionPlan = await client.planTransactions(myInstructionPlan);
+ * const transactionMessage = await client.planTransaction(myInstructionPlan);
  * ```
+ *
+ * @see {@link transactionPlanSendingExecutor}
  */
 export function transactionPlanner(transactionPlanner: TransactionPlanner) {
-    return <T extends object>(client: T) => extendClient(client, { transactionPlanner });
+    return <T extends object>(client: T) => {
+        const additions: ClientWithTransactionPlanning & {
+            /** @deprecated Use `planTransaction` or `planTransactions` instead. */
+            transactionPlanner: TransactionPlanner;
+        } = {
+            ...getTransactionPlanningFunctions(transactionPlanner),
+            transactionPlanner,
+        };
+        return extendClient(client, additions);
+    };
+}
+
+/**
+ * A plugin that adds `sendTransaction` and `sendTransactions` functions to the
+ * client, using the client's planning functions and the provided transaction
+ * plan executor.
+ *
+ * Both functions accept transaction messages, instructions, instruction plans
+ * or transaction plans as input, planning the input first when it is not
+ * already a transaction plan. Planning goes through the client's
+ * `planTransaction` and `planTransactions` functions, so the
+ * {@link transactionPlanner} plugin must be installed first.
+ *
+ * Note that `sendTransaction` asserts that the transaction plan result is both
+ * successful and contains a single transaction. This differs from
+ * `sendTransactions`, which returns the full transaction plan result as
+ * produced by the executor.
+ *
+ * For backwards compatibility this plugin also sets a `transactionPlanExecutor`
+ * field on the client, but that field is deprecated in favour of the two
+ * functions above.
+ *
+ * @typeParam TContext - The extra context type provided by the transaction plan
+ * executor on its transaction plan results. It is inferred from the executor and
+ * preserved on the deprecated `transactionPlanExecutor` field.
+ *
+ * @param transactionPlanExecutor - The transaction plan executor used to execute
+ * planned transactions.
+ * @returns A plugin that adds `client.sendTransaction` and `client.sendTransactions`.
+ * @throws If the client has no `planTransaction` or `planTransactions` set.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from '@solana/kit';
+ * import { transactionPlanner, transactionPlanSendingExecutor } from '@solana/kit-plugin-instruction-plan';
+ *
+ * const client = createClient()
+ *     .use(transactionPlanner(myTransactionPlanner))
+ *     .use(transactionPlanSendingExecutor(myTransactionPlanExecutor));
+ *
+ * const singleResult = await client.sendTransaction(myInstructionPlan);
+ * const result = await client.sendTransactions(myInstructionPlan);
+ * ```
+ *
+ * @see {@link transactionPlanner}
+ */
+export function transactionPlanSendingExecutor<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+>(transactionPlanExecutor: TransactionPlanExecutor<TContext>) {
+    return <T extends ClientWithTransactionPlanning>(client: T) => {
+        if (!client.planTransaction || !client.planTransactions) {
+            throw new Error(
+                'Transaction planning functions are required on the client to send transactions. ' +
+                    'Please add a transaction planner plugin to your client before using this plugin.',
+            );
+        }
+        const additions: ClientWithTransactionSending & {
+            /** @deprecated Use `sendTransaction` or `sendTransactions` instead. */
+            transactionPlanExecutor: TransactionPlanExecutor<TContext>;
+        } = {
+            ...getTransactionSendingFunctions(client, transactionPlanExecutor),
+            transactionPlanExecutor,
+        };
+        return extendClient(client, additions);
+    };
 }
 
 /**
@@ -55,8 +143,31 @@ export function transactionPlanner(transactionPlanner: TransactionPlanner) {
  * // Use the transaction plan executor.
  * const transactionPlanResult = await client.transactionPlanExecutor(myTransactionPlan);
  * ```
+ *
+ * @typeParam TContext - The extra context type provided by the transaction plan
+ * executor on its transaction plan results. It is inferred from the executor and
+ * preserved on the `transactionPlanExecutor` field.
+ *
+ * @deprecated Use {@link transactionPlanSendingExecutor} instead, which installs
+ * `sendTransaction` and `sendTransactions` alongside the executor. This plugin
+ * only sets the deprecated `transactionPlanExecutor` field.
+ *
+ * ```ts
+ * // Before
+ * const client = createClient()
+ *     .use(transactionPlanner(myTransactionPlanner))
+ *     .use(transactionPlanExecutor(myTransactionPlanExecutor))
+ *     .use(planAndSendTransactions());
+ *
+ * // After
+ * const client = createClient()
+ *     .use(transactionPlanner(myTransactionPlanner))
+ *     .use(transactionPlanSendingExecutor(myTransactionPlanExecutor));
+ * ```
  */
-export function transactionPlanExecutor(transactionPlanExecutor: TransactionPlanExecutor) {
+export function transactionPlanExecutor<TContext extends TransactionPlanResultContext = TransactionPlanResultContext>(
+    transactionPlanExecutor: TransactionPlanExecutor<TContext>,
+) {
     return <T extends object>(client: T) => extendClient(client, { transactionPlanExecutor });
 }
 
@@ -96,21 +207,46 @@ export function transactionPlanExecutor(transactionPlanExecutor: TransactionPlan
  * const singleResult = await client.sendTransaction(myInstructionPlan);
  * const result = await client.sendTransactions(myInstructionPlan);
  * ```
+ *
+ * @deprecated No longer needed. {@link transactionPlanner} now installs
+ * `planTransaction` and `planTransactions`, and
+ * {@link transactionPlanSendingExecutor} installs `sendTransaction` and
+ * `sendTransactions`.
+ *
+ * ```ts
+ * // Before
+ * const client = createClient()
+ *     .use(transactionPlanner(myTransactionPlanner))
+ *     .use(transactionPlanExecutor(myTransactionPlanExecutor))
+ *     .use(planAndSendTransactions());
+ *
+ * // After
+ * const client = createClient()
+ *     .use(transactionPlanner(myTransactionPlanner))
+ *     .use(transactionPlanSendingExecutor(myTransactionPlanExecutor));
+ * ```
  */
 export function planAndSendTransactions() {
     return <T extends { transactionPlanExecutor: TransactionPlanExecutor; transactionPlanner: TransactionPlanner }>(
         client: T,
-    ) => extendClient(client, getTransactionPlanningAndSendingFunctions(client));
+    ) => {
+        const planner: TransactionPlanner = (instructionPlan, config) =>
+            client.transactionPlanner(instructionPlan, config);
+        const executor: TransactionPlanExecutor = (transactionPlan, config) =>
+            client.transactionPlanExecutor(transactionPlan, config);
+        const planningFunctions = getTransactionPlanningFunctions(planner);
+        return extendClient(client, {
+            ...planningFunctions,
+            ...getTransactionSendingFunctions(planningFunctions, executor),
+        });
+    };
 }
 
-function getTransactionPlanningAndSendingFunctions(client: {
-    transactionPlanExecutor: TransactionPlanExecutor;
-    transactionPlanner: TransactionPlanner;
-}): ClientWithTransactionPlanning & ClientWithTransactionSending {
+function getTransactionPlanningFunctions(planner: TransactionPlanner): ClientWithTransactionPlanning {
     const planTransactions: ClientWithTransactionPlanning['planTransactions'] = async (input, config = {}) => {
         const instructionPlan = parseInstructionPlanInput(input);
         config?.abortSignal?.throwIfAborted();
-        return await client.transactionPlanner(instructionPlan, config);
+        return await planner(instructionPlan, config);
     };
 
     const planTransaction: ClientWithTransactionPlanning['planTransaction'] = async (input, config = {}) => {
@@ -119,13 +255,20 @@ function getTransactionPlanningAndSendingFunctions(client: {
         return transactionPlan.message;
     };
 
+    return { planTransaction, planTransactions };
+}
+
+function getTransactionSendingFunctions(
+    client: ClientWithTransactionPlanning,
+    executor: TransactionPlanExecutor,
+): ClientWithTransactionSending {
     const sendTransactions: ClientWithTransactionSending['sendTransactions'] = async (input, config = {}) => {
         const plan = parseInstructionOrTransactionPlanInput(input);
         config?.abortSignal?.throwIfAborted();
-        const transactionPlan = isTransactionPlan(plan) ? plan : await planTransactions(plan, config);
+        const transactionPlan = isTransactionPlan(plan) ? plan : await client.planTransactions(plan, config);
         config?.abortSignal?.throwIfAborted();
         try {
-            return await client.transactionPlanExecutor(transactionPlan, config);
+            return await executor(transactionPlan, config);
         } catch (error) {
             if (!isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)) {
                 throw error;
@@ -142,10 +285,10 @@ function getTransactionPlanningAndSendingFunctions(client: {
         config?.abortSignal?.throwIfAborted();
         const transactionPlan = isTransactionPlan(plan)
             ? plan
-            : singleTransactionPlan(await planTransaction(plan, config));
+            : singleTransactionPlan(await client.planTransaction(plan, config));
         config?.abortSignal?.throwIfAborted();
         try {
-            const result = await client.transactionPlanExecutor(transactionPlan, config);
+            const result = await executor(transactionPlan, config);
             assertIsSuccessfulSingleTransactionPlanResult(result);
             return result;
         } catch (error) {
@@ -162,5 +305,5 @@ function getTransactionPlanningAndSendingFunctions(client: {
         }
     };
 
-    return { planTransaction, planTransactions, sendTransaction, sendTransactions };
+    return { sendTransaction, sendTransactions };
 }

--- a/packages/kit-plugin-instruction-plan/test/core.test.ts
+++ b/packages/kit-plugin-instruction-plan/test/core.test.ts
@@ -26,11 +26,18 @@ import {
     TransactionMessage,
     TransactionMessageWithFeePayer,
     TransactionPlan,
+    TransactionPlanExecutor,
+    TransactionPlanner,
     TransactionPlanResult,
 } from '@solana/kit';
 import { assert, describe, expect, it, vi } from 'vitest';
 
-import { planAndSendTransactions, transactionPlanExecutor, transactionPlanner } from '../src';
+import {
+    planAndSendTransactions,
+    transactionPlanExecutor,
+    transactionPlanner,
+    transactionPlanSendingExecutor,
+} from '../src';
 
 describe('transactionPlanner', () => {
     it('sets the provided transactionPlanner on the client', () => {
@@ -38,6 +45,26 @@ describe('transactionPlanner', () => {
         const client = createClient().use(transactionPlanner(customTransactionPlanner));
         expect(client).toHaveProperty('transactionPlanner');
         expect(client.transactionPlanner).toBe(customTransactionPlanner);
+    });
+
+    it('adds planTransaction and planTransactions to the client', () => {
+        const client = createClient().use(transactionPlanner(vi.fn()));
+        expect(client).toHaveProperty('planTransaction');
+        expect(client).toHaveProperty('planTransactions');
+    });
+
+    it('plans instructions without needing any other plugin', async () => {
+        const instruction = {} as Instruction;
+        const transactionPlan = singleTransactionPlan({} as TransactionMessage & TransactionMessageWithFeePayer);
+        const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
+        const client = createClient().use(transactionPlanner(customTransactionPlanner));
+
+        const message = await client.planTransaction(instruction);
+
+        expect(message).toBe(transactionPlan.message);
+        expect(customTransactionPlanner).toHaveBeenCalledExactlyOnceWith(singleInstructionPlan(instruction), {
+            abortSignal: undefined,
+        });
     });
 });
 
@@ -50,7 +77,80 @@ describe('transactionPlanExecutor', () => {
     });
 });
 
-describe('planAndSendTransactions', () => {
+describe('transactionPlanSendingExecutor', () => {
+    it('sets the provided executor on the deprecated transactionPlanExecutor field', () => {
+        const customTransactionPlanExecutor = vi.fn();
+        const client = createClient()
+            .use(transactionPlanner(vi.fn()))
+            .use(transactionPlanSendingExecutor(customTransactionPlanExecutor));
+        expect(client.transactionPlanExecutor).toBe(customTransactionPlanExecutor);
+    });
+
+    it('adds sendTransaction and sendTransactions to the client', () => {
+        const client = createClient().use(transactionPlanner(vi.fn())).use(transactionPlanSendingExecutor(vi.fn()));
+        expect(client).toHaveProperty('sendTransaction');
+        expect(client).toHaveProperty('sendTransactions');
+    });
+
+    it("plans using the client's planning functions", async () => {
+        const instruction = {} as Instruction;
+        const message = {} as TransactionMessage & TransactionMessageWithFeePayer;
+        const result = successfulSingleTransactionPlanResult(message, { signature: '1111' as Signature });
+        const customTransactionPlanner = vi.fn().mockResolvedValue(singleTransactionPlan(message));
+        const customTransactionPlanExecutor = vi.fn().mockResolvedValue(result);
+
+        const client = createClient()
+            .use(transactionPlanner(customTransactionPlanner))
+            .use(transactionPlanSendingExecutor(customTransactionPlanExecutor));
+
+        await expect(client.sendTransaction(instruction)).resolves.toBe(result);
+        expect(customTransactionPlanner).toHaveBeenCalledExactlyOnceWith(singleInstructionPlan(instruction), {
+            abortSignal: undefined,
+        });
+    });
+
+    it('keeps using the planner installed at the time it was applied', async () => {
+        const message = {} as TransactionMessage & TransactionMessageWithFeePayer;
+        const firstPlanner = vi.fn().mockResolvedValue(singleTransactionPlan(message));
+        const secondPlanner = vi.fn().mockResolvedValue(singleTransactionPlan(message));
+        const customTransactionPlanExecutor = vi.fn().mockResolvedValue(sequentialTransactionPlanResult([]));
+
+        const client = createClient()
+            .use(transactionPlanner(firstPlanner))
+            .use(transactionPlanSendingExecutor(customTransactionPlanExecutor))
+            .use(transactionPlanner(secondPlanner));
+
+        await client.sendTransactions({} as Instruction);
+
+        expect(firstPlanner).toHaveBeenCalledOnce();
+        expect(secondPlanner).not.toHaveBeenCalled();
+    });
+
+    it('requires transaction planning functions on the client', () => {
+        // @ts-expect-error Missing planning functions on the client.
+        expect(() => createClient().use(transactionPlanSendingExecutor(vi.fn()))).toThrow(
+            /Transaction planning functions are required/,
+        );
+    });
+});
+
+const WIRINGS = [
+    {
+        createTestClient: (planner: TransactionPlanner, executor: TransactionPlanExecutor) =>
+            createClient().use(transactionPlanner(planner)).use(transactionPlanSendingExecutor(executor)),
+        name: 'transactionPlanner + transactionPlanSendingExecutor',
+    },
+    {
+        createTestClient: (planner: TransactionPlanner, executor: TransactionPlanExecutor) =>
+            createClient()
+                .use(transactionPlanner(planner))
+                .use(transactionPlanExecutor(executor))
+                .use(planAndSendTransactions()),
+        name: 'planAndSendTransactions (deprecated)',
+    },
+] as const;
+
+describe.each(WIRINGS)('$name', ({ createTestClient }) => {
     describe('client.planTransaction', () => {
         it('adds a planTransaction function on the client that plans instructions and returns a transaction message', async () => {
             const instruction = {} as Instruction;
@@ -58,10 +158,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             expect(client).toHaveProperty('planTransaction');
             const result = await client.planTransaction(instruction);
@@ -82,10 +179,7 @@ describe('planAndSendTransactions', () => {
             ]);
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const promise = client.planTransaction(instructionPlan);
             await expect(promise).rejects.toThrowError(
@@ -101,10 +195,7 @@ describe('planAndSendTransactions', () => {
             const transactionPlan = singleTransactionPlan({} as TransactionMessage & TransactionMessageWithFeePayer);
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const abortSignal = new AbortController().signal;
             await client.planTransaction({} as Instruction, { abortSignal });
@@ -115,10 +206,7 @@ describe('planAndSendTransactions', () => {
         it('does not call the planner if the abort signal is already triggered', async () => {
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn();
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const abortController = new AbortController();
             abortController.abort();
@@ -132,10 +220,7 @@ describe('planAndSendTransactions', () => {
             const transactionPlan = singleTransactionPlan({} as TransactionMessage & TransactionMessageWithFeePayer);
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             await client.planTransaction(instructionPlan);
             expect(customTransactionPlanner).toHaveBeenCalledExactlyOnceWith(instructionPlan, {
@@ -155,10 +240,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             expect(client).toHaveProperty('planTransactions');
             const result = await client.planTransactions(instructions);
@@ -175,10 +257,7 @@ describe('planAndSendTransactions', () => {
             const transactionPlan = singleTransactionPlan({} as TransactionMessage & TransactionMessageWithFeePayer);
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const abortSignal = new AbortController().signal;
             await client.planTransactions({} as Instruction, { abortSignal });
@@ -189,10 +268,7 @@ describe('planAndSendTransactions', () => {
         it('does not call the planner if the abort signal is already triggered', async () => {
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn();
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const abortController = new AbortController();
             abortController.abort();
@@ -209,10 +285,7 @@ describe('planAndSendTransactions', () => {
             ]);
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             await client.planTransactions(instructionPlan);
             expect(customTransactionPlanner).toHaveBeenCalledExactlyOnceWith(instructionPlan, {
@@ -233,10 +306,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             expect(client).toHaveProperty('sendTransaction');
             const result = await client.sendTransaction(instruction);
@@ -258,10 +328,7 @@ describe('planAndSendTransactions', () => {
             ]);
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const promise = client.sendTransaction(instructionPlan);
             await expect(promise).rejects.toThrowError(
@@ -283,10 +350,7 @@ describe('planAndSendTransactions', () => {
             ]);
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const promise = client.sendTransaction(instructionPlan);
             await expect(promise).rejects.toThrowError(
@@ -306,10 +370,7 @@ describe('planAndSendTransactions', () => {
             );
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const promise = client.sendTransaction(instructionPlan);
             await expect(promise).rejects.toThrowError(
@@ -329,10 +390,7 @@ describe('planAndSendTransactions', () => {
             );
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const abortSignal = new AbortController().signal;
             await client.sendTransaction({} as Instruction, { abortSignal });
@@ -343,10 +401,7 @@ describe('planAndSendTransactions', () => {
         it('does not call the planner if the abort signal is already triggered', async () => {
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn();
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const abortController = new AbortController();
             abortController.abort();
@@ -363,10 +418,7 @@ describe('planAndSendTransactions', () => {
             });
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             await client.sendTransaction(instructionPlan);
             expect(customTransactionPlanner).toHaveBeenCalledExactlyOnceWith(instructionPlan, {
@@ -385,10 +437,7 @@ describe('planAndSendTransactions', () => {
             });
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             await client.sendTransaction(transaction);
             expect(customTransactionPlanner).not.toHaveBeenCalled();
@@ -407,10 +456,7 @@ describe('planAndSendTransactions', () => {
             });
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             await client.sendTransaction(transactionPlan);
             expect(customTransactionPlanner).not.toHaveBeenCalled();
@@ -428,10 +474,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
             const customTransactionPlanExecutor = vi.fn().mockRejectedValue(executionError);
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const thrownError = await client.sendTransaction({} as Instruction).catch((e: unknown) => e);
             assert(isSolanaError(thrownError, SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION));
@@ -460,10 +503,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
             const customTransactionPlanExecutor = vi.fn().mockRejectedValue(executionError);
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const thrownError = await client.sendTransaction({} as Instruction).catch((e: unknown) => e);
             assert(isSolanaError(thrownError, SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION));
@@ -479,10 +519,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
             const customTransactionPlanExecutor = vi.fn().mockRejectedValue(genericError);
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const promise = client.sendTransaction({} as Instruction);
             await expect(promise).rejects.toBe(genericError);
@@ -497,10 +534,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue(transactionPlanResult);
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             expect(client).toHaveProperty('sendTransactions');
             const result = await client.sendTransactions(instruction);
@@ -516,10 +550,7 @@ describe('planAndSendTransactions', () => {
         it('passes the abort signal through the planner and executor', async () => {
             const customTransactionPlanner = vi.fn().mockResolvedValue({});
             const customTransactionPlanExecutor = vi.fn().mockResolvedValue({});
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const abortSignal = new AbortController().signal;
             await client.sendTransactions({} as Instruction, { abortSignal });
@@ -530,10 +561,7 @@ describe('planAndSendTransactions', () => {
         it('does not call the planner if the abort signal is already triggered', async () => {
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn();
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const abortController = new AbortController();
             abortController.abort();
@@ -550,10 +578,7 @@ describe('planAndSendTransactions', () => {
             ]);
             const customTransactionPlanner = vi.fn().mockResolvedValue(transactionPlan);
             const customTransactionPlanExecutor = vi.fn();
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             await client.sendTransactions(instructionPlan);
             expect(customTransactionPlanner).toHaveBeenCalledExactlyOnceWith(instructionPlan, {
@@ -569,10 +594,7 @@ describe('planAndSendTransactions', () => {
             const transaction = setTransactionMessageFeePayer(payer, createTransactionMessage({ version: 0 }));
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn();
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             await client.sendTransactions(transaction);
             expect(customTransactionPlanner).not.toHaveBeenCalled();
@@ -592,10 +614,7 @@ describe('planAndSendTransactions', () => {
             );
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn();
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             await client.sendTransactions([transactionA, transactionB]);
             expect(customTransactionPlanner).not.toHaveBeenCalled();
@@ -612,10 +631,7 @@ describe('planAndSendTransactions', () => {
             ]);
             const customTransactionPlanner = vi.fn();
             const customTransactionPlanExecutor = vi.fn();
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             await client.sendTransactions(transactionPlan);
             expect(customTransactionPlanner).not.toHaveBeenCalled();
@@ -633,10 +649,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
             const customTransactionPlanExecutor = vi.fn().mockRejectedValue(executionError);
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const thrownError = await client.sendTransactions({} as Instruction).catch((e: unknown) => e);
             assert(isSolanaError(thrownError, SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS));
@@ -665,10 +678,7 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
             const customTransactionPlanExecutor = vi.fn().mockRejectedValue(executionError);
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const thrownError = await client.sendTransactions({} as Instruction).catch((e: unknown) => e);
             assert(isSolanaError(thrownError, SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS));
@@ -685,13 +695,36 @@ describe('planAndSendTransactions', () => {
 
             const customTransactionPlanner = vi.fn().mockResolvedValue(txPlan);
             const customTransactionPlanExecutor = vi.fn().mockRejectedValue(genericError);
-            const client = createClient()
-                .use(transactionPlanner(customTransactionPlanner))
-                .use(transactionPlanExecutor(customTransactionPlanExecutor))
-                .use(planAndSendTransactions());
+            const client = createTestClient(customTransactionPlanner, customTransactionPlanExecutor);
 
             const promise = client.sendTransactions({} as Instruction);
             await expect(promise).rejects.toBe(genericError);
         });
+    });
+});
+
+describe('planAndSendTransactions', () => {
+    it('reads client.transactionPlanner lazily on every call', async () => {
+        const message = {} as TransactionMessage & TransactionMessageWithFeePayer;
+        const firstPlanner = vi.fn().mockResolvedValue(singleTransactionPlan(message));
+        const secondPlanner = vi.fn().mockResolvedValue(singleTransactionPlan(message));
+        let current: TransactionPlanner = firstPlanner;
+
+        const client = createClient()
+            .use(() => ({
+                get transactionPlanner() {
+                    return current;
+                },
+            }))
+            .use(transactionPlanExecutor(vi.fn()))
+            .use(planAndSendTransactions());
+
+        await client.planTransaction({} as Instruction);
+        expect(firstPlanner).toHaveBeenCalledOnce();
+
+        current = secondPlanner;
+        await client.planTransaction({} as Instruction);
+        expect(firstPlanner).toHaveBeenCalledOnce();
+        expect(secondPlanner).toHaveBeenCalledOnce();
     });
 });

--- a/packages/kit-plugin-litesvm/README.md
+++ b/packages/kit-plugin-litesvm/README.md
@@ -38,7 +38,7 @@ const client = createClient().use(payer(myPayer)).use(litesvm());
 
 All options are provided via a `LiteSvmConfig` object:
 
-- `transactionConfig`: Options to configure how transaction messages are created. See `litesvmTransactionPlanner` options below.
+- `transactionConfig`: Options to configure how transaction messages are created. See the `litesvmTransactionPlanner` options below.
 
 ### Features
 
@@ -46,9 +46,9 @@ All options are provided via a `LiteSvmConfig` object:
 - `rpc`: Call a subset of Solana RPC methods against the LiteSVM instance.
 - `airdrop`: Request SOL from the LiteSVM faucet.
 - `getMinimumBalance`: Compute minimum lamports for rent exemption.
-- `transactionPlanner`: Plan instructions into transaction messages.
-- `transactionPlanExecutor`: Sign and send planned transactions.
-- `sendTransaction(s)` / `planTransaction(s)`: Convenience helpers that combine planning and execution.
+- `planTransaction(s)`: Plan instructions into transaction messages without executing them.
+- `sendTransaction(s)`: Plan and execute instructions, instruction plans, or transaction messages in one call.
+- `transactionPlanner` / `transactionPlanExecutor` (deprecated): Fields kept for backward compatibility. Use `planTransaction(s)` / `sendTransaction(s)` instead.
 
 ## `litesvmConnection` plugin
 
@@ -129,18 +129,18 @@ const client = createClient().use(litesvmConnection()).use(litesvmGetMinimumBala
 
 ## `litesvmTransactionPlanner` plugin
 
-This plugin provides a default transaction planner that creates transaction messages with a fee payer and optional priority fees.
+Adds `planTransaction` and `planTransactions` to the client, using a planner that plans instructions into transaction messages with a fee payer and optional priority fees. The fee payer is read from `client.payer` lazily, at plan time, so a dynamic payer (such as a connected wallet) is always respected.
 
-### Installation
+### Usage
 
-The client must have a `payer` set before applying this plugin.
+The client must have a `payer` set before installing the plugin.
 
 ```ts
 import { createClient } from '@solana/kit';
 import {
     litesvmConnection,
+    litesvmTransactionPlanSendingExecutor,
     litesvmTransactionPlanner,
-    litesvmTransactionPlanExecutor,
 } from '@solana/kit-plugin-litesvm';
 import { generatedPayer } from '@solana/kit-plugin-signer';
 
@@ -148,7 +148,9 @@ const client = await createClient()
     .use(litesvmConnection())
     .use(generatedPayer())
     .use(litesvmTransactionPlanner())
-    .use(litesvmTransactionPlanExecutor());
+    .use(litesvmTransactionPlanSendingExecutor());
+
+const transactionPlan = await client.planTransactions(myInstructionPlan);
 ```
 
 ### Options
@@ -164,27 +166,20 @@ Unlike the RPC planner, the LiteSVM planner does not estimate resource limits, s
 
 Version 1 transactions are defined for forward compatibility but are not yet buildable by `@solana/kit`; passing `version: 1` currently throws. When available, version 1 will accept `priorityFeeLamports` (a flat total in lamports) instead of `microLamportsPerComputeUnit`.
 
-### Features
+## `litesvmTransactionPlanSendingExecutor` plugin
 
-- `transactionPlanner`: A function that plans instructions into transaction messages.
-    ```ts
-    const transactionPlan = await client.transactionPlanner(myInstructionPlan);
-    ```
+Adds `sendTransaction` and `sendTransactions` to the client, using an executor that signs and sends transactions to the LiteSVM instance. When a transaction fails, it throws a `SolanaError` with the same error codes the RPC executor would produce. The executor stores the LiteSVM transaction metadata (`FailedTransactionMetadata` or `TransactionMetadata`) on `context.transactionMetadata`, so consumers can inspect logs, compute units consumed, and return data from the plan result.
 
-## `litesvmTransactionPlanExecutor` plugin
+### Usage
 
-This plugin provides a default transaction plan executor that signs and sends transactions to the LiteSVM instance.
-
-### Installation
-
-This plugin requires an `svm` instance to be configured on the client.
+The client must have an `svm` instance configured, and a transaction planner installed, before installing this plugin — sending plans through the client's planning functions.
 
 ```ts
 import { createClient } from '@solana/kit';
 import {
     litesvmConnection,
+    litesvmTransactionPlanSendingExecutor,
     litesvmTransactionPlanner,
-    litesvmTransactionPlanExecutor,
 } from '@solana/kit-plugin-litesvm';
 import { generatedPayer } from '@solana/kit-plugin-signer';
 
@@ -192,12 +187,24 @@ const client = await createClient()
     .use(litesvmConnection())
     .use(generatedPayer())
     .use(litesvmTransactionPlanner())
-    .use(litesvmTransactionPlanExecutor());
+    .use(litesvmTransactionPlanSendingExecutor());
+
+const transactionPlanResult = await client.sendTransactions(myInstructionPlan);
 ```
 
-### Features
+## Deprecated plugins
 
-- `transactionPlanExecutor`: A function that executes planned transactions.
+The following plugins are still exported for backward compatibility but are deprecated.
+
+- `litesvmTransactionPlanExecutor()`: Only sets the deprecated `client.transactionPlanExecutor` field. Use `litesvmTransactionPlanSendingExecutor` instead, which installs `sendTransaction` and `sendTransactions` alongside the executor.
+
     ```ts
-    const transactionPlanResult = await client.transactionPlanExecutor(myTransactionPlan);
+    // Before
+    const client = await createClient()
+        .use(litesvmTransactionPlanner())
+        .use(litesvmTransactionPlanExecutor())
+        .use(planAndSendTransactions());
+
+    // After
+    const client = await createClient().use(litesvmTransactionPlanner()).use(litesvmTransactionPlanSendingExecutor());
     ```

--- a/packages/kit-plugin-litesvm/src/litesvm.ts
+++ b/packages/kit-plugin-litesvm/src/litesvm.ts
@@ -1,10 +1,9 @@
 import { ClientWithPayer, pipe } from '@solana/kit';
-import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
 
 import { litesvmAirdrop } from './airdrop';
 import { litesvmGetMinimumBalance } from './get-minimum-balance';
 import { litesvmConnection } from './litesvm-connection';
-import { litesvmTransactionPlanExecutor } from './transaction-plan-executor';
+import { litesvmTransactionPlanSendingExecutor } from './transaction-plan-executor';
 import { litesvmTransactionPlanner, TransactionPlannerConfig } from './transaction-planner';
 
 export type LiteSvmConfig = {
@@ -23,8 +22,8 @@ export type LiteSvmConfig = {
  * The client must have a `payer` set before applying this plugin.
  *
  * @return A plugin that adds `client.svm`, `client.rpc`, `client.airdrop`,
- * `client.getMinimumBalance`, `client.transactionPlanner`,
- * `client.transactionPlanExecutor`, and `client.sendTransactions`.
+ * `client.getMinimumBalance`, `client.planTransaction`, `client.planTransactions`,
+ * `client.sendTransaction` and `client.sendTransactions`.
  *
  * @example
  * ```ts
@@ -40,15 +39,13 @@ export type LiteSvmConfig = {
  * @see {@link litesvmConnection}
  */
 export function litesvm(config: LiteSvmConfig = {}) {
-    return <T extends ClientWithPayer>(client: T) => {
-        return pipe(
+    return <T extends ClientWithPayer>(client: T) =>
+        pipe(
             client,
             litesvmConnection(),
             litesvmAirdrop(),
             litesvmGetMinimumBalance(),
             litesvmTransactionPlanner(config.transactionConfig),
-            litesvmTransactionPlanExecutor(),
-            planAndSendTransactions(),
+            litesvmTransactionPlanSendingExecutor(),
         );
-    };
 }

--- a/packages/kit-plugin-litesvm/src/transaction-plan-executor.ts
+++ b/packages/kit-plugin-litesvm/src/transaction-plan-executor.ts
@@ -1,7 +1,56 @@
-import { createTransactionPlanExecutor, extendClient, pipe, signTransactionMessageWithSigners } from '@solana/kit';
+import {
+    ClientWithTransactionPlanning,
+    createTransactionPlanExecutor,
+    pipe,
+    signTransactionMessageWithSigners,
+    TransactionPlanExecutor,
+} from '@solana/kit';
+import { transactionPlanExecutor, transactionPlanSendingExecutor } from '@solana/kit-plugin-instruction-plan';
 import type { FailedTransactionMetadata, LiteSVM, TransactionMetadata } from 'litesvm';
 
 import { getSolanaErrorFromLiteSvmFailure, isFailedTransaction } from './transaction-error';
+
+/**
+ * A plugin that adds `sendTransaction` and `sendTransactions` to the client
+ * using a default transaction plan executor backed by LiteSVM.
+ *
+ * The executor signs transaction messages and sends them to the LiteSVM
+ * instance. When a transaction fails, the executor throws a `SolanaError`
+ * with the same error codes that the RPC executor would produce, allowing
+ * consistent error handling across both executors.
+ *
+ * The executor stores the LiteSVM {@link TransactionMetadata} (or
+ * {@link FailedTransactionMetadata} on failure) on
+ * `context.transactionMetadata`, allowing consumers to inspect
+ * transaction logs, compute units consumed, return data, and other
+ * metadata from the plan result.
+ *
+ * Since sending goes through the client's planning functions,
+ * {@link litesvmTransactionPlanner} — or another `transactionPlanner` plugin —
+ * must be installed first.
+ *
+ * @returns A plugin that adds `client.sendTransaction` and `client.sendTransactions`.
+ * @throws If the client has no `svm` set, or no transaction planning functions set.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from '@solana/kit';
+ * import { litesvmConnection, litesvmTransactionPlanner, litesvmTransactionPlanSendingExecutor } from '@solana/kit-plugin-litesvm';
+ * import { generatedPayer } from '@solana/kit-plugin-signer';
+ *
+ * const client = await createClient()
+ *     .use(litesvmConnection())
+ *     .use(generatedPayer())
+ *     .use(litesvmTransactionPlanner())
+ *     .use(litesvmTransactionPlanSendingExecutor());
+ * ```
+ *
+ * @see {@link litesvmTransactionPlanner}
+ */
+export function litesvmTransactionPlanSendingExecutor() {
+    return <T extends ClientWithTransactionPlanning & { svm: LiteSVM }>(client: T) =>
+        transactionPlanSendingExecutor(createExecutor(client))(client);
+}
 
 /**
  * A plugin that provides a default transaction plan executor using LiteSVM.
@@ -19,49 +68,60 @@ import { getSolanaErrorFromLiteSvmFailure, isFailedTransaction } from './transac
  *
  * @returns A plugin that adds `transactionPlanExecutor` to the client.
  *
- * @example
- * ```ts
- * import { createClient } from '@solana/kit';
- * import { litesvmConnection, litesvmTransactionPlanner, litesvmTransactionPlanExecutor } from '@solana/kit-plugin-litesvm';
- * import { generatedPayer } from '@solana/kit-plugin-signer';
+ * @deprecated Use {@link litesvmTransactionPlanSendingExecutor} instead, which
+ * installs `sendTransaction` and `sendTransactions` alongside the executor. This
+ * plugin only sets the deprecated `transactionPlanExecutor` field.
  *
+ * ```ts
+ * // Before
  * const client = await createClient()
- *     .use(litesvmConnection())
- *     .use(generatedPayer())
  *     .use(litesvmTransactionPlanner())
- *     .use(litesvmTransactionPlanExecutor());
+ *     .use(litesvmTransactionPlanExecutor())
+ *     .use(planAndSendTransactions());
+ *
+ * // After
+ * const client = await createClient()
+ *     .use(litesvmTransactionPlanner())
+ *     .use(litesvmTransactionPlanSendingExecutor());
  * ```
  */
 export function litesvmTransactionPlanExecutor() {
-    return <T extends { svm: LiteSVM }>(client: T) => {
-        if (!client.svm) {
-            throw new Error(
-                'A LiteSVM instance is required on the client to create the LiteSVM transaction plan executor. ' +
-                    'Please add the LiteSVM plugin to your client before using this plugin.',
+    return <T extends { svm: LiteSVM }>(client: T) => transactionPlanExecutor(createExecutor(client))(client);
+}
+
+/**
+ * Creates the transaction plan executor installed by
+ * {@link litesvmTransactionPlanSendingExecutor}, which signs planned
+ * transaction messages and sends them to the client's LiteSVM instance.
+ */
+function createExecutor(client: {
+    svm: LiteSVM;
+}): TransactionPlanExecutor<{ transactionMetadata: FailedTransactionMetadata | TransactionMetadata }> {
+    if (!client.svm) {
+        throw new Error(
+            'A LiteSVM instance is required on the client to create the LiteSVM transaction plan executor. ' +
+                'Please add the LiteSVM plugin to your client before using this plugin.',
+        );
+    }
+
+    return createTransactionPlanExecutor<{
+        transactionMetadata: FailedTransactionMetadata | TransactionMetadata;
+    }>({
+        executeTransactionMessage: async (context, transactionMessage, config) => {
+            const signedTransaction = await pipe(
+                transactionMessage,
+                tx => client.svm.setTransactionMessageLifetimeUsingLatestBlockhash(tx),
+                tx => (context.message = tx),
+                async tx => await signTransactionMessageWithSigners(tx, config),
             );
-        }
 
-        const transactionPlanExecutor = createTransactionPlanExecutor<{
-            transactionMetadata: FailedTransactionMetadata | TransactionMetadata;
-        }>({
-            executeTransactionMessage: async (context, transactionMessage, config) => {
-                const signedTransaction = await pipe(
-                    transactionMessage,
-                    tx => client.svm.setTransactionMessageLifetimeUsingLatestBlockhash(tx),
-                    tx => (context.message = tx),
-                    async tx => await signTransactionMessageWithSigners(tx, config),
-                );
-
-                context.transaction = signedTransaction;
-                const result = client.svm.sendTransaction(signedTransaction);
-                context.transactionMetadata = result;
-                if (isFailedTransaction(result)) {
-                    throw getSolanaErrorFromLiteSvmFailure(result);
-                }
-                return signedTransaction;
-            },
-        });
-
-        return extendClient(client, { transactionPlanExecutor });
-    };
+            context.transaction = signedTransaction;
+            const result = client.svm.sendTransaction(signedTransaction);
+            context.transactionMetadata = result;
+            if (isFailedTransaction(result)) {
+                throw getSolanaErrorFromLiteSvmFailure(result);
+            }
+            return signedTransaction;
+        },
+    });
 }

--- a/packages/kit-plugin-litesvm/src/transaction-planner.ts
+++ b/packages/kit-plugin-litesvm/src/transaction-planner.ts
@@ -2,13 +2,14 @@ import {
     ClientWithPayer,
     createTransactionMessage,
     createTransactionPlanner,
-    extendClient,
     Lamports,
     MicroLamports,
     pipe,
     setTransactionMessageComputeUnitPrice,
     setTransactionMessageFeePayerSigner,
+    TransactionPlanner,
 } from '@solana/kit';
+import { transactionPlanner } from '@solana/kit-plugin-instruction-plan';
 
 /**
  * A plugin that provides a default transaction planner using LiteSVM.
@@ -21,52 +22,64 @@ import {
  * since LiteSVM executes transactions locally without a simulation-based
  * estimation step.
  *
+ * The fee payer is read from `client.payer` lazily, at plan time, so that a
+ * dynamic payer (such as a connected wallet) is always respected.
+ *
  * @param config - Optional configuration for the planner.
- * @returns A plugin that adds `transactionPlanner` to the client.
+ * @returns A plugin that adds `client.planTransaction` and `client.planTransactions`.
+ * @throws If `config.version` is `1`, which `@solana/kit` cannot yet build.
  *
  * @example
  * ```ts
  * import { createClient } from '@solana/kit';
- * import { litesvmConnection, litesvmTransactionPlanner, litesvmTransactionPlanExecutor } from '@solana/kit-plugin-litesvm';
+ * import { litesvmConnection, litesvmTransactionPlanner, litesvmTransactionPlanSendingExecutor } from '@solana/kit-plugin-litesvm';
  * import { generatedPayer } from '@solana/kit-plugin-signer';
  *
  * const client = await createClient()
  *     .use(litesvmConnection())
  *     .use(generatedPayer())
  *     .use(litesvmTransactionPlanner())
- *     .use(litesvmTransactionPlanExecutor());
+ *     .use(litesvmTransactionPlanSendingExecutor());
  * ```
+ *
+ * @see {@link litesvmTransactionPlanSendingExecutor}
  */
 export function litesvmTransactionPlanner(config: TransactionPlannerConfig = {}) {
-    return <T extends ClientWithPayer>(client: T) => {
-        if (config.version === 1) {
-            // The v1 transaction path is defined at the type level for forward
-            // compatibility, but `createTransactionMessage` cannot yet build v1
-            // messages, so we fail loudly rather than silently misbehave.
-            throw new Error(
-                'Version 1 transactions are not yet supported by `litesvmTransactionPlanner`. ' +
-                    'Use version 0 or legacy transactions for now.',
+    return <T extends ClientWithPayer>(client: T) => transactionPlanner(createPlanner(client, config))(client);
+}
+
+/**
+ * Creates the transaction planner installed by {@link litesvmTransactionPlanner}.
+ *
+ * The fee payer is read from the client at plan time rather than at
+ * construction time, so a dynamic `client.payer` is always respected.
+ */
+function createPlanner(client: ClientWithPayer, config: TransactionPlannerConfig): TransactionPlanner {
+    if (config.version === 1) {
+        // The v1 transaction path is defined at the type level for forward
+        // compatibility, but `createTransactionMessage` cannot yet build v1
+        // messages, so we fail loudly rather than silently misbehave.
+        throw new Error(
+            'Version 1 transactions are not yet supported by `litesvmTransactionPlanner`. ' +
+                'Use version 0 or legacy transactions for now.',
+        );
+    }
+
+    const version = config.version ?? 0;
+    const microLamportsPerComputeUnit = config.microLamportsPerComputeUnit;
+
+    return createTransactionPlanner({
+        createTransactionMessage: () => {
+            return pipe(
+                createTransactionMessage({ version }),
+                tx => setTransactionMessageFeePayerSigner(client.payer, tx),
+                tx =>
+                    microLamportsPerComputeUnit === undefined
+                        ? tx
+                        : setTransactionMessageComputeUnitPrice(microLamportsPerComputeUnit, tx),
             );
-        }
-
-        const version = config.version ?? 0;
-        const microLamportsPerComputeUnit = config.microLamportsPerComputeUnit;
-
-        const transactionPlanner = createTransactionPlanner({
-            createTransactionMessage: () => {
-                return pipe(
-                    createTransactionMessage({ version }),
-                    tx => setTransactionMessageFeePayerSigner(client.payer, tx),
-                    tx =>
-                        microLamportsPerComputeUnit === undefined
-                            ? tx
-                            : setTransactionMessageComputeUnitPrice(microLamportsPerComputeUnit, tx),
-                );
-            },
-        });
-
-        return extendClient(client, { transactionPlanner });
-    };
+        },
+    });
 }
 
 /**

--- a/packages/kit-plugin-litesvm/test/litesvm.test.ts
+++ b/packages/kit-plugin-litesvm/test/litesvm.test.ts
@@ -1,5 +1,6 @@
-import { createClient, TransactionSigner } from '@solana/kit';
-import { describe, expect, it } from 'vitest';
+import { createClient, TransactionPlanExecutor, TransactionSigner } from '@solana/kit';
+import type { FailedTransactionMetadata, TransactionMetadata } from 'litesvm';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { litesvm as nodeLitesvm } from '../src/index';
 import { litesvm as browserLitesvm } from '../src/index.browser';
@@ -25,6 +26,18 @@ describe('litesvm', () => {
         expect(client).toHaveProperty('getMinimumBalance');
         expect(client).toHaveProperty('transactionPlanner');
         expect(client).toHaveProperty('transactionPlanExecutor');
-        expect(client).toHaveProperty('sendTransactions');
+        expect(client.planTransaction).toBeTypeOf('function');
+        expect(client.planTransactions).toBeTypeOf('function');
+        expect(client.sendTransaction).toBeTypeOf('function');
+        expect(client.sendTransactions).toBeTypeOf('function');
+    });
+
+    it('preserves the LiteSVM transaction metadata context on the executor', () => {
+        const client = createClient()
+            .use(() => ({ payer }))
+            .use(nodeLitesvm());
+        expectTypeOf(client.transactionPlanExecutor).toEqualTypeOf<
+            TransactionPlanExecutor<{ transactionMetadata: FailedTransactionMetadata | TransactionMetadata }>
+        >();
     });
 });

--- a/packages/kit-plugin-litesvm/test/transaction-plan-executor.test.ts
+++ b/packages/kit-plugin-litesvm/test/transaction-plan-executor.test.ts
@@ -21,17 +21,26 @@ import {
 import type { FailedTransactionMetadata, LiteSVM, TransactionMetadata } from 'litesvm';
 import { describe, expect, it, vi } from 'vitest';
 
-import { litesvmConnection, litesvmTransactionPlanExecutor, litesvmTransactionPlanner } from '../src';
+import {
+    litesvmConnection,
+    litesvmTransactionPlanExecutor,
+    litesvmTransactionPlanner,
+    litesvmTransactionPlanSendingExecutor,
+} from '../src';
 
 const MOCK_INSTRUCTION = { programAddress: '11111111111111111111111111111111' as Address };
 
-describe('litesvmTransactionPlanExecutor', () => {
+describe('litesvmTransactionPlanSendingExecutor', () => {
     describe('with mocks', () => {
-        it('provides a transactionPlanExecutor on the client', () => {
+        it('adds sendTransaction and sendTransactions to the client', async () => {
+            const payer = await generateKeyPairSigner();
             const svm = {} as LiteSVM;
             const client = createClient()
-                .use(() => ({ svm }))
-                .use(litesvmTransactionPlanExecutor());
+                .use(() => ({ payer, svm }))
+                .use(litesvmTransactionPlanner())
+                .use(litesvmTransactionPlanSendingExecutor());
+            expect(client).toHaveProperty('sendTransaction');
+            expect(client).toHaveProperty('sendTransactions');
             expect(client).toHaveProperty('transactionPlanExecutor');
         });
 
@@ -44,7 +53,7 @@ describe('litesvmTransactionPlanExecutor', () => {
             const client = createClient()
                 .use(() => ({ payer, svm }))
                 .use(litesvmTransactionPlanner())
-                .use(litesvmTransactionPlanExecutor());
+                .use(litesvmTransactionPlanSendingExecutor());
 
             const instructionPlan = singleInstructionPlan(MOCK_INSTRUCTION);
             const transactionPlan = await client.transactionPlanner(instructionPlan);
@@ -65,7 +74,7 @@ describe('litesvmTransactionPlanExecutor', () => {
             const client = createClient()
                 .use(() => ({ payer, svm }))
                 .use(litesvmTransactionPlanner())
-                .use(litesvmTransactionPlanExecutor());
+                .use(litesvmTransactionPlanSendingExecutor());
 
             const instructionPlan = singleInstructionPlan(MOCK_INSTRUCTION);
             const transactionPlan = await client.transactionPlanner(instructionPlan);
@@ -81,7 +90,8 @@ describe('litesvmTransactionPlanExecutor', () => {
             const svm = { sendTransaction, setTransactionMessageLifetimeUsingLatestBlockhash } as unknown as LiteSVM;
             const client = createClient()
                 .use(() => ({ payer, svm }))
-                .use(litesvmTransactionPlanExecutor());
+                .use(litesvmTransactionPlanner())
+                .use(litesvmTransactionPlanSendingExecutor());
 
             const transactionPlan = singleTransactionPlan(
                 setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 })),
@@ -101,7 +111,8 @@ describe('litesvmTransactionPlanExecutor', () => {
             const svm = { sendTransaction, setTransactionMessageLifetimeUsingLatestBlockhash } as unknown as LiteSVM;
             const client = createClient()
                 .use(() => ({ payer, svm }))
-                .use(litesvmTransactionPlanExecutor());
+                .use(litesvmTransactionPlanner())
+                .use(litesvmTransactionPlanSendingExecutor());
 
             const transactionPlan = singleTransactionPlan(
                 setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 })),
@@ -132,7 +143,8 @@ describe('litesvmTransactionPlanExecutor', () => {
             const svm = { sendTransaction, setTransactionMessageLifetimeUsingLatestBlockhash } as unknown as LiteSVM;
             const client = createClient()
                 .use(() => ({ payer, svm }))
-                .use(litesvmTransactionPlanExecutor());
+                .use(litesvmTransactionPlanner())
+                .use(litesvmTransactionPlanSendingExecutor());
 
             const transactionPlan = singleTransactionPlan(
                 setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 })),
@@ -155,7 +167,7 @@ describe('litesvmTransactionPlanExecutor', () => {
 
         it('requires an svm instance on the client', () => {
             // @ts-expect-error Missing svm instance on the client.
-            expect(() => createClient().use(litesvmTransactionPlanExecutor())).toThrow();
+            expect(() => createClient().use(litesvmTransactionPlanSendingExecutor())).toThrow();
         });
     });
 
@@ -173,7 +185,7 @@ describe('litesvmTransactionPlanExecutor', () => {
                 .use(litesvmConnection())
                 .use(client => extendClient(client, { payer }))
                 .use(litesvmTransactionPlanner())
-                .use(litesvmTransactionPlanExecutor());
+                .use(litesvmTransactionPlanSendingExecutor());
             client.svm.airdrop(payer.address, lamports(1_000_000_000n));
 
             const transactionPlan = singleTransactionPlan(
@@ -190,7 +202,7 @@ describe('litesvmTransactionPlanExecutor', () => {
                 .use(litesvmConnection())
                 .use(client => extendClient(client, { payer }))
                 .use(litesvmTransactionPlanner())
-                .use(litesvmTransactionPlanExecutor());
+                .use(litesvmTransactionPlanSendingExecutor());
             client.svm.airdrop(payer.address, lamports(1_000_000_000n)); // 1 SOL
 
             const instruction = getTransferSolInstruction({
@@ -210,7 +222,7 @@ describe('litesvmTransactionPlanExecutor', () => {
                 .use(litesvmConnection())
                 .use(client => extendClient(client, { payer }))
                 .use(litesvmTransactionPlanner())
-                .use(litesvmTransactionPlanExecutor());
+                .use(litesvmTransactionPlanSendingExecutor());
             client.svm.airdrop(payer.address, lamports(1_000_000_000n));
 
             // Send an instruction with invalid data to the system program.
@@ -245,7 +257,7 @@ describe('litesvmTransactionPlanExecutor', () => {
                 .use(litesvmConnection())
                 .use(client => extendClient(client, { payer }))
                 .use(litesvmTransactionPlanner())
-                .use(litesvmTransactionPlanExecutor());
+                .use(litesvmTransactionPlanSendingExecutor());
             // Do NOT airdrop — payer account doesn't exist.
 
             const transactionPlan = singleTransactionPlan(
@@ -270,7 +282,7 @@ describe('litesvmTransactionPlanExecutor', () => {
                 .use(litesvmConnection())
                 .use(client => extendClient(client, { payer }))
                 .use(litesvmTransactionPlanner())
-                .use(litesvmTransactionPlanExecutor());
+                .use(litesvmTransactionPlanSendingExecutor());
             client.svm.airdrop(payer.address, lamports(1_000_000_000n));
 
             const transactionPlan = singleTransactionPlan(
@@ -292,7 +304,7 @@ describe('litesvmTransactionPlanExecutor', () => {
                 .use(litesvmConnection())
                 .use(client => extendClient(client, { payer }))
                 .use(litesvmTransactionPlanner())
-                .use(litesvmTransactionPlanExecutor());
+                .use(litesvmTransactionPlanSendingExecutor());
             // Do NOT airdrop — payer account doesn't exist.
 
             const transactionPlan = singleTransactionPlan(
@@ -306,5 +318,22 @@ describe('litesvmTransactionPlanExecutor', () => {
             expect(metadata).toBeDefined();
             expect(metadata.err()).toBeDefined();
         });
+    });
+});
+
+describe('litesvmTransactionPlanExecutor', () => {
+    it('sets the deprecated transactionPlanExecutor field without requiring a planner', () => {
+        const svm = { sendTransaction: vi.fn() } as unknown as LiteSVM;
+        const client = createClient()
+            .use(() => ({ svm }))
+            .use(litesvmTransactionPlanExecutor());
+        expect(client).toHaveProperty('transactionPlanExecutor');
+        expect(client).not.toHaveProperty('sendTransaction');
+        expect(client).not.toHaveProperty('sendTransactions');
+    });
+
+    it('requires an svm instance on the client', () => {
+        // @ts-expect-error Missing svm on the client.
+        expect(() => createClient().use(litesvmTransactionPlanExecutor())).toThrow(/A LiteSVM instance is required/);
     });
 });

--- a/packages/kit-plugin-litesvm/test/transaction-planner.test.ts
+++ b/packages/kit-plugin-litesvm/test/transaction-planner.test.ts
@@ -39,6 +39,24 @@ describe('litesvmTransactionPlanner', () => {
         expect(transactionPlan.message.feePayer).toBe(payer);
     });
 
+    it('reads client.payer at plan time rather than at install time', async () => {
+        const first = await generateKeyPairSigner();
+        const second = await generateKeyPairSigner();
+        let current = first;
+        const client = createClient()
+            .use(() => ({
+                get payer() {
+                    return current;
+                },
+            }))
+            .use(litesvmTransactionPlanner());
+
+        current = second;
+        const instructionPlan = singleInstructionPlan(MOCK_INSTRUCTION);
+        const transactionMessage = await client.planTransaction(instructionPlan);
+        expect(transactionMessage.feePayer.address).toBe(second.address);
+    });
+
     it('creates version 0 transaction messages by default', async () => {
         const payer = await generateKeyPairSigner();
         const client = createClient()

--- a/packages/kit-plugin-rpc/README.md
+++ b/packages/kit-plugin-rpc/README.md
@@ -41,7 +41,7 @@ All options are provided via a `SolanaRpcConfig` object:
 - `rpcSubscriptionsUrl`: URL of the RPC Subscriptions endpoint. Defaults to the `rpcUrl` with the protocol changed from `http` to `ws`. As a convenience, the exact strings `http://127.0.0.1:8899` and `http://localhost:8899` (the canonical local validator RPC endpoints) are rewritten to port `8900`. The match is exact-string only — any other host, scheme, or port (including `https://localhost:8899` or `http://0.0.0.0:8899`) is left untouched. Pass `rpcSubscriptionsUrl` explicitly when your RPC and WebSocket endpoints use different ports.
 - `rpcConfig`: Optional configuration forwarded to `createSolanaRpc`.
 - `rpcSubscriptionsConfig`: Optional configuration forwarded to `createSolanaRpcSubscriptions`.
-- `transactionConfig`: Options to configure how transaction messages are created. See `rpcTransactionPlanner` options below.
+- `transactionConfig`: Options to configure how transaction messages are created. See the `rpcTransactionPlanner` options below.
 - `maxConcurrency`: Maximum number of concurrent transaction executions. Defaults to 10.
 - `skipPreflight`: Whether to always skip preflight simulation. Defaults to `false`.
 
@@ -50,9 +50,9 @@ All options are provided via a `SolanaRpcConfig` object:
 - `rpc`: Call any Solana RPC method.
 - `rpcSubscriptions`: Subscribe to Solana RPC notifications.
 - `getMinimumBalance`: Compute minimum lamports for rent exemption.
-- `transactionPlanner`: Plan instructions into transaction messages.
-- `transactionPlanExecutor`: Sign and send planned transactions.
-- `sendTransaction(s)` / `planTransaction(s)`: Convenience helpers that combine planning and execution.
+- `planTransaction(s)`: Plan instructions into transaction messages without executing them.
+- `sendTransaction(s)`: Plan and execute instructions, instruction plans, or transaction messages in one call.
+- `transactionPlanner` / `transactionPlanExecutor` (deprecated): Fields kept for backward compatibility. Use `planTransaction(s)` / `sendTransaction(s)` instead.
 
 ## `solanaMainnetRpc` plugin
 
@@ -245,22 +245,24 @@ const client = createClient()
 
 ## `rpcTransactionPlanner` plugin
 
-This plugin provides a default transaction planner that creates transaction messages with a fee payer, provisory resource limits (a compute unit limit, plus a loaded accounts data size limit for version 1 transactions), and optional priority fees.
+Adds `planTransaction` and `planTransactions` to the client, using a planner that plans instructions into transaction messages with a fee payer, provisory resource limits (a compute unit limit, plus a loaded accounts data size limit for version 1 transactions), and optional priority fees. The fee payer is read from `client.payer` lazily, at plan time, so a dynamic payer (such as a connected wallet) is always respected.
 
-### Installation
+### Usage
 
-The client must have a `payer` set before applying this plugin.
+The client must have a `payer` set before installing the plugin.
 
 ```ts
 import { createClient } from '@solana/kit';
-import { solanaRpcConnection, rpcTransactionPlanner, rpcTransactionPlanExecutor } from '@solana/kit-plugin-rpc';
+import { rpcTransactionPlanSendingExecutor, rpcTransactionPlanner, solanaRpcConnection } from '@solana/kit-plugin-rpc';
 import { generatedPayer } from '@solana/kit-plugin-signer';
 
 const client = await createClient()
     .use(solanaRpcConnection({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
     .use(generatedPayer())
     .use(rpcTransactionPlanner())
-    .use(rpcTransactionPlanExecutor());
+    .use(rpcTransactionPlanSendingExecutor());
+
+const transactionPlan = await client.planTransactions(myInstructionPlan);
 ```
 
 ### Options
@@ -275,46 +277,36 @@ For legacy and version 0 transactions:
 
 Version 1 transactions are defined for forward compatibility but are not yet buildable by `@solana/kit`; passing `version: 1` currently throws. When available, version 1 will accept `priorityFeeLamports` (a flat total in lamports) instead of `microLamportsPerComputeUnit`, alongside the shared `estimateResourceLimits` option.
 
-### Features
+## `rpcTransactionPlanSendingExecutor` plugin
 
-- `transactionPlanner`: A function that plans instructions into transaction messages.
-    ```ts
-    const transactionPlan = await client.transactionPlanner(myInstructionPlan);
-    ```
+Adds `sendTransaction` and `sendTransactions` to the client, using an executor that estimates resource limits, signs, and sends transactions via RPC. Resource limit estimation covers the compute unit limit and, for version 1 transactions, the loaded accounts data size limit.
 
-## `rpcTransactionPlanExecutor` plugin
+### Usage
 
-This plugin provides a default transaction plan executor that estimates resource limits, signs, and sends transactions via RPC. Resource limit estimation covers the compute unit limit and, for version 1 transactions, the loaded accounts data size limit.
-
-### Installation
-
-This plugin requires `rpc` and `rpcSubscriptions` to be configured on the client.
+The client must have `rpc` and `rpcSubscriptions` configured, and a transaction planner installed, before installing this plugin — sending plans through the client's planning functions.
 
 ```ts
 import { createClient } from '@solana/kit';
-import { solanaRpcConnection, rpcTransactionPlanner, rpcTransactionPlanExecutor } from '@solana/kit-plugin-rpc';
+import { rpcTransactionPlanSendingExecutor, rpcTransactionPlanner, solanaRpcConnection } from '@solana/kit-plugin-rpc';
 import { generatedPayer } from '@solana/kit-plugin-signer';
 
 const client = await createClient()
     .use(solanaRpcConnection({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
     .use(generatedPayer())
     .use(rpcTransactionPlanner())
-    .use(rpcTransactionPlanExecutor());
+    .use(rpcTransactionPlanSendingExecutor());
+
+const transactionPlanResult = await client.sendTransactions(myInstructionPlan);
 ```
 
 ### Options
+
+All options are provided via a `RpcTransactionPlanExecutorConfig` object:
 
 - `estimateResourceLimits`: Whether to estimate and set resource limits by simulating before sending (default: `true`). This should match the `estimateResourceLimits` option on the planner; `solanaRpc` keeps them in sync automatically.
 - `getComputeUnitLimitFromEstimate`: A `(estimatedComputeUnits: number) => number` function that maps the estimated compute unit consumption to the compute unit limit to set, adding headroom for variation between simulation and execution. Defaults to a function that adds a buffer on top of the estimate of at least 300 compute units, or a margin that decays linearly from 10% at low estimates to 2% at 500,000 compute units and above, whichever is greater. The result is always capped at 1,400,000 (the per-transaction maximum).
 - `maxConcurrency`: Maximum number of concurrent executions (default: 10).
 - `skipPreflight`: Whether to skip the preflight simulation when sending transactions (default: `false`).
-
-### Features
-
-- `transactionPlanExecutor`: A function that executes planned transactions.
-    ```ts
-    const transactionPlanResult = await client.transactionPlanExecutor(myTransactionPlan);
-    ```
 
 ### Preflight and Resource Limit Estimation
 
@@ -373,3 +365,15 @@ The following plugins are still exported for backward compatibility but are depr
 
 - `rpcConnection(rpc)` / `rpcSubscriptionsConnection(rpcSubscriptions)`: Trivial wrappers around `extendClient`. Inline `extendClient({ rpc })` or `extendClient({ rpcSubscriptions })` instead, or use `solanaRpcConnection` when starting from a cluster URL.
 - `solanaRpcSubscriptionsConnection(url, config?)`: No longer needed because `solanaRpcConnection` installs both `rpc` and `rpcSubscriptions`.
+- `rpcTransactionPlanExecutor(config?)`: Only sets the deprecated `client.transactionPlanExecutor` field. Use `rpcTransactionPlanSendingExecutor` instead, which installs `sendTransaction` and `sendTransactions` alongside the executor.
+
+    ```ts
+    // Before
+    const client = await createClient()
+        .use(rpcTransactionPlanner())
+        .use(rpcTransactionPlanExecutor())
+        .use(planAndSendTransactions());
+
+    // After
+    const client = await createClient().use(rpcTransactionPlanner()).use(rpcTransactionPlanSendingExecutor());
+    ```

--- a/packages/kit-plugin-rpc/src/solana-rpc.ts
+++ b/packages/kit-plugin-rpc/src/solana-rpc.ts
@@ -15,12 +15,11 @@ import {
     SolanaRpcSubscriptionsApi,
     TestnetUrl,
 } from '@solana/kit';
-import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
 
 import { rpcAirdrop } from './airdrop';
 import { rpcGetMinimumBalance } from './get-minimum-balance';
 import { rpcSubscriptionsConnection } from './rpc';
-import { rpcTransactionPlanExecutor } from './transaction-plan-executor';
+import { rpcTransactionPlanSendingExecutor } from './transaction-plan-executor';
 import { rpcTransactionPlanner, TransactionPlannerConfig } from './transaction-planner';
 
 /**
@@ -114,8 +113,8 @@ export type SolanaRpcConfig<TClusterUrl extends ClusterUrl = ClusterUrl> = Solan
  *
  * @param config - Configuration for the Solana RPC connection.
  * @return A plugin that adds `client.rpc`, `client.rpcSubscriptions`,
- * `client.getMinimumBalance`, `client.transactionPlanner`,
- * `client.transactionPlanExecutor`, and `client.sendTransactions`.
+ * `client.getMinimumBalance`, `client.planTransaction`, `client.planTransactions`,
+ * `client.sendTransaction` and `client.sendTransactions`.
  *
  * @example
  * ```ts
@@ -140,13 +139,12 @@ export function solanaRpc<TClusterUrl extends ClusterUrl>(config: SolanaRpcConfi
             solanaRpcConnection<TClusterUrl>(config),
             rpcGetMinimumBalance(),
             rpcTransactionPlanner(config.transactionConfig),
-            rpcTransactionPlanExecutor({
+            rpcTransactionPlanSendingExecutor({
                 estimateResourceLimits: config.transactionConfig?.estimateResourceLimits,
                 getComputeUnitLimitFromEstimate: config.getComputeUnitLimitFromEstimate,
                 maxConcurrency: config.maxConcurrency,
                 skipPreflight: config.skipPreflight,
             }),
-            planAndSendTransactions(),
         );
 }
 

--- a/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
+++ b/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
@@ -2,10 +2,10 @@ import {
     assertIsTransactionWithBlockhashLifetime,
     ClientWithRpc,
     ClientWithRpcSubscriptions,
+    ClientWithTransactionPlanning,
     createTransactionPlanExecutor,
     estimateAndSetResourceLimitsFactory,
     estimateResourceLimitsFactory,
-    extendClient,
     GetEpochInfoApi,
     GetLatestBlockhashApi,
     GetSignatureStatusesApi,
@@ -20,8 +20,59 @@ import {
     SimulateTransactionApi,
     SlotNotificationsApi,
     SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_RESOURCE_LIMITS,
+    TransactionPlanExecutor,
     TransactionPlanExecutorConfig,
 } from '@solana/kit';
+import { transactionPlanExecutor, transactionPlanSendingExecutor } from '@solana/kit-plugin-instruction-plan';
+
+/**
+ * A plugin that adds `sendTransaction` and `sendTransactions` to the client
+ * using a default transaction plan executor backed by RPC.
+ *
+ * The executor handles resource limit estimation (compute units and, for
+ * version 1 transactions, the loaded accounts data size), transaction signing,
+ * and sending via RPC. A concurrency limit can be set to avoid hitting rate
+ * limits when sending many transactions in parallel.
+ *
+ * Since sending goes through the client's planning functions,
+ * {@link rpcTransactionPlanner} — or another `transactionPlanner` plugin — must
+ * be installed first.
+ *
+ * @param config - Optional configuration for the executor.
+ * @returns A plugin that adds `client.sendTransaction` and `client.sendTransactions`.
+ * @throws If the client has no `rpc` or no `rpcSubscriptions` set, or no
+ * transaction planning functions set.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from '@solana/kit';
+ * import { solanaRpcConnection, rpcTransactionPlanner, rpcTransactionPlanSendingExecutor } from '@solana/kit-plugin-rpc';
+ * import { generatedPayer } from '@solana/kit-plugin-signer';
+ *
+ * const client = await createClient()
+ *     .use(solanaRpcConnection({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
+ *     .use(generatedPayer())
+ *     .use(rpcTransactionPlanner())
+ *     .use(rpcTransactionPlanSendingExecutor());
+ * ```
+ *
+ * @see {@link rpcTransactionPlanner}
+ */
+export function rpcTransactionPlanSendingExecutor(config: RpcTransactionPlanExecutorConfig = {}) {
+    return <
+        T extends ClientWithRpc<
+            GetEpochInfoApi &
+                GetLatestBlockhashApi &
+                GetSignatureStatusesApi &
+                SendTransactionApi &
+                SimulateTransactionApi
+        > &
+            ClientWithRpcSubscriptions<SignatureNotificationsApi & SlotNotificationsApi> &
+            ClientWithTransactionPlanning,
+    >(
+        client: T,
+    ) => transactionPlanSendingExecutor(createExecutor(client, config))(client);
+}
 
 /**
  * A plugin that provides a default transaction plan executor using RPC.
@@ -34,83 +85,24 @@ import {
  * @param config - Optional configuration for the executor.
  * @returns A plugin that adds `transactionPlanExecutor` to the client.
  *
- * @example
- * ```ts
- * import { createClient } from '@solana/kit';
- * import { solanaRpcConnection, rpcTransactionPlanner, rpcTransactionPlanExecutor } from '@solana/kit-plugin-rpc';
- * import { generatedPayer } from '@solana/kit-plugin-signer';
+ * @deprecated Use {@link rpcTransactionPlanSendingExecutor} instead, which
+ * installs `sendTransaction` and `sendTransactions` alongside the executor. This
+ * plugin only sets the deprecated `transactionPlanExecutor` field.
  *
+ * ```ts
+ * // Before
  * const client = await createClient()
- *     .use(solanaRpcConnection({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
- *     .use(generatedPayer())
  *     .use(rpcTransactionPlanner())
- *     .use(rpcTransactionPlanExecutor());
+ *     .use(rpcTransactionPlanExecutor())
+ *     .use(planAndSendTransactions());
+ *
+ * // After
+ * const client = await createClient()
+ *     .use(rpcTransactionPlanner())
+ *     .use(rpcTransactionPlanSendingExecutor());
  * ```
  */
-export function rpcTransactionPlanExecutor(
-    config: {
-        /**
-         * Whether to estimate and set resource limits (the compute unit limit
-         * and, for version 1 transactions, the loaded accounts data size limit)
-         * by simulating the transaction before sending.
-         *
-         * When `true` (default), any resource limit that is still provisory or
-         * unset is estimated via a simulation and replaced with the estimated
-         * value (with a compute unit buffer applied via
-         * `getComputeUnitLimitFromEstimate`). When `false`, no estimation
-         * simulation is performed and the message is sent with exactly the
-         * resource limits it already carries.
-         *
-         * This should match the `estimateResourceLimits` option passed to
-         * {@link rpcTransactionPlanner}, which controls whether provisory limits
-         * are reserved in the first place. {@link solanaRpc} keeps them in sync
-         * automatically.
-         *
-         * Defaults to `true`.
-         */
-        estimateResourceLimits?: boolean;
-        /**
-         * Maps the estimated compute unit consumption from simulation to the
-         * compute unit limit to set on the transaction, adding headroom to
-         * account for variation between simulation and execution.
-         *
-         * By default, a function is used that adds a buffer on top of the
-         * estimate of at least 300 compute units, or a margin that decays
-         * linearly from 10% at low estimates to 2% at 500,000 compute units and
-         * above, whichever is greater.
-         *
-         * The returned value is always capped at 1,400,000, the maximum number of
-         * compute units allowed per transaction.
-         *
-         * @param estimatedComputeUnits - The compute units consumed during simulation.
-         * @returns The compute unit limit to set on the transaction.
-         */
-        getComputeUnitLimitFromEstimate?: (estimatedComputeUnits: number) => number;
-        /**
-         * The maximum number of concurrent executions allowed.
-         * Defaults to 10.
-         */
-        maxConcurrency?: number;
-        /**
-         * Whether to skip the preflight simulation when sending transactions.
-         *
-         * When `false` (default), preflight is skipped only if a resource limit
-         * estimation simulation was already performed for that transaction.
-         * If every applicable resource limit is already explicitly set (i.e. no
-         * estimation was needed) or estimation is disabled, preflight runs as the
-         * only simulation.
-         *
-         * When `true`, preflight is always skipped and the transaction is sent
-         * directly to the validator. Additionally, if the resource limit estimation
-         * simulation fails, the consumed resources from the failed simulation are
-         * used to set the limits so the transaction still reaches the validator.
-         * This is useful for debugging failed transactions in an explorer.
-         *
-         * Defaults to `false`.
-         */
-        skipPreflight?: boolean;
-    } = {},
-) {
+export function rpcTransactionPlanExecutor(config: RpcTransactionPlanExecutorConfig = {}) {
     return <
         T extends ClientWithRpc<
             GetEpochInfoApi &
@@ -122,68 +114,147 @@ export function rpcTransactionPlanExecutor(
             ClientWithRpcSubscriptions<SignatureNotificationsApi & SlotNotificationsApi>,
     >(
         client: T,
-    ) => {
-        if (!client.rpc || !client.rpcSubscriptions) {
-            throw new Error(
-                'An RPC instance with subscriptions is required on the client to create the RPC transaction plan executor. ' +
-                    'Please add the RPC plugin to your client before using this plugin.',
+    ) => transactionPlanExecutor(createExecutor(client, config))(client);
+}
+
+/**
+ * Configuration for {@link rpcTransactionPlanSendingExecutor}.
+ *
+ * @see {@link rpcTransactionPlanSendingExecutor}
+ */
+export type RpcTransactionPlanExecutorConfig = {
+    /**
+     * Whether to estimate and set resource limits (the compute unit limit
+     * and, for version 1 transactions, the loaded accounts data size limit)
+     * by simulating the transaction before sending.
+     *
+     * When `true` (default), any resource limit that is still provisory or
+     * unset is estimated via a simulation and replaced with the estimated
+     * value (with a compute unit buffer applied via
+     * `getComputeUnitLimitFromEstimate`). When `false`, no estimation
+     * simulation is performed and the message is sent with exactly the
+     * resource limits it already carries.
+     *
+     * This should match the `estimateResourceLimits` option passed to
+     * {@link rpcTransactionPlanner}, which controls whether provisory limits
+     * are reserved in the first place. {@link solanaRpc} keeps them in sync
+     * automatically.
+     *
+     * Defaults to `true`.
+     */
+    estimateResourceLimits?: boolean;
+    /**
+     * Maps the estimated compute unit consumption from simulation to the
+     * compute unit limit to set on the transaction, adding headroom to
+     * account for variation between simulation and execution.
+     *
+     * By default, a function is used that adds a buffer on top of the
+     * estimate of at least 300 compute units, or a margin that decays
+     * linearly from 10% at low estimates to 2% at 500,000 compute units and
+     * above, whichever is greater.
+     *
+     * The returned value is always capped at 1,400,000, the maximum number of
+     * compute units allowed per transaction.
+     *
+     * @param estimatedComputeUnits - The compute units consumed during simulation.
+     * @returns The compute unit limit to set on the transaction.
+     */
+    getComputeUnitLimitFromEstimate?: (estimatedComputeUnits: number) => number;
+    /**
+     * The maximum number of concurrent executions allowed.
+     * Defaults to 10.
+     */
+    maxConcurrency?: number;
+    /**
+     * Whether to skip the preflight simulation when sending transactions.
+     *
+     * When `false` (default), preflight is skipped only if a resource limit
+     * estimation simulation was already performed for that transaction.
+     * If every applicable resource limit is already explicitly set (i.e. no
+     * estimation was needed) or estimation is disabled, preflight runs as the
+     * only simulation.
+     *
+     * When `true`, preflight is always skipped and the transaction is sent
+     * directly to the validator. Additionally, if the resource limit estimation
+     * simulation fails, the consumed resources from the failed simulation are
+     * used to set the limits so the transaction still reaches the validator.
+     * This is useful for debugging failed transactions in an explorer.
+     *
+     * Defaults to `false`.
+     */
+    skipPreflight?: boolean;
+};
+
+/**
+ * Creates the transaction plan executor installed by
+ * {@link rpcTransactionPlanSendingExecutor}, which signs and sends planned
+ * transaction messages using the client's RPC and RPC Subscriptions.
+ */
+function createExecutor(
+    client: ClientWithRpc<
+        GetEpochInfoApi & GetLatestBlockhashApi & GetSignatureStatusesApi & SendTransactionApi & SimulateTransactionApi
+    > &
+        ClientWithRpcSubscriptions<SignatureNotificationsApi & SlotNotificationsApi>,
+    config: RpcTransactionPlanExecutorConfig,
+): TransactionPlanExecutor {
+    if (!client.rpc || !client.rpcSubscriptions) {
+        throw new Error(
+            'An RPC instance with subscriptions is required on the client to create the RPC transaction plan executor. ' +
+                'Please add the RPC plugin to your client before using this plugin.',
+        );
+    }
+
+    const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({
+        rpc: client.rpc,
+        rpcSubscriptions: client.rpcSubscriptions,
+    });
+    const estimateResourceLimits = estimateResourceLimitsFactory({ rpc: client.rpc });
+    const shouldEstimateResourceLimits = config.estimateResourceLimits ?? true;
+    const getComputeUnitLimitFromEstimate =
+        config.getComputeUnitLimitFromEstimate ?? getDefaultComputeUnitLimitFromEstimate;
+    const skipPreflight = config.skipPreflight ?? false;
+
+    return createTransactionPlanExecutor({
+        executeTransactionMessage: limitFunction(async (context, transactionMessage, executorConfig) => {
+            const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send(executorConfig);
+
+            // `estimateAndSetResourceLimits` only invokes our estimator when a
+            // resource limit actually needs estimating, so this flag tells us
+            // whether an estimation simulation was performed. When it was, we
+            // skip the redundant preflight simulation while sending.
+            let didSimulateToEstimate = false;
+            const estimateAndSetResourceLimits = estimateAndSetResourceLimitsFactory(
+                bufferAndRecoverResourceLimits(
+                    estimateResourceLimits,
+                    getComputeUnitLimitFromEstimate,
+                    skipPreflight,
+                    () => {
+                        didSimulateToEstimate = true;
+                    },
+                ),
             );
-        }
 
-        const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({
-            rpc: client.rpc,
-            rpcSubscriptions: client.rpcSubscriptions,
-        });
-        const estimateResourceLimits = estimateResourceLimitsFactory({ rpc: client.rpc });
-        const shouldEstimateResourceLimits = config.estimateResourceLimits ?? true;
-        const getComputeUnitLimitFromEstimate =
-            config.getComputeUnitLimitFromEstimate ?? getDefaultComputeUnitLimitFromEstimate;
-        const skipPreflight = config.skipPreflight ?? false;
-
-        const transactionPlanExecutor = createTransactionPlanExecutor({
-            executeTransactionMessage: limitFunction(async (context, transactionMessage, executorConfig) => {
-                const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send(executorConfig);
-
-                // `estimateAndSetResourceLimits` only invokes our estimator when a
-                // resource limit actually needs estimating, so this flag tells us
-                // whether an estimation simulation was performed. When it was, we
-                // skip the redundant preflight simulation while sending.
-                let didSimulateToEstimate = false;
-                const estimateAndSetResourceLimits = estimateAndSetResourceLimitsFactory(
-                    bufferAndRecoverResourceLimits(
-                        estimateResourceLimits,
-                        getComputeUnitLimitFromEstimate,
-                        skipPreflight,
-                        () => {
-                            didSimulateToEstimate = true;
-                        },
-                    ),
-                );
-
-                const signedTransaction = await pipe(
-                    transactionMessage,
-                    tx => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-                    tx => (context.message = tx),
-                    // Skip the estimation step entirely when disabled, so the
-                    // message is sent with exactly the resource limits it carries.
-                    async tx =>
-                        shouldEstimateResourceLimits ? await estimateAndSetResourceLimits(tx, executorConfig) : tx,
-                    async tx => (context.message = await tx),
-                    async tx => await signTransactionMessageWithSigners(await tx, executorConfig),
-                    async tx => (context.transaction = await tx),
-                );
-                assertIsTransactionWithBlockhashLifetime(signedTransaction);
-                await sendAndConfirmTransaction(signedTransaction, {
-                    commitment: 'confirmed',
-                    skipPreflight: skipPreflight || didSimulateToEstimate,
-                    ...executorConfig,
-                });
-                return signedTransaction;
-            }, config.maxConcurrency ?? 10),
-        } satisfies TransactionPlanExecutorConfig);
-
-        return extendClient(client, { transactionPlanExecutor });
-    };
+            const signedTransaction = await pipe(
+                transactionMessage,
+                tx => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+                tx => (context.message = tx),
+                // Skip the estimation step entirely when disabled, so the
+                // message is sent with exactly the resource limits it carries.
+                async tx =>
+                    shouldEstimateResourceLimits ? await estimateAndSetResourceLimits(tx, executorConfig) : tx,
+                async tx => (context.message = await tx),
+                async tx => await signTransactionMessageWithSigners(await tx, executorConfig),
+                async tx => (context.transaction = await tx),
+            );
+            assertIsTransactionWithBlockhashLifetime(signedTransaction);
+            await sendAndConfirmTransaction(signedTransaction, {
+                commitment: 'confirmed',
+                skipPreflight: skipPreflight || didSimulateToEstimate,
+                ...executorConfig,
+            });
+            return signedTransaction;
+        }, config.maxConcurrency ?? 10),
+    } satisfies TransactionPlanExecutorConfig);
 }
 
 /**

--- a/packages/kit-plugin-rpc/src/transaction-planner.ts
+++ b/packages/kit-plugin-rpc/src/transaction-planner.ts
@@ -2,14 +2,15 @@ import {
     ClientWithPayer,
     createTransactionMessage,
     createTransactionPlanner,
-    extendClient,
     fillTransactionMessageProvisoryResourceLimits,
     Lamports,
     MicroLamports,
     pipe,
     setTransactionMessageComputeUnitPrice,
     setTransactionMessageFeePayerSigner,
+    TransactionPlanner,
 } from '@solana/kit';
+import { transactionPlanner } from '@solana/kit-plugin-instruction-plan';
 
 /**
  * A plugin that provides a default transaction planner using RPC.
@@ -21,20 +22,24 @@ import {
  *   unless `estimateResourceLimits` is `false`.
  * - Optional priority fees.
  *
+ * The fee payer is read from `client.payer` lazily, at plan time, so that a
+ * dynamic payer (such as a connected wallet) is always respected.
+ *
  * @param config - Optional configuration for the planner.
- * @returns A plugin that adds `transactionPlanner` to the client.
+ * @returns A plugin that adds `client.planTransaction` and `client.planTransactions`.
+ * @throws If `config.version` is `1`, which `@solana/kit` cannot yet build.
  *
  * @example
  * ```ts
  * import { createClient } from '@solana/kit';
- * import { solanaRpcConnection, rpcTransactionPlanner, rpcTransactionPlanExecutor } from '@solana/kit-plugin-rpc';
+ * import { solanaRpcConnection, rpcTransactionPlanner, rpcTransactionPlanSendingExecutor } from '@solana/kit-plugin-rpc';
  * import { generatedPayer } from '@solana/kit-plugin-signer';
  *
  * const client = await createClient()
  *     .use(solanaRpcConnection({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
  *     .use(generatedPayer())
  *     .use(rpcTransactionPlanner())
- *     .use(rpcTransactionPlanExecutor());
+ *     .use(rpcTransactionPlanSendingExecutor());
  * ```
  *
  * @example
@@ -44,39 +49,47 @@ import {
  * ```ts
  * rpcTransactionPlanner({ estimateResourceLimits: false });
  * ```
+ *
+ * @see {@link rpcTransactionPlanSendingExecutor}
  */
 export function rpcTransactionPlanner(config: TransactionPlannerConfig = {}) {
-    return <T extends ClientWithPayer>(client: T) => {
-        if (config.version === 1) {
-            // The v1 transaction path is defined at the type level for forward
-            // compatibility, but `createTransactionMessage` cannot yet build v1
-            // messages, so we fail loudly rather than silently misbehave.
-            throw new Error(
-                'Version 1 transactions are not yet supported by `rpcTransactionPlanner`. ' +
-                    'Use version 0 or legacy transactions for now.',
+    return <T extends ClientWithPayer>(client: T) => transactionPlanner(createPlanner(client, config))(client);
+}
+
+/**
+ * Creates the transaction planner installed by {@link rpcTransactionPlanner}.
+ *
+ * The fee payer is read from the client at plan time rather than at
+ * construction time, so a dynamic `client.payer` is always respected.
+ */
+function createPlanner(client: ClientWithPayer, config: TransactionPlannerConfig): TransactionPlanner {
+    if (config.version === 1) {
+        // The v1 transaction path is defined at the type level for forward
+        // compatibility, but `createTransactionMessage` cannot yet build v1
+        // messages, so we fail loudly rather than silently misbehave.
+        throw new Error(
+            'Version 1 transactions are not yet supported by `rpcTransactionPlanner`. ' +
+                'Use version 0 or legacy transactions for now.',
+        );
+    }
+
+    const version = config.version ?? 0;
+    const estimateResourceLimits = config.estimateResourceLimits ?? true;
+    const microLamportsPerComputeUnit = config.microLamportsPerComputeUnit;
+
+    return createTransactionPlanner({
+        createTransactionMessage: () => {
+            return pipe(
+                createTransactionMessage({ version }),
+                tx => setTransactionMessageFeePayerSigner(client.payer, tx),
+                tx => (estimateResourceLimits ? fillTransactionMessageProvisoryResourceLimits(tx) : tx),
+                tx =>
+                    microLamportsPerComputeUnit === undefined
+                        ? tx
+                        : setTransactionMessageComputeUnitPrice(microLamportsPerComputeUnit, tx),
             );
-        }
-
-        const version = config.version ?? 0;
-        const estimateResourceLimits = config.estimateResourceLimits ?? true;
-        const microLamportsPerComputeUnit = config.microLamportsPerComputeUnit;
-
-        const transactionPlanner = createTransactionPlanner({
-            createTransactionMessage: () => {
-                return pipe(
-                    createTransactionMessage({ version }),
-                    tx => setTransactionMessageFeePayerSigner(client.payer, tx),
-                    tx => (estimateResourceLimits ? fillTransactionMessageProvisoryResourceLimits(tx) : tx),
-                    tx =>
-                        microLamportsPerComputeUnit === undefined
-                            ? tx
-                            : setTransactionMessageComputeUnitPrice(microLamportsPerComputeUnit, tx),
-                );
-            },
-        });
-
-        return extendClient(client, { transactionPlanner });
-    };
+        },
+    });
 }
 
 /**

--- a/packages/kit-plugin-rpc/test/index.test.ts
+++ b/packages/kit-plugin-rpc/test/index.test.ts
@@ -151,7 +151,10 @@ describe('solanaRpc', () => {
         expect(client).toHaveProperty('getMinimumBalance');
         expect(client).toHaveProperty('transactionPlanner');
         expect(client).toHaveProperty('transactionPlanExecutor');
-        expect(client).toHaveProperty('sendTransactions');
+        expect(client.planTransaction).toBeTypeOf('function');
+        expect(client.planTransactions).toBeTypeOf('function');
+        expect(client.sendTransaction).toBeTypeOf('function');
+        expect(client.sendTransactions).toBeTypeOf('function');
     });
 
     it('derives the WebSocket URL from the RPC URL by default', () => {

--- a/packages/kit-plugin-rpc/test/transaction-plan-executor.test.ts
+++ b/packages/kit-plugin-rpc/test/transaction-plan-executor.test.ts
@@ -20,7 +20,7 @@ import {
 } from '@solana/kit';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 
-import { rpcTransactionPlanExecutor, rpcTransactionPlanner } from '../src';
+import { rpcTransactionPlanExecutor, rpcTransactionPlanner, rpcTransactionPlanSendingExecutor } from '../src';
 
 const MOCK_BLOCKHASH = { blockhash: '11111111111111111111111111111111', lastValidBlockHeight: 0n };
 const MOCK_INSTRUCTION = {
@@ -36,13 +36,17 @@ beforeEach(() => {
     vi.clearAllMocks();
 });
 
-describe('rpcTransactionPlanExecutor', () => {
-    it('provides a transactionPlanExecutor on the client', () => {
+describe('rpcTransactionPlanSendingExecutor', () => {
+    it('adds sendTransaction and sendTransactions to the client', async () => {
+        const payer = await generateKeyPairSigner();
         const rpc = {} as Rpc<SolanaRpcApi>;
         const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
         const client = createClient()
-            .use(() => ({ rpc, rpcSubscriptions }))
-            .use(rpcTransactionPlanExecutor());
+            .use(() => ({ payer, rpc, rpcSubscriptions }))
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor());
+        expect(client).toHaveProperty('sendTransaction');
+        expect(client).toHaveProperty('sendTransactions');
         expect(client).toHaveProperty('transactionPlanExecutor');
     });
 
@@ -61,7 +65,7 @@ describe('rpcTransactionPlanExecutor', () => {
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
             .use(rpcTransactionPlanner())
-            .use(rpcTransactionPlanExecutor());
+            .use(rpcTransactionPlanSendingExecutor());
 
         const instructionPlan = singleInstructionPlan(MOCK_INSTRUCTION);
         const transactionPlan = await client.transactionPlanner(instructionPlan);
@@ -88,7 +92,8 @@ describe('rpcTransactionPlanExecutor', () => {
 
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
-            .use(rpcTransactionPlanExecutor());
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor());
 
         await client.transactionPlanExecutor(
             singleTransactionPlan(setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }))),
@@ -118,7 +123,8 @@ describe('rpcTransactionPlanExecutor', () => {
 
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
-            .use(rpcTransactionPlanExecutor());
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor());
 
         // Create a transaction message with an explicit (non-provisory) compute unit limit.
         const txMessage = pipe(
@@ -152,7 +158,8 @@ describe('rpcTransactionPlanExecutor', () => {
 
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
-            .use(rpcTransactionPlanExecutor({ skipPreflight: true }));
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor({ skipPreflight: true }));
 
         // Create a transaction message with an explicit (non-provisory) compute unit limit.
         const txMessage = pipe(
@@ -188,7 +195,8 @@ describe('rpcTransactionPlanExecutor', () => {
 
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
-            .use(rpcTransactionPlanExecutor());
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor());
 
         const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
         const promise = client.transactionPlanExecutor(singleTransactionPlan(txMessage));
@@ -216,7 +224,8 @@ describe('rpcTransactionPlanExecutor', () => {
 
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
-            .use(rpcTransactionPlanExecutor({ skipPreflight: true }));
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor({ skipPreflight: true }));
 
         const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
         await client.transactionPlanExecutor(singleTransactionPlan(txMessage));
@@ -245,7 +254,8 @@ describe('rpcTransactionPlanExecutor', () => {
 
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
-            .use(rpcTransactionPlanExecutor());
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor());
 
         const txMessage = setTransactionMessageFeePayerSigner(
             payer,
@@ -278,7 +288,8 @@ describe('rpcTransactionPlanExecutor', () => {
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
             // Even with skipPreflight, a missing data size cannot be recovered.
-            .use(rpcTransactionPlanExecutor({ skipPreflight: true }));
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor({ skipPreflight: true }));
 
         const txMessage = setTransactionMessageFeePayerSigner(
             payer,
@@ -309,7 +320,8 @@ describe('rpcTransactionPlanExecutor', () => {
 
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
-            .use(rpcTransactionPlanExecutor({ skipPreflight: true }));
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor({ skipPreflight: true }));
 
         const txMessage = setTransactionMessageFeePayerSigner(
             payer,
@@ -339,7 +351,8 @@ describe('rpcTransactionPlanExecutor', () => {
 
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
-            .use(rpcTransactionPlanExecutor());
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor());
 
         // Both applicable resource limits are explicit, so no estimation is needed.
         const txMessage = pipe(
@@ -376,7 +389,7 @@ describe('rpcTransactionPlanExecutor', () => {
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
             .use(rpcTransactionPlanner({ estimateResourceLimits: false }))
-            .use(rpcTransactionPlanExecutor({ estimateResourceLimits: false }));
+            .use(rpcTransactionPlanSendingExecutor({ estimateResourceLimits: false }));
 
         const transactionPlan = await client.transactionPlanner(singleInstructionPlan(MOCK_INSTRUCTION));
         await client.transactionPlanExecutor(transactionPlan);
@@ -406,7 +419,7 @@ describe('rpcTransactionPlanExecutor', () => {
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
             .use(rpcTransactionPlanner({ estimateResourceLimits: false }))
-            .use(rpcTransactionPlanExecutor({ estimateResourceLimits: false, skipPreflight: true }));
+            .use(rpcTransactionPlanSendingExecutor({ estimateResourceLimits: false, skipPreflight: true }));
 
         const transactionPlan = await client.transactionPlanner(singleInstructionPlan(MOCK_INSTRUCTION));
         await client.transactionPlanExecutor(transactionPlan);
@@ -435,7 +448,8 @@ describe('rpcTransactionPlanExecutor', () => {
 
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
-            .use(rpcTransactionPlanExecutor());
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor());
 
         const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
         const result = (await client.transactionPlanExecutor(
@@ -462,7 +476,8 @@ describe('rpcTransactionPlanExecutor', () => {
 
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
-            .use(rpcTransactionPlanExecutor());
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor());
 
         const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
         const result = (await client.transactionPlanExecutor(
@@ -489,7 +504,8 @@ describe('rpcTransactionPlanExecutor', () => {
 
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
-            .use(rpcTransactionPlanExecutor());
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor());
 
         const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
         const result = (await client.transactionPlanExecutor(
@@ -514,7 +530,8 @@ describe('rpcTransactionPlanExecutor', () => {
         const getComputeUnitLimitFromEstimate = vi.fn((estimatedComputeUnits: number) => estimatedComputeUnits * 2);
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
-            .use(rpcTransactionPlanExecutor({ getComputeUnitLimitFromEstimate }));
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor({ getComputeUnitLimitFromEstimate }));
 
         const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
         const result = (await client.transactionPlanExecutor(
@@ -543,7 +560,8 @@ describe('rpcTransactionPlanExecutor', () => {
 
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
-            .use(rpcTransactionPlanExecutor({ skipPreflight: true }));
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor({ skipPreflight: true }));
 
         const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
         const result = (await client.transactionPlanExecutor(
@@ -569,7 +587,8 @@ describe('rpcTransactionPlanExecutor', () => {
 
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
-            .use(rpcTransactionPlanExecutor());
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor());
 
         const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
         const result = (await client.transactionPlanExecutor(
@@ -594,7 +613,8 @@ describe('rpcTransactionPlanExecutor', () => {
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
             // A custom function that returns an out-of-range value must still be capped.
-            .use(rpcTransactionPlanExecutor({ getComputeUnitLimitFromEstimate: () => 2_000_000 }));
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor({ getComputeUnitLimitFromEstimate: () => 2_000_000 }));
 
         const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
         const result = (await client.transactionPlanExecutor(
@@ -622,7 +642,7 @@ describe('rpcTransactionPlanExecutor', () => {
         const client = createClient()
             .use(() => ({ payer, rpc, rpcSubscriptions }))
             .use(rpcTransactionPlanner())
-            .use(rpcTransactionPlanExecutor({ maxConcurrency: 2 }));
+            .use(rpcTransactionPlanSendingExecutor({ maxConcurrency: 2 }));
 
         const singlePlan = await client.transactionPlanner(singleInstructionPlan(MOCK_INSTRUCTION));
         const transactionPlan = parallelTransactionPlan([singlePlan, singlePlan, singlePlan, singlePlan]);
@@ -654,7 +674,7 @@ describe('rpcTransactionPlanExecutor', () => {
             createClient()
                 .use(() => ({ rpcSubscriptions }))
                 // @ts-expect-error Missing RPC on the client.
-                .use(rpcTransactionPlanExecutor()),
+                .use(rpcTransactionPlanSendingExecutor()),
         ).toThrow();
     });
 
@@ -664,7 +684,27 @@ describe('rpcTransactionPlanExecutor', () => {
             createClient()
                 .use(() => ({ rpc }))
                 // @ts-expect-error Missing RPC Subscriptions on the client.
-                .use(rpcTransactionPlanExecutor()),
+                .use(rpcTransactionPlanSendingExecutor()),
         ).toThrow();
+    });
+});
+
+describe('rpcTransactionPlanExecutor', () => {
+    it('sets the deprecated transactionPlanExecutor field without requiring a planner', () => {
+        const rpc = {} as Rpc<SolanaRpcApi>;
+        const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        const client = createClient()
+            .use(() => ({ rpc, rpcSubscriptions }))
+            .use(rpcTransactionPlanExecutor());
+        expect(client).toHaveProperty('transactionPlanExecutor');
+        expect(client).not.toHaveProperty('sendTransaction');
+        expect(client).not.toHaveProperty('sendTransactions');
+    });
+
+    it('requires an RPC instance on the client', () => {
+        // @ts-expect-error Missing RPC and RPC Subscriptions on the client.
+        expect(() => createClient().use(rpcTransactionPlanExecutor())).toThrow(
+            /An RPC instance with subscriptions is required/,
+        );
     });
 });

--- a/packages/kit-plugin-rpc/test/transaction-planner.test.ts
+++ b/packages/kit-plugin-rpc/test/transaction-planner.test.ts
@@ -40,6 +40,24 @@ describe('rpcTransactionPlanner', () => {
         expect(transactionPlan.message.feePayer).toBe(payer);
     });
 
+    it('reads client.payer at plan time rather than at install time', async () => {
+        const first = await generateKeyPairSigner();
+        const second = await generateKeyPairSigner();
+        let current = first;
+        const client = createClient()
+            .use(() => ({
+                get payer() {
+                    return current;
+                },
+            }))
+            .use(rpcTransactionPlanner());
+
+        current = second;
+        const instructionPlan = singleInstructionPlan(MOCK_INSTRUCTION);
+        const transactionMessage = await client.planTransaction(instructionPlan);
+        expect(transactionMessage.feePayer.address).toBe(second.address);
+    });
+
     it('creates version 0 transaction messages by default', async () => {
         const payer = await generateKeyPairSigner();
         const client = createClient()

--- a/packages/kit-plugin-wallet/README.md
+++ b/packages/kit-plugin-wallet/README.md
@@ -30,12 +30,10 @@ pnpm install @solana/kit-plugin-wallet
 import { createClient } from '@solana/kit';
 import { solanaRpc } from '@solana/kit-plugin-rpc';
 import { walletSigner } from '@solana/kit-plugin-wallet';
-import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
 
 const client = createClient()
     .use(walletSigner({ chain: 'solana:mainnet' }))
-    .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
-    .use(planAndSendTransactions());
+    .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
 
 // Read discovered wallets from state
 const { wallets } = client.wallet.getState();
@@ -56,8 +54,7 @@ import { walletSigner } from '@solana/kit-plugin-wallet';
 
 const client = createClient()
     .use(walletSigner({ chain: 'solana:mainnet' }))
-    .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
-    .use(planAndSendTransactions());
+    .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
 ```
 
 ## `walletPayer` plugin
@@ -69,8 +66,7 @@ import { walletPayer } from '@solana/kit-plugin-wallet';
 
 const client = createClient()
     .use(walletPayer({ chain: 'solana:mainnet' }))
-    .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
-    .use(planAndSendTransactions());
+    .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
 ```
 
 ## `walletIdentity` plugin
@@ -84,8 +80,7 @@ import { walletIdentity } from '@solana/kit-plugin-wallet';
 const client = createClient()
     .use(payer(relayerKeypair))
     .use(walletIdentity({ chain: 'solana:mainnet' }))
-    .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
-    .use(planAndSendTransactions());
+    .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
 
 // client.payer is always relayerKeypair
 // client.identity is the connected wallet's signer
@@ -102,8 +97,7 @@ import { walletWithoutSigner } from '@solana/kit-plugin-wallet';
 const client = createClient()
     .use(payer(backendKeypair))
     .use(walletWithoutSigner({ chain: 'solana:mainnet' }))
-    .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
-    .use(planAndSendTransactions());
+    .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
 
 // client.payer is always backendKeypair
 // client.wallet.getState().connected?.signer for manual use
@@ -377,8 +371,7 @@ React Native is treated the same way as the server: wallet-standard browser disc
 ```ts
 const client = createClient()
     .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
-    .use(walletSigner({ chain: 'solana:mainnet' }))
-    .use(planAndSendTransactions());
+    .use(walletSigner({ chain: 'solana:mainnet' }));
 
 // Server: status === 'pending', client.payer throws
 // Browser: auto-connects, client.payer becomes the wallet signer

--- a/packages/kit-plugin-wallet/src/wallet.ts
+++ b/packages/kit-plugin-wallet/src/wallet.ts
@@ -96,8 +96,7 @@ function createPlugin<TAdditions extends ClientWithWallet>(
  * ```ts
  * const client = createClient()
  *   .use(walletSigner({ chain: 'solana:mainnet' }))
- *   .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
- *   .use(planAndSendTransactions());
+ *   .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
  * ```
  *
  * @param config - Plugin configuration.
@@ -135,8 +134,7 @@ export function walletSigner(config: WalletPluginConfig) {
  * const client = createClient()
  *   .use(payer(relayerKeypair))
  *   .use(walletIdentity({ chain: 'solana:mainnet' }))
- *   .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
- *   .use(planAndSendTransactions());
+ *   .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
  * ```
  *
  * @param config - Plugin configuration.
@@ -168,8 +166,7 @@ export function walletIdentity(config: WalletPluginConfig) {
  * ```ts
  * const client = createClient()
  *   .use(walletPayer({ chain: 'solana:mainnet' }))
- *   .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
- *   .use(planAndSendTransactions());
+ *   .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
  * ```
  *
  * @param config - Plugin configuration.
@@ -199,8 +196,7 @@ export function walletPayer(config: WalletPluginConfig) {
  * const client = createClient()
  *   .use(payer(backendKeypair))
  *   .use(walletWithoutSigner({ chain: 'solana:mainnet' }))
- *   .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
- *   .use(planAndSendTransactions());
+ *   .use(solanaRpc({ rpcUrl: 'https://api.mainnet-beta.solana.com' }));
  *
  * // client.payer is always backendKeypair
  * // client.wallet.getState().connected?.signer for manual use


### PR DESCRIPTION
We plan to add functions for `client.signTransaction(s)`, which will be backed by an independent transaction plan executor. This PR addresses 2 concerns with this: first, deprecating the single `client.transactionPlanExecutor`, and secondly re-working how we add the plan and send functions to be more extensible.

- The `transactionPlanner` plugin now adds `planTransaction(s)` functions
- The `transactionPlanExecutor` plugin is deprecated
- It's replaced by a new `transactionPlanSendingExecutor`, which adds `sendTransaction(s)` functions, and consumes the `planTransaction(s)` functions already on the client
- `transactionPlanner` and `transactionPlanExecutor` are still written to the client, but both are deprecated. The `plan/sendTransaction(s)` functions should be used instead.
- In the `rpc` and `litesvm` packages, we refactor plugins like `rpcTransactionPlanner` to call the `transactionPlanner` plugin from the instruction-plans package. This is necessary because the instruction-plans plugin now adds the actual `planTransaction(s)` functions. Previously it just wrote `transactionPlanner` to the client and `kit-plugin-rpc` just did that itself.
- The `planAndSendTransactions` plugin is now deprecated, it's no longer needed as other plugins add the `plan/sendTransaction(s)` functions.

This PR is non-breaking, and everything that is deprecated works the same way it always has. Higher-level plugins like `solanaRpc` and `litesvm` have an unchanged API.