### PR TITLE
feat(wallet): expose reconnecting account

### DIFF
--- a/.changeset/spotty-donkeys-change.md
+++ b/.changeset/spotty-donkeys-change.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-wallet': minor
+---
+
+Add `reconnectingTo` to wallet state so apps can display the persisted account while silent reconnection is in progress.

--- a/packages/kit-plugin-wallet/README.md
+++ b/packages/kit-plugin-wallet/README.md
@@ -125,6 +125,8 @@ All wallet state is accessed via `client.wallet.getState()`, which returns a ref
 
 - **`getState().status`** — The current connection status: `'pending'`, `'disconnected'`, `'connecting'`, `'connected'`, `'disconnecting'`, or `'reconnecting'`.
 
+- **`getState().reconnectingTo`** — The persisted account currently being reconnected, or `null` when it is unavailable. Use this to keep the wallet identity visible with a loading indicator during silent reconnect; no signer is exposed until the connection succeeds.
+
 - **`connect(wallet)`** — Connect to a wallet and select the first newly authorized account.
 
     ```ts

--- a/packages/kit-plugin-wallet/src/store.ts
+++ b/packages/kit-plugin-wallet/src/store.ts
@@ -169,6 +169,8 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
 
     function updateState(updates: Partial<WalletStoreState>): void {
         const prev = state;
+        // Maintain the invariant: `reconnectingTo` is only populated when status === 'reconnecting'.
+        // If a future call site passes an explicit `reconnectingTo` with a non-reconnecting status, this clears it.
         const nextUpdates =
             updates.status !== undefined && updates.status !== 'reconnecting'
                 ? { ...updates, reconnectingTo: null }

--- a/packages/kit-plugin-wallet/src/store.ts
+++ b/packages/kit-plugin-wallet/src/store.ts
@@ -57,6 +57,7 @@ export type WalletStore = WalletNamespace & {
 type WalletStoreState = {
     account: UiWalletAccount | null;
     connectedWallet: UiWallet | null;
+    reconnectingTo: UiWalletAccount | null;
     signer: WalletSigner | null;
     status: WalletStatus;
     wallets: readonly UiWallet[];
@@ -71,6 +72,7 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
     if (!__BROWSER__ || __REACTNATIVE__) {
         const ssrSnapshot: WalletState = Object.freeze({
             connected: null,
+            reconnectingTo: null,
             status: 'pending' as const,
             wallets: Object.freeze([]) as readonly UiWallet[],
         });
@@ -97,6 +99,7 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
     let state: WalletStoreState = {
         account: null,
         connectedWallet: null,
+        reconnectingTo: null,
         signer: null,
         status: 'pending',
         wallets: [],
@@ -149,6 +152,7 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
                           wallet: s.connectedWallet,
                       })
                     : null,
+            reconnectingTo: s.status === 'reconnecting' ? s.reconnectingTo : null,
             status: s.status,
             wallets: s.wallets,
         });
@@ -165,7 +169,11 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
 
     function updateState(updates: Partial<WalletStoreState>): void {
         const prev = state;
-        state = { ...state, ...updates };
+        const nextUpdates =
+            updates.status !== undefined && updates.status !== 'reconnecting'
+                ? { ...updates, reconnectingTo: null }
+                : updates;
+        state = { ...state, ...nextUpdates };
 
         // Resolve `whenReady` the moment the status leaves the transient
         // warm-up set. `readyDeferred` is only ever created while transient (in
@@ -187,6 +195,7 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
         if (
             state.connectedWallet !== prev.connectedWallet ||
             state.account !== prev.account ||
+            state.reconnectingTo !== prev.reconnectingTo ||
             state.status !== prev.status ||
             state.signer !== prev.signer ||
             state.wallets !== prev.wallets
@@ -829,7 +838,7 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
                 clearPersistedAccount();
             } else {
                 // Wallet not registered yet — wait for it to appear.
-                updateState({ status: 'reconnecting' });
+                updateState({ reconnectingTo: null, status: 'reconnecting' });
 
                 // Change state to disconnected after 3s
                 // Note that the listener stays alive until reconnect is cancelled, so this is
@@ -894,7 +903,8 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
 
     async function attemptSilentReconnect(savedAddress: string, uiWallet: UiWallet): Promise<void> {
         const generation = ++connectGeneration;
-        updateState({ status: 'reconnecting' });
+        const reconnectingTo = uiWallet.accounts.find(account => account.address === savedAddress) ?? null;
+        updateState({ reconnectingTo, status: 'reconnecting' });
 
         try {
             const connectFeature = getWalletFeature(

--- a/packages/kit-plugin-wallet/src/types.ts
+++ b/packages/kit-plugin-wallet/src/types.ts
@@ -61,6 +61,15 @@ export type WalletState = {
         readonly signer: WalletSigner | null;
         readonly wallet: UiWallet;
     } | null;
+    /**
+     * The persisted account currently being reconnected, or `null` when no
+     * reconnect is in progress or the wallet has not exposed that account yet.
+     *
+     * This account is informational only and does not include a signer. Use it
+     * to keep the previous wallet identity visible while `status` is
+     * `'reconnecting'`.
+     */
+    readonly reconnectingTo: UiWalletAccount | null;
     /** The current connection status. */
     readonly status: WalletStatus;
     /** All discovered wallets matching the configured chain and filter. */

--- a/packages/kit-plugin-wallet/test/store.test.ts
+++ b/packages/kit-plugin-wallet/test/store.test.ts
@@ -32,6 +32,7 @@ describe.skipIf(__BROWSER__)('store (SSR / non-browser)', () => {
         expect(store.getState().status).toBe('pending');
         expect(store.getState().wallets).toEqual([]);
         expect(store.getState().connected).toBeNull();
+        expect(store.getState().reconnectingTo).toBeNull();
     });
 
     it('throws for connect on server', async () => {
@@ -89,6 +90,7 @@ describe.skipIf(!__BROWSER__)('store (browser)', () => {
     it('starts in disconnected status when no storage/autoConnect', () => {
         const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
         expect(store.getState().status).toBe('disconnected');
+        expect(store.getState().reconnectingTo).toBeNull();
     });
 
     it('discovers registered wallets', () => {
@@ -2296,6 +2298,32 @@ describe.skipIf(!__BROWSER__)('store auto-connect (browser)', () => {
         expect(setItem).not.toHaveBeenCalled();
     });
 
+    it('exposes the saved account while a silent reconnect is in flight', async () => {
+        const account = createMockAccount();
+        const mockWallet = createMockUiWallet({
+            accounts: [account],
+            name: 'TestWallet',
+        });
+        registerWallet(mockWallet);
+
+        const reconnect = Promise.withResolvers<void>();
+        connectMock.mockReturnValueOnce(reconnect.promise);
+        const storage = createMockStorage({ 'kit-wallet': `TestWallet:${account.address}` });
+        const store = createWalletStore({ chain: 'solana:mainnet', storage });
+
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(store.getState().status).toBe('reconnecting');
+        expect(store.getState().reconnectingTo).toBe(account);
+        expect(store.getState().connected).toBeNull();
+
+        reconnect.resolve();
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(store.getState().status).toBe('connected');
+        expect(store.getState().reconnectingTo).toBeNull();
+    });
+
     it('falls back to disconnected when storage read rejects', async () => {
         const storage: WalletStorage = {
             getItem: () => Promise.reject(new Error('storage unavailable')),
@@ -2391,6 +2419,7 @@ describe.skipIf(!__BROWSER__)('store late wallet registration (browser)', () => 
 
         // Wallet not registered yet — should be reconnecting.
         expect(store.getState().status).toBe('reconnecting');
+        expect(store.getState().reconnectingTo).toBeNull();
 
         // Wallet registers late.
         const lateWallet = createMockUiWallet({
@@ -2411,6 +2440,7 @@ describe.skipIf(!__BROWSER__)('store late wallet registration (browser)', () => 
 
         await vi.advanceTimersByTimeAsync(0);
         expect(store.getState().status).toBe('reconnecting');
+        expect(store.getState().reconnectingTo).toBeNull();
 
         await vi.advanceTimersByTimeAsync(3000);
         expect(store.getState().status).toBe('disconnected');
@@ -2436,6 +2466,7 @@ describe.skipIf(!__BROWSER__)('store late wallet registration (browser)', () => 
         await vi.advanceTimersByTimeAsync(0);
 
         expect(store.getState().status).toBe('connected');
+        expect(store.getState().reconnectingTo).toBeNull();
         expect(store.getState().connected!.account.address).toBe(account.address);
     });
 
@@ -2999,6 +3030,7 @@ describe.skipIf(!__BROWSER__)('store whenReady (browser)', () => {
 
         await vi.advanceTimersByTimeAsync(0);
         expect(store.getState().status).toBe('reconnecting');
+        expect(store.getState().reconnectingTo).toBe(account);
         // Same transient episode — still the same promise.
         expect(store.whenReady()).toBe(p);
         // If `p` were already resolved the race would pick 'ready'; it is still pending.
@@ -3008,6 +3040,7 @@ describe.skipIf(!__BROWSER__)('store whenReady (browser)', () => {
         reconnect.resolve();
         await vi.advanceTimersByTimeAsync(0);
         expect(store.getState().status).toBe('connected');
+        expect(store.getState().reconnectingTo).toBeNull();
         await expect(p).resolves.toBeUndefined();
 
         // After settling, a fresh call returns an already-resolved promise, not the old one.

--- a/packages/kit-plugin-wallet/test/store.test.ts
+++ b/packages/kit-plugin-wallet/test/store.test.ts
@@ -2324,6 +2324,31 @@ describe.skipIf(!__BROWSER__)('store auto-connect (browser)', () => {
         expect(store.getState().reconnectingTo).toBeNull();
     });
 
+    it('exposes null reconnectingTo while silent reconnecting if saved account is missing', async () => {
+        const account = createMockAccount();
+        // Wallet doesn't include the saved account
+        const mockWallet = createMockUiWallet({
+            accounts: [],
+            name: 'TestWallet',
+        });
+        registerWallet(mockWallet);
+
+        const reconnect = Promise.withResolvers<void>();
+        connectMock.mockReturnValueOnce(reconnect.promise);
+        const storage = createMockStorage({ 'kit-wallet': `TestWallet:${account.address}` });
+        const store = createWalletStore({ chain: 'solana:mainnet', storage });
+
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(store.getState().status).toBe('reconnecting');
+        expect(store.getState().reconnectingTo).toBeNull();
+
+        reconnect.resolve();
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(store.getState().status).toBe('disconnected');
+    });
+
     it('falls back to disconnected when storage read rejects', async () => {
         const storage: WalletStorage = {
             getItem: () => Promise.reject(new Error('storage unavailable')),
@@ -2421,6 +2446,9 @@ describe.skipIf(!__BROWSER__)('store late wallet registration (browser)', () => 
         expect(store.getState().status).toBe('reconnecting');
         expect(store.getState().reconnectingTo).toBeNull();
 
+        const reconnect = Promise.withResolvers<void>();
+        connectMock.mockReturnValueOnce(reconnect.promise);
+
         // Wallet registers late.
         const lateWallet = createMockUiWallet({
             accounts: [account],
@@ -2428,6 +2456,12 @@ describe.skipIf(!__BROWSER__)('store late wallet registration (browser)', () => 
         });
         lateRegisterWallet(lateWallet);
 
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(store.getState().status).toBe('reconnecting');
+        expect(store.getState().reconnectingTo).toBe(account);
+
+        reconnect.resolve();
         await vi.advanceTimersByTimeAsync(0);
 
         expect(store.getState().status).toBe('connected');

--- a/packages/kit-plugin-wallet/test/useWalletState.react.test.tsx
+++ b/packages/kit-plugin-wallet/test/useWalletState.react.test.tsx
@@ -34,7 +34,7 @@ function clientFor(wallet: object): ClientWithWallet {
     return { wallet } as never;
 }
 
-const INITIAL: WalletState = { connected: null, status: 'disconnected', wallets: [] };
+const INITIAL: WalletState = { connected: null, reconnectingTo: null, status: 'disconnected', wallets: [] };
 
 describe('useWalletStatus', () => {
     it('returns the current status and updates when it changes', () => {


### PR DESCRIPTION
Expose the persisted wallet account through getState().reconnectingTo while silent reconnection is in progress, without exposing a signer before the connection succeeds. The field stays null when the wallet has not registered or has not exposed the saved account, and is cleared whenever reconnecting settles.

This updates the public state documentation, adds a minor changeset, and covers browser, SSR, delayed registration, successful reconnect, and readiness transitions.

Validation:
- pnpm --dir packages/kit-plugin-wallet test:unit (187 passed)
- pnpm --dir packages/kit-plugin-wallet test:types
- pnpm --dir packages/kit-plugin-wallet build
- targeted oxlint and oxfmt --check

Closes #350
