### PR TITLE
Wallet: Add a useReconnectingAccount react hook

### DIFF
--- a/.changeset/purple-bats-guess.md
+++ b/.changeset/purple-bats-guess.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-wallet': minor
+---
+
+Add a `useReconnectingAccount` React hook that subscribes to the `reconnectingTo` field of the wallet state — the persisted account currently being auto-reconnected, or `null` when no reconnect is in progress.

--- a/packages/kit-plugin-wallet/README.md
+++ b/packages/kit-plugin-wallet/README.md
@@ -171,12 +171,13 @@ The `@solana/kit-plugin-wallet/react` subpath exposes hooks for reading wallet s
 
 The **state** hooks subscribe via `useSyncExternalStore`, each to a single slice of `WalletState`, so a component only re-renders when the slice it reads changes:
 
-| Hook                 | Returns                                                                          |
-| -------------------- | -------------------------------------------------------------------------------- |
-| `useWalletStatus`    | The current `WalletStatus`.                                                      |
-| `useConnectedWallet` | The active connection (`{ account, signer, wallet }`) or null.                   |
-| `useWallets`         | The discovered wallets for the client's chain.                                   |
-| `useIsWalletReady`   | `false` while the initial warm-up is in progress (`'pending'`/`'reconnecting'`). |
+| Hook                     | Returns                                                                          |
+| ------------------------ | -------------------------------------------------------------------------------- |
+| `useWalletStatus`        | The current `WalletStatus`.                                                      |
+| `useConnectedWallet`     | The active connection (`{ account, signer, wallet }`) or null.                   |
+| `useReconnectingAccount` | The persisted account being auto-reconnected, or null.                           |
+| `useWallets`             | The discovered wallets for the client's chain.                                   |
+| `useIsWalletReady`       | `false` while the initial warm-up is in progress (`'pending'`/`'reconnecting'`). |
 
 The **action** hooks wrap the async wallet actions with `useAction` from `@solana/react`, returning its result (`dispatch`, `dispatchAsync`, `data`, `error`, `status`, `isRunning`, `reset`, …). The hook manages the `AbortSignal` internally, so an in-flight call is aborted when a newer one is dispatched:
 

--- a/packages/kit-plugin-wallet/src/react/__typetests__/index.ts
+++ b/packages/kit-plugin-wallet/src/react/__typetests__/index.ts
@@ -9,6 +9,7 @@ import {
     useConnectedWallet,
     useDisconnect,
     useIsWalletReady,
+    useReconnectingAccount,
     useSelectAccount,
     useSignIn,
     useSignMessage,
@@ -60,6 +61,15 @@ const client = null as unknown as ClientWithWallet;
     connected satisfies WalletState['connected'];
     // The connection is nullable when disconnected.
     connected satisfies { account: UiWalletAccount } | null;
+}
+
+// [DESCRIBE] useReconnectingAccount
+{
+    const reconnectingTo = useReconnectingAccount(client);
+    // The account is nullable when no reconnect is in progress.
+    reconnectingTo satisfies UiWalletAccount | null;
+    // The return type stays assignable to the state slice it reads.
+    reconnectingTo satisfies WalletState['reconnectingTo'];
 }
 
 // [DESCRIBE] useWallets

--- a/packages/kit-plugin-wallet/src/react/index.ts
+++ b/packages/kit-plugin-wallet/src/react/index.ts
@@ -60,6 +60,33 @@ export function useConnectedWallet(client: ClientWithWallet): WalletState['conne
 }
 
 /**
+ * Subscribes to the account being auto-reconnected from a React component.
+ *
+ * Wraps `client.wallet.subscribe` / `getState` with `useSyncExternalStore`, re-rendering only when
+ * the reconnecting account changes.
+ *
+ * @param client - A client with a wallet plugin installed (e.g. `walletSigner()`).
+ * @returns The persisted {@link UiWalletAccount} currently being reconnected, or `null` when no
+ *   reconnect is in progress or the wallet has not exposed that account yet. The account is
+ *   informational only (no signer) — use it to keep the previous wallet identity visible while the
+ *   status is `'reconnecting'`.
+ *
+ * @example
+ * ```tsx
+ * const reconnectingTo = useReconnectingAccount(client);
+ * if (reconnectingTo) return <p>Reconnecting to {reconnectingTo.address}…</p>;
+ * ```
+ *
+ * @see {@link useWalletStatus}
+ * @see {@link useConnectedWallet}
+ */
+export function useReconnectingAccount(client: ClientWithWallet): UiWalletAccount | null {
+    const { wallet } = client;
+    const getReconnectingTo = () => wallet.getState().reconnectingTo;
+    return useSyncExternalStore(wallet.subscribe, getReconnectingTo, getReconnectingTo);
+}
+
+/**
  * Subscribes to the list of discovered wallets from a React component.
  *
  * Wraps `client.wallet.subscribe` / `getState` with `useSyncExternalStore`, re-rendering only when

--- a/packages/kit-plugin-wallet/test/useWalletState.react.test.tsx
+++ b/packages/kit-plugin-wallet/test/useWalletState.react.test.tsx
@@ -2,7 +2,13 @@ import { act, cleanup, renderHook } from '@testing-library/react';
 import type { UiWallet } from '@wallet-standard/ui';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { useConnectedWallet, useIsWalletReady, useWallets, useWalletStatus } from '../src/react';
+import {
+    useConnectedWallet,
+    useIsWalletReady,
+    useReconnectingAccount,
+    useWallets,
+    useWalletStatus,
+} from '../src/react';
 import type { ClientWithWallet, WalletState } from '../src/types';
 
 // Unmount rendered trees between tests. This package doesn't enable vitest
@@ -58,6 +64,22 @@ describe('useConnectedWallet', () => {
         const connected = { account: {}, signer: null, wallet: {} } as WalletState['connected'];
         act(() => store.setState({ ...INITIAL, connected, status: 'connected' }));
         expect(result.current).toBe(connected);
+    });
+});
+
+describe('useReconnectingAccount', () => {
+    it('returns the reconnecting account and updates when it changes', () => {
+        const store = createFakeStore(INITIAL);
+        const { result } = renderHook(() => useReconnectingAccount(clientFor(store)));
+
+        expect(result.current).toBeNull();
+
+        const reconnectingTo = {} as WalletState['reconnectingTo'];
+        act(() => store.setState({ ...INITIAL, reconnectingTo, status: 'reconnecting' }));
+        expect(result.current).toBe(reconnectingTo);
+
+        act(() => store.setState({ ...INITIAL, reconnectingTo: null, status: 'connected' }));
+        expect(result.current).toBeNull();
     });
 });
 


### PR DESCRIPTION
Following from #370, this PR exposes the new `reconnectingTo` field of the wallet plugin in a react hook, `useReconnectingAccount`

As with the other hooks in this plugin, the logic all belongs to the react-agnostic plugin state, this hook just wraps it with `useSyncExternalStore`

This allows an app to access the `reconnectingTo` state through a hook that only re-renders when the value changes

Closes: #379 