### PR TITLE
Fix dataSlice being ignored by LiteSVM getAccountInfo and getMultipleAccounts

### DIFF
--- a/.changeset/hip-deserts-switch.md
+++ b/.changeset/hip-deserts-switch.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-litesvm': patch
+---
+
+Fix `getAccountInfo` and `getMultipleAccounts` on the LiteSVM RPC silently ignoring the `dataSlice` config option. Both now return the requested byte range while preserving the account's full `space`, matching `getProgramAccounts` and the Solana JSON-RPC API.

--- a/packages/kit-plugin-litesvm/src/litesvm-to-rpc.ts
+++ b/packages/kit-plugin-litesvm/src/litesvm-to-rpc.ts
@@ -106,15 +106,16 @@ export function createRpcFromSvm(svm: LiteSVM): Rpc<LiteSvmRpcApi> {
     };
     const convertMaybeEncodedAccount = (
         account: MaybeEncodedAccount,
+        dataSlice?: DataSlice,
     ): (AccountInfoBase & AccountInfoWithBase64EncodedData) | null => {
-        return account.exists ? encodeAccountBase64(account) : null;
+        return account.exists ? encodeAccountBase64(account, dataSlice) : null;
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const supportedApi: Record<keyof LiteSvmRpcApi, (...args: any[]) => unknown> = {
-        getAccountInfo: (address: Address, config?: { encoding?: Encoding }) => {
+        getAccountInfo: (address: Address, config?: { dataSlice?: DataSlice; encoding?: Encoding }) => {
             assertEncodingIsBase64(config?.encoding);
-            const response = convertMaybeEncodedAccount(svm.getAccount(address));
+            const response = convertMaybeEncodedAccount(svm.getAccount(address), config?.dataSlice);
             return withContext(response, svm.getClock().slot);
         },
         getBalance: (address: Address) => {
@@ -138,9 +139,14 @@ export function createRpcFromSvm(svm: LiteSVM): Rpc<LiteSvmRpcApi> {
         getMinimumBalanceForRentExemption: (size: bigint) => {
             return lamports(svm.minimumBalanceForRentExemption(size));
         },
-        getMultipleAccounts: (addresses: readonly Address[], config?: { encoding?: Encoding }) => {
+        getMultipleAccounts: (
+            addresses: readonly Address[],
+            config?: { dataSlice?: DataSlice; encoding?: Encoding },
+        ) => {
             assertEncodingIsBase64(config?.encoding);
-            const response = addresses.map(address => convertMaybeEncodedAccount(svm.getAccount(address)));
+            const response = addresses.map(address =>
+                convertMaybeEncodedAccount(svm.getAccount(address), config?.dataSlice),
+            );
             return withContext(response, svm.getClock().slot);
         },
         getProgramAccounts: (programId: Address, config?: GetProgramAccountsConfig) => {

--- a/packages/kit-plugin-litesvm/test/litesvm-to-rpc.test.ts
+++ b/packages/kit-plugin-litesvm/test/litesvm-to-rpc.test.ts
@@ -54,6 +54,31 @@ describe('createRpcFromSvm', () => {
         expect(value).toBeNull();
     });
 
+    it('slices the data of an account while preserving the full account space', async () => {
+        const client = createClient().use(litesvm());
+        const accountAddress = await generateKeyPairSigner().then(signer => signer.address);
+
+        client.svm.setAccount({
+            address: accountAddress,
+            data: new Uint8Array([10, 20, 30, 40]),
+            executable: false,
+            lamports: lamports(1_000_000n),
+            programAddress: address('11111111111111111111111111111111'),
+            space: 4n,
+        });
+
+        const { value } = await client.rpc
+            .getAccountInfo(accountAddress, { dataSlice: { length: 2, offset: 1 }, encoding: 'base64' })
+            .send();
+        expect(value).toEqual({
+            data: ['FB4=', 'base64'],
+            executable: false,
+            lamports: lamports(1_000_000n),
+            owner: address('11111111111111111111111111111111'),
+            space: 4n,
+        });
+    });
+
     it('can fetch multiple accounts set on the svm', async () => {
         const client = createClient().use(litesvm());
 
@@ -98,6 +123,49 @@ describe('createRpcFromSvm', () => {
             space: 4n,
         });
         expect(value[2]).toBeNull();
+    });
+
+    it('slices the data of multiple accounts while preserving the full account space', async () => {
+        const client = createClient().use(litesvm());
+        const [addressA, addressB] = await Promise.all([
+            generateKeyPairSigner().then(signer => signer.address),
+            generateKeyPairSigner().then(signer => signer.address),
+        ]);
+
+        client.svm.setAccount({
+            address: addressA,
+            data: new Uint8Array([10, 20, 30, 40]),
+            executable: false,
+            lamports: lamports(1_000_000n),
+            programAddress: address('11111111111111111111111111111111'),
+            space: 4n,
+        });
+        client.svm.setAccount({
+            address: addressB,
+            data: new Uint8Array([50, 60, 70, 80]),
+            executable: false,
+            lamports: lamports(2_000_000n),
+            programAddress: address('11111111111111111111111111111111'),
+            space: 4n,
+        });
+
+        const { value } = await client.rpc
+            .getMultipleAccounts([addressA, addressB], { dataSlice: { length: 2, offset: 1 }, encoding: 'base64' })
+            .send();
+        expect(value[0]).toEqual({
+            data: ['FB4=', 'base64'],
+            executable: false,
+            lamports: lamports(1_000_000n),
+            owner: address('11111111111111111111111111111111'),
+            space: 4n,
+        });
+        expect(value[1]).toEqual({
+            data: ['PEY=', 'base64'],
+            executable: false,
+            lamports: lamports(2_000_000n),
+            owner: address('11111111111111111111111111111111'),
+            space: 4n,
+        });
     });
 
     it('can fetch the balance of an account set on the svm', async () => {


### PR DESCRIPTION
The LiteSVM RPC's `getProgramAccounts` honors the `dataSlice` config option, but `getAccountInfo` and `getMultipleAccounts` silently ignored it and always returned the full account data. Their config type only listed `encoding`, and `convertMaybeEncodedAccount` never forwarded a slice to the existing `encodeAccountBase64` helper.

This threads `dataSlice` through both methods so they return the requested byte range while preserving the account's full `space`, matching `getProgramAccounts` and the Solana JSON-RPC API. Adds a test for each method covering the slice-with-full-space behavior.
