### PR TITLE
Upgrade to Kit v8.0.0

### DIFF
--- a/.changeset/sunny-eagles-arrive.md
+++ b/.changeset/sunny-eagles-arrive.md
@@ -1,0 +1,9 @@
+---
+'@solana/kit-plugin-instruction-plan': minor
+'@solana/kit-plugin-litesvm': minor
+'@solana/kit-plugin-rpc': minor
+'@solana/kit-plugin-signer': minor
+'@solana/kit-plugin-wallet': minor
+---
+
+Upgrade to Kit v8. All packages now require `@solana/kit@^8.0.0` as a peer dependency, and the wallet plugin additionally requires `@solana/react@^8.0.0` and `@solana/wallet-account-signer@^8.0.0`. Following Kit v8's redesign of transaction plan result contexts, the `transactionPlanSendingExecutor` plugin now propagates the executor's result context type to the `sendTransaction` and `sendTransactions` functions it installs, and the executor plugins default their context to `TransactionPlanResultContextWithSignature` so successful results keep a typed `context.signature` out of the box.

--- a/examples/token-airdrop/package.json
+++ b/examples/token-airdrop/package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "@solana-program/system": "^0.13.0",
         "@solana-program/token": "^0.14.0",
-        "@solana/kit": "^7.1.0",
+        "@solana/kit": "^8.0.0",
         "@solana/kit-plugin-rpc": "workspace:*",
         "@solana/kit-plugin-signer": "workspace:*"
     },

--- a/examples/transfer-lamports/package.json
+++ b/examples/transfer-lamports/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "@solana-program/system": "^0.13.0",
-        "@solana/kit": "^7.1.0",
+        "@solana/kit": "^8.0.0",
         "@solana/kit-plugin-rpc": "workspace:*",
         "@solana/kit-plugin-signer": "workspace:*"
     },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "@changesets/changelog-github": "^1.0.0",
         "@changesets/cli": "^3.0.0",
         "@solana-config/oxc": "^0.1.1",
-        "@solana/kit": "^7.1.0",
+        "@solana/kit": "^8.0.0",
         "@types/node": "^26",
         "agadoo": "^3.0.0",
         "happy-dom": "^20.11.2",

--- a/packages/kit-plugin-instruction-plan/package.json
+++ b/packages/kit-plugin-instruction-plan/package.json
@@ -53,7 +53,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^7.1.0"
+        "@solana/kit": "^8.0.0"
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-plugin-instruction-plan/src/core.ts
+++ b/packages/kit-plugin-instruction-plan/src/core.ts
@@ -19,6 +19,7 @@ import {
     TransactionPlanner,
     TransactionPlanResult,
     TransactionPlanResultContext,
+    TransactionPlanResultContextWithSignature,
 } from '@solana/kit';
 
 /**
@@ -108,7 +109,7 @@ export function transactionPlanner(transactionPlanner: TransactionPlanner) {
  * @see {@link transactionPlanner}
  */
 export function transactionPlanSendingExecutor<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
 >(transactionPlanExecutor: TransactionPlanExecutor<TContext>) {
     return <T extends ClientWithTransactionPlanning>(client: T) => {
         if (!client.planTransaction || !client.planTransactions) {
@@ -117,7 +118,7 @@ export function transactionPlanSendingExecutor<
                     'Please add a transaction planner plugin to your client before using this plugin.',
             );
         }
-        const additions: ClientWithTransactionSending & {
+        const additions: ClientWithTransactionSending<TContext> & {
             /** @deprecated Use `sendTransaction` or `sendTransactions` instead. */
             transactionPlanExecutor: TransactionPlanExecutor<TContext>;
         } = {
@@ -165,9 +166,9 @@ export function transactionPlanSendingExecutor<
  *     .use(transactionPlanSendingExecutor(myTransactionPlanExecutor));
  * ```
  */
-export function transactionPlanExecutor<TContext extends TransactionPlanResultContext = TransactionPlanResultContext>(
-    transactionPlanExecutor: TransactionPlanExecutor<TContext>,
-) {
+export function transactionPlanExecutor<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
+>(transactionPlanExecutor: TransactionPlanExecutor<TContext>) {
     return <T extends object>(client: T) => extendClient(client, { transactionPlanExecutor });
 }
 
@@ -258,11 +259,11 @@ function getTransactionPlanningFunctions(planner: TransactionPlanner): ClientWit
     return { planTransaction, planTransactions };
 }
 
-function getTransactionSendingFunctions(
+function getTransactionSendingFunctions<TContext extends TransactionPlanResultContext>(
     client: ClientWithTransactionPlanning,
-    executor: TransactionPlanExecutor,
-): ClientWithTransactionSending {
-    const sendTransactions: ClientWithTransactionSending['sendTransactions'] = async (input, config = {}) => {
+    executor: TransactionPlanExecutor<TContext>,
+): ClientWithTransactionSending<TContext> {
+    const sendTransactions: ClientWithTransactionSending<TContext>['sendTransactions'] = async (input, config = {}) => {
         const plan = parseInstructionOrTransactionPlanInput(input);
         config?.abortSignal?.throwIfAborted();
         const transactionPlan = isTransactionPlan(plan) ? plan : await client.planTransactions(plan, config);
@@ -280,7 +281,7 @@ function getTransactionSendingFunctions(
         }
     };
 
-    const sendTransaction: ClientWithTransactionSending['sendTransaction'] = async (input, config = {}) => {
+    const sendTransaction: ClientWithTransactionSending<TContext>['sendTransaction'] = async (input, config = {}) => {
         const plan = parseInstructionOrTransactionPlanInput(input);
         config?.abortSignal?.throwIfAborted();
         const transactionPlan = isTransactionPlan(plan)

--- a/packages/kit-plugin-litesvm/README.md
+++ b/packages/kit-plugin-litesvm/README.md
@@ -208,9 +208,9 @@ function logComputeUnits(result: SuccessfulSingleTransactionPlanResult<LiteSvmSe
 }
 ```
 
-Because the context is filled in as execution progresses, a transaction that fails or is canceled part way through carries only what was recorded before it stopped. A future version of Kit will make these fields optional on failed/cancelled results. Treat them as present only on successful results.
+Because the context is filled in as execution progresses, a transaction that fails or is canceled part way through carries only what was recorded before it stopped. Failed and canceled results therefore type the context as partial — only successful results guarantee every field.
 
-Note that `sendTransaction` and `sendTransactions` do not yet propagate this context type — Kit's `ClientWithTransactionSending` interface is not parameterised over it, so their results type the context as Kit's default. The properties above are populated at runtime regardless.
+The `sendTransaction` and `sendTransactions` functions installed by this plugin propagate this context type, so their results carry a typed `LiteSvmSendContext` without any annotation needed.
 
 ## Deprecated plugins
 

--- a/packages/kit-plugin-litesvm/package.json
+++ b/packages/kit-plugin-litesvm/package.json
@@ -59,7 +59,7 @@
         "@solana-program/system": "^0.13.0"
     },
     "peerDependencies": {
-        "@solana/kit": "^7.1.0"
+        "@solana/kit": "^8.0.0"
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-plugin-litesvm/src/transaction-plan-executor.ts
+++ b/packages/kit-plugin-litesvm/src/transaction-plan-executor.ts
@@ -110,8 +110,7 @@ export function litesvmTransactionPlanExecutor() {
  * @remarks
  * These properties are only guaranteed on successful results. The context is
  * filled in as execution progresses, so a transaction that fails or is canceled
- * part way through carries only what was recorded before it stopped. Kit
- * will soon type these as `Partial`, but does not do so yet.
+ * part way through carries only what was recorded before it stopped.
  *
  * A successful result always carries a {@link TransactionMetadata}, since the
  * executor throws when LiteSVM reports a failure. The type stays a union because

--- a/packages/kit-plugin-rpc/README.md
+++ b/packages/kit-plugin-rpc/README.md
@@ -323,9 +323,9 @@ function logSentTransaction(result: SuccessfulSingleTransactionPlanResult<RpcSen
 }
 ```
 
-Because the context is filled in as execution progresses, a transaction that fails or is canceled part way through carries only what was recorded before it stopped. A future version of Kit will make these fields optional on failed/cancelled results. Treat them as present only on successful results.
+Because the context is filled in as execution progresses, a transaction that fails or is canceled part way through carries only what was recorded before it stopped. Failed and canceled results therefore type the context as partial — only successful results guarantee every field.
 
-Note that `sendTransaction` and `sendTransactions` do not yet propagate this context type — Kit's `ClientWithTransactionSending` interface is not parameterised over it, so their results type the context as Kit's default. The properties above are populated at runtime regardless.
+The `sendTransaction` and `sendTransactions` functions installed by this plugin propagate this context type, so their results carry a typed `RpcSendContext` without any annotation needed.
 
 ### Preflight and Resource Limit Estimation
 

--- a/packages/kit-plugin-rpc/package.json
+++ b/packages/kit-plugin-rpc/package.json
@@ -55,7 +55,7 @@
         "@solana/kit-plugin-instruction-plan": "workspace:*"
     },
     "peerDependencies": {
-        "@solana/kit": "^7.1.0"
+        "@solana/kit": "^8.0.0"
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
+++ b/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
@@ -204,8 +204,7 @@ export type RpcTransactionPlanExecutorConfig = {
  * @remarks
  * These properties are only guaranteed on successful results. The context is
  * filled in as execution progresses, so a transaction that fails or is canceled
- * part way through carries only what was recorded before it stopped. Kit
- * will soon type these as `Partial`, but does not do so yet.
+ * part way through carries only what was recorded before it stopped.
  *
  * @example
  * Annotating a result produced by the executor.

--- a/packages/kit-plugin-rpc/test/transaction-plan-executor.test.ts
+++ b/packages/kit-plugin-rpc/test/transaction-plan-executor.test.ts
@@ -282,11 +282,7 @@ describe('rpcTransactionPlanSendingExecutor', () => {
             .use(rpcTransactionPlanner())
             .use(rpcTransactionPlanSendingExecutor());
 
-        const txMessage = setTransactionMessageFeePayerSigner(
-            payer,
-            // @ts-expect-error Version 1 transaction messages work at runtime but are not yet in the public type.
-            createTransactionMessage({ version: 1 }),
-        );
+        const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 1 }));
         await client.transactionPlanExecutor(singleTransactionPlan(txMessage));
 
         // Estimation runs a single simulation, so preflight is skipped when sending.
@@ -316,11 +312,7 @@ describe('rpcTransactionPlanSendingExecutor', () => {
             .use(rpcTransactionPlanner())
             .use(rpcTransactionPlanSendingExecutor({ skipPreflight: true }));
 
-        const txMessage = setTransactionMessageFeePayerSigner(
-            payer,
-            // @ts-expect-error Version 1 transaction messages work at runtime but are not yet in the public type.
-            createTransactionMessage({ version: 1 }),
-        );
+        const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 1 }));
         const promise = client.transactionPlanExecutor(singleTransactionPlan(txMessage));
 
         await expect(promise).rejects.toThrow();
@@ -348,11 +340,7 @@ describe('rpcTransactionPlanSendingExecutor', () => {
             .use(rpcTransactionPlanner())
             .use(rpcTransactionPlanSendingExecutor({ skipPreflight: true }));
 
-        const txMessage = setTransactionMessageFeePayerSigner(
-            payer,
-            // @ts-expect-error Version 1 transaction messages work at runtime but are not yet in the public type.
-            createTransactionMessage({ version: 1 }),
-        );
+        const txMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 1 }));
         await client.transactionPlanExecutor(singleTransactionPlan(txMessage));
 
         // The recovered limits let the transaction reach the validator with preflight skipped.
@@ -381,7 +369,6 @@ describe('rpcTransactionPlanSendingExecutor', () => {
 
         // Both applicable resource limits are explicit, so no estimation is needed.
         const txMessage = pipe(
-            // @ts-expect-error Version 1 transaction messages work at runtime but are not yet in the public type.
             createTransactionMessage({ version: 1 }),
             tx => setTransactionMessageFeePayerSigner(payer, tx),
             tx => setTransactionMessageComputeUnitLimit(500, tx),

--- a/packages/kit-plugin-signer/package.json
+++ b/packages/kit-plugin-signer/package.json
@@ -54,7 +54,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^7.1.0"
+        "@solana/kit": "^8.0.0"
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-plugin-wallet/package.json
+++ b/packages/kit-plugin-wallet/package.json
@@ -71,7 +71,7 @@
         "test:unit": "vitest run"
     },
     "dependencies": {
-        "@solana/wallet-account-signer": "^7.1.0",
+        "@solana/wallet-account-signer": "^8.0.0",
         "@solana/wallet-standard-chains": "^1.1.2",
         "@solana/wallet-standard-features": "^1.4.0",
         "@wallet-standard/app": "^1.1.1",
@@ -82,7 +82,7 @@
         "@wallet-standard/ui-registry": "^1.1.1"
     },
     "devDependencies": {
-        "@solana/react": "^7.1.0",
+        "@solana/react": "^8.0.0",
         "@testing-library/react": "^16.0.0",
         "@types/react": "^19.2.18",
         "@wallet-standard/errors": "^0.1.2",
@@ -90,8 +90,8 @@
         "react-dom": "^19.2.8"
     },
     "peerDependencies": {
-        "@solana/kit": "^7.0.0",
-        "@solana/react": "^7.1.0",
+        "@solana/kit": "^8.0.0",
+        "@solana/react": "^8.0.0",
         "react": "^19.2.8"
     },
     "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@solana/kit': ^7.1.0
+  '@solana/kit': ^8.0.0
 
 importers:
 
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.1.1
         version: 0.1.1(oxfmt@0.63.0)(oxlint@1.78.0(oxlint-tsgolint@7.0.2001))
       '@solana/kit':
-        specifier: ^7.1.0
-        version: 7.1.0(typescript@7.0.2)
+        specifier: ^8.0.0
+        version: 8.0.0(typescript@7.0.2)
       '@types/node':
         specifier: ^26
         version: 26.2.0
@@ -64,13 +64,13 @@ importers:
     dependencies:
       '@solana-program/system':
         specifier: ^0.13.0
-        version: 0.13.0(@solana/kit@7.1.0(typescript@7.0.2))
+        version: 0.13.0(@solana/kit@8.0.0(typescript@7.0.2))
       '@solana-program/token':
         specifier: ^0.14.0
-        version: 0.14.0(@solana/kit@7.1.0(typescript@7.0.2))
+        version: 0.14.0(@solana/kit@8.0.0(typescript@7.0.2))
       '@solana/kit':
-        specifier: ^7.1.0
-        version: 7.1.0(typescript@7.0.2)
+        specifier: ^8.0.0
+        version: 8.0.0(typescript@7.0.2)
       '@solana/kit-plugin-rpc':
         specifier: workspace:*
         version: link:../../packages/kit-plugin-rpc
@@ -82,10 +82,10 @@ importers:
     dependencies:
       '@solana-program/system':
         specifier: ^0.13.0
-        version: 0.13.0(@solana/kit@7.1.0(typescript@7.0.2))
+        version: 0.13.0(@solana/kit@8.0.0(typescript@7.0.2))
       '@solana/kit':
-        specifier: ^7.1.0
-        version: 7.1.0(typescript@7.0.2)
+        specifier: ^8.0.0
+        version: 8.0.0(typescript@7.0.2)
       '@solana/kit-plugin-rpc':
         specifier: workspace:*
         version: link:../../packages/kit-plugin-rpc
@@ -96,14 +96,14 @@ importers:
   packages/kit-plugin-instruction-plan:
     dependencies:
       '@solana/kit':
-        specifier: ^7.1.0
-        version: 7.1.0(typescript@7.0.2)
+        specifier: ^8.0.0
+        version: 8.0.0(typescript@7.0.2)
 
   packages/kit-plugin-litesvm:
     dependencies:
       '@solana/kit':
-        specifier: ^7.1.0
-        version: 7.1.0(typescript@7.0.2)
+        specifier: ^8.0.0
+        version: 8.0.0(typescript@7.0.2)
       '@solana/kit-plugin-instruction-plan':
         specifier: workspace:*
         version: link:../kit-plugin-instruction-plan
@@ -113,13 +113,13 @@ importers:
     devDependencies:
       '@solana-program/system':
         specifier: ^0.13.0
-        version: 0.13.0(@solana/kit@7.1.0(typescript@7.0.2))
+        version: 0.13.0(@solana/kit@8.0.0(typescript@7.0.2))
 
   packages/kit-plugin-rpc:
     dependencies:
       '@solana/kit':
-        specifier: ^7.1.0
-        version: 7.1.0(typescript@7.0.2)
+        specifier: ^8.0.0
+        version: 8.0.0(typescript@7.0.2)
       '@solana/kit-plugin-instruction-plan':
         specifier: workspace:*
         version: link:../kit-plugin-instruction-plan
@@ -127,17 +127,17 @@ importers:
   packages/kit-plugin-signer:
     dependencies:
       '@solana/kit':
-        specifier: ^7.1.0
-        version: 7.1.0(typescript@7.0.2)
+        specifier: ^8.0.0
+        version: 8.0.0(typescript@7.0.2)
 
   packages/kit-plugin-wallet:
     dependencies:
       '@solana/kit':
-        specifier: ^7.1.0
-        version: 7.1.0(typescript@7.0.2)
+        specifier: ^8.0.0
+        version: 8.0.0(typescript@7.0.2)
       '@solana/wallet-account-signer':
-        specifier: ^7.1.0
-        version: 7.1.1(typescript@7.0.2)
+        specifier: ^8.0.0
+        version: 8.0.0(typescript@7.0.2)
       '@solana/wallet-standard-chains':
         specifier: ^1.1.2
         version: 1.1.2
@@ -164,8 +164,8 @@ importers:
         version: 1.1.1
     devDependencies:
       '@solana/react':
-        specifier: ^7.1.0
-        version: 7.1.1(@solana/kit@7.1.0(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
+        specifier: ^8.0.0
+        version: 8.0.0(@solana/kit@8.0.0(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
       '@testing-library/react':
         specifier: ^16.0.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1144,21 +1144,21 @@ packages:
   '@solana-program/system@0.12.2':
     resolution: {integrity: sha512-MaBeOxlvTruQhA7UYkOb3hVTEHPPagOtd+PvTm6a8rGgvEAP0kD4BbC37NceOaR4ABNqdaCmD5OMVRKgrE6KAg==}
     peerDependencies:
-      '@solana/kit': ^7.1.0
+      '@solana/kit': ^8.0.0
 
   '@solana-program/system@0.13.0':
     resolution: {integrity: sha512-Id6QQxCG7ByImXPD5X/c3Ag2kySD+49aJ9waIkfxyUFyokhMQgxYQAx2rKuaygaBlaBQY6VVfBS46pqxZV+99A==}
     peerDependencies:
-      '@solana/kit': ^7.1.0
+      '@solana/kit': ^8.0.0
 
   '@solana-program/token@0.14.0':
     resolution: {integrity: sha512-zpLMr6JZndlsQCQvrm0gezfwdr1lmzOGqN6v2WIYXjtDmbF+xg6zh/MAp2UFHRpv3uDmylEdjtQo05pa2OeaYg==}
     engines: {node: '>=24.0.0'}
     peerDependencies:
-      '@solana/kit': ^7.1.0
+      '@solana/kit': ^8.0.0
 
-  '@solana/accounts@7.1.0':
-    resolution: {integrity: sha512-0Vp2advYsTb7eb0jZveXZJaux6OSYcI3nitwoXOTZzCuzjbIjiHI/bpn3CcqfKBPW/1dnCIWAW7VW1otqH0a1w==}
+  '@solana/accounts@8.0.0':
+    resolution: {integrity: sha512-+uqFCoI/P9oo0FGR3t3TJJxi0aoAdaEvFXzZCfNoLH5txZLTiw6/d/9QCSE/FXpbNZfk0VPGWcGN+QAXp/yrRA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1166,8 +1166,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/addresses@7.1.0':
-    resolution: {integrity: sha512-kA/aav0TdyhrXCG6VCGG/fTuGu4ix5UW2PxtsbpBdZcyi+3TznLS1xKzIZBzqn0DL0q6HKdud6Ene7DWZDH1lw==}
+  '@solana/addresses@8.0.0':
+    resolution: {integrity: sha512-hPtZOGxeMVEVoXleEsYcOj1mhxtvUTeEivE3iqCT7HJGGnYZFaV0/MduoqsEMiaBM+2ggjpVh9V7QoXPJIhbhw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1175,8 +1175,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/addresses@7.1.1':
-    resolution: {integrity: sha512-/Tk2aTOT7UEcaJrdEcB3+SK09v5cZ/92NWqHBzEobxusTPNoeOFxa3MwV74Q1MgPecWdLz7TPreEhAKpcvV/vw==}
+  '@solana/assertions@8.0.0':
+    resolution: {integrity: sha512-qvS9Jicl3ZKc4QkRhz6ZT32E/hmPMR3CkGaQccG8JhMVbOSJBK6+18IO2T03K1kNGnP335FDDL6H/Yzw0IhQ7g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1184,8 +1184,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/assertions@7.1.0':
-    resolution: {integrity: sha512-LD9+fhZb/xBECl27gfxDEX+qyj4PRV6700RJuprJWNMvGd8v0eoO0N+0QwnopK7o7O4w3DaW9/a3jH+iiwEqzw==}
+  '@solana/codecs-core@8.0.0':
+    resolution: {integrity: sha512-WU/W1IEssIae1rKfJHAwuxvbnhwFH9+WCjD+l4oK2TiKgRDIdO3ndF58ABl5hFqgISCthHxeiFqBtd8C8EhzWw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1193,8 +1193,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/assertions@7.1.1':
-    resolution: {integrity: sha512-tD07UKuw5i9Tw5xloVH+TUMrLzbHKixaB4DlGXumMEQU+JbYRPtFNqtMlrpVLuVM45nkbPfFp2Da0sXNRIqFHA==}
+  '@solana/codecs-data-structures@8.0.0':
+    resolution: {integrity: sha512-iCwbuANIuUbr7f69wx8E7tzT5tHcrJpKq8Ni06Y7H8aKhzJUlTeNQnpCbQr/e2bhvM6VI65yaXLUNEXfM7OS6Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1202,8 +1202,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-core@7.1.0':
-    resolution: {integrity: sha512-pl1gCCvviKekrijEDieZ1ps3LjC6ova2pZ/ZBXEJJa46nF7M0hwdZe/KzbMxKQ8WtT/WqW8Uyh6JQt8IJcMgRw==}
+  '@solana/codecs-numbers@8.0.0':
+    resolution: {integrity: sha512-Islv8gZPQhVA1DvCk3KspTTw9r0z/qL6EWwN5/vvA9LYWe11RmNarJ+C0qxg1vPh2lQh8W6t/GcpZS/TJbHI0A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1211,53 +1211,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-core@7.1.1':
-    resolution: {integrity: sha512-C1UOAQ7LH8RuCTfaij6hthTZeBlpp8GuD2g9Nag/xgiNKJGvAfVrcorb+kO/sufdYI8Lu+BiVvPeKOjQDQiKqg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/codecs-data-structures@7.1.0':
-    resolution: {integrity: sha512-yCwyXCD1qtj0qJwCLQVS9aojKDio7t8kqXQVhLfasYFsckvecK+OObkoILkBXBJVmpOXI8nRYwNAb63+CvJo/g==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/codecs-data-structures@7.1.1':
-    resolution: {integrity: sha512-MO+wMAuaatAQ96N3HhTsd7Uno+79rJw88P+OiU2n+pHK/rZuyu1yB2j12veqK4jUNWPR0aOyCuZ4rB2idrDjpg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/codecs-numbers@7.1.0':
-    resolution: {integrity: sha512-Hfw5OXx7tbSJ4iQ0r1ar6D+7XixkX8K36ni9cHDrunpiTo9SLIE0Lzj9/889aPNv4J4JggW1bpqzcrz3RI/o5g==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/codecs-numbers@7.1.1':
-    resolution: {integrity: sha512-TWWrQq6Wp5Yf5bSc6RbxDDYCRUBBmRtRgjvUMHGp0P9K+4uFwxllRjSZFzBPHgXj3UTeZmFJdcoD271QhAgibg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/codecs-strings@7.1.0':
-    resolution: {integrity: sha512-YIv/XVDYTzkYiFRdbjK6tI1BUKNlV1ta5hl9oK6+CoCDZn7nECfAN96KPYs94jzbN5VgMgbEqi6tlQcdy5KuCg==}
+  '@solana/codecs-strings@8.0.0':
+    resolution: {integrity: sha512-4l8XCWIFt9DYX/zH22Jygmu+DRjKpFjFE1CNqnin24+LZ6WQu6Zk3cU+nftV3OrLns2Yi+o4cSlv/eVUsxA3qA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
@@ -1268,20 +1223,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-strings@7.1.1':
-    resolution: {integrity: sha512-6qWl+atG60D2LmP47GyGapQFhVsG1sVhVrEaM3lV09vwrGOMeOZARZ4ObaQ5m6uQmM04G+f8dY9d17nCMbGHGg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      fastestsmallesttextencoderdecoder:
-        optional: true
-      typescript:
-        optional: true
-
-  '@solana/codecs@7.1.0':
-    resolution: {integrity: sha512-4M1MgIiRX46qMUnrUjVnRnTxETmCZ7VLWddMdf+t6y3aVsMzz8kd9ngH7NloFhHtnAO0n3qJjs2rdgx/Dxd3Zg==}
+  '@solana/codecs@8.0.0':
+    resolution: {integrity: sha512-Pk33P602YQSYHJka2IH4LhTg9vcVskYQb/XfOCqXyXDsgJS2x3au7kpXB7Q6M5yiw8VBw8ZNu/a0iGBX44v7tw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1289,8 +1232,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/errors@7.1.0':
-    resolution: {integrity: sha512-sJ0mM6SHN7fa6auHARRAGjjDpkFzhx6jmgHZAjliC/xADMfI2IYrTnAwguRV9dVBOsEHicylIXszvsyRb6BmEw==}
+  '@solana/errors@8.0.0':
+    resolution: {integrity: sha512-S7vuD1EWVkp2OX9J7fQW7j7nGP3e+iuscDktheMDxpM/5d9GwfjjNiFDTOQB/SwEKuFd9PnZ5Wq5MmMBJxVSrw==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
@@ -1299,18 +1242,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/errors@7.1.1':
-    resolution: {integrity: sha512-q35qck8rBnNvJlPU00mnHEQm7gWvghzYz8khqVoLhjgodTzGp46VqnIOyI1LXOAF6XDal58bMNDO980MQgq8yw==}
-    engines: {node: '>=20.18.0'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/fast-stable-stringify@7.1.0':
-    resolution: {integrity: sha512-DV35b2DoqFwQlO7acwi0WG47oLSORGep7/lTkd/VrCB/MdM0J5TggQ0gRqc9v3ORBDQHcOYmMx6ym4Obqd1EFg==}
+  '@solana/fast-stable-stringify@8.0.0':
+    resolution: {integrity: sha512-2cg1e6ytDOtID8AnoqdIC0vzmEo5J2N96RtON6+nuyYjaOKH+i8T5nLmUAmVpcozcdntp899MfGGrUcxHJ/7Sw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1318,8 +1251,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/fixed-points@7.1.0':
-    resolution: {integrity: sha512-xyVO7h8woz53L5dz9pV5akdf/EcluEvtV85cYtca1pp0ZpdcdnGQ2yve3mN/GuOEb+Ixzthrew2p0c5h9w4Bhg==}
+  '@solana/fixed-points@8.0.0':
+    resolution: {integrity: sha512-KA7ZA3xUIGNqDlagrTpzUtXsVSZn+vZC4odBDT3iXoRQysqV9t5g191HFH1OiTM68+7H8Rrte1Z0pTZSrQceTg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1327,8 +1260,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/fixed-points@7.1.1':
-    resolution: {integrity: sha512-qPj/V7kcFG/P0kuEa1U529+5L6mbkMwRIwvYBTDgBqPOt6wOdk9/c7Qn2VUQgSV0HgCXWxdHUdwaxBrYqO2ibg==}
+  '@solana/functional@8.0.0':
+    resolution: {integrity: sha512-w5GZeeLJQyIBc21PRWPzOs7M+7aKJdbklA5cqzSx7u5cNjJQ9VDs7/JkPTtgTzrhNIqa7jqZRNf97ecx7dQVvg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1336,8 +1269,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/functional@7.1.0':
-    resolution: {integrity: sha512-1yfUFHkeMvrD/6yTDu3op3CgWIfr1KAvHo3XQL6yBvz0miEbiQ6tAEZbrwHpudES43sG8ZvlgrkL0Oiu5KwC9g==}
+  '@solana/instruction-plans@8.0.0':
+    resolution: {integrity: sha512-sD9W72Pn59UT1swV5wwR7uFpBdAUAc+o2Am3fEFZbm24HWQVhcV5rOmCZqzu/dlU10puFFra28AEVq20o5crAg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1345,8 +1278,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/functional@7.1.1':
-    resolution: {integrity: sha512-AnFohvUHGrqAu3kTxxC0rZyU4JddA08hOUZ1/DT9XogCZWetBpNJktX9uNuXQe+sN4FKTX2MfL//iBFBAsxtDA==}
+  '@solana/instructions@8.0.0':
+    resolution: {integrity: sha512-xcToa7n5IBnjaKfOBwHwj2UU+wmE7Rvh8jLFHRrSeAXzqZkABDviMrrKAPdcgD+/lhnofyuz1cYLH6cuc5hdnQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1354,8 +1287,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/instruction-plans@7.1.0':
-    resolution: {integrity: sha512-Ug7YSchE8Oq8PsaKYlr8IH0woYjmAgi7JdVwd1wtE1pReHvufH63WUsE6B6guqIkQPxiLZL/tmODzKas2zlVtA==}
+  '@solana/keys@8.0.0':
+    resolution: {integrity: sha512-nUg748MurpMmfVoWYwshpxrWsJZIcJ31mYf9xm1Z7NV0fySWyZYhgQbrEtONpMW6TPt2kpgBYDVKWs/wAyPokw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1363,8 +1296,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/instructions@7.1.0':
-    resolution: {integrity: sha512-KnXUtSIbKCUjlposzfikAO3qSVliOSoMBzglQYSn3e0x0PpJ2MsVH6tzzI6v124YVhs0OSs5wFwYjENTedPgcg==}
+  '@solana/kit@8.0.0':
+    resolution: {integrity: sha512-HAruLcW5OPVJu/T/NeMHFTPC8c6De1TjXsOGF8ZablZV14ytlyx2CwyIkOJeU2WTRq1WNM933RI/XuOBUCPrtA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1372,8 +1305,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/instructions@7.1.1':
-    resolution: {integrity: sha512-VxMpJI++RTwaqSBLIP1GTjOPLtlYOqxOJ93ug6DlSdu9jku8M/or77DiXDUi62VmEh3bbsECR646vTJXUaPArw==}
+  '@solana/nominal-types@8.0.0':
+    resolution: {integrity: sha512-aCvkLVfJLy7q0xSbzJXLMZkLEDtxbQZtJKJJAsdi7u40KwkK4ZLITLYc7wbIVKCpxLJcs1XspwJKLZGlcFGwSQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1381,8 +1314,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/keys@7.1.0':
-    resolution: {integrity: sha512-BGRkTPeBIKPojwVEdYaBXtLMQ0fp8xtQiRxDhOSyYpd1bz52K4bmvrugVtSqfjWLVO+I8SRZGpSZq2G5+DgR1Q==}
+  '@solana/offchain-messages@8.0.0':
+    resolution: {integrity: sha512-wynBOsq3bwwqDG+KIUK9/5hNlo/tpRjmUf+VcFWUdD0LgSRr9NtF8QL2/Modj/m+Xj1iFkjfP+p8f94iGUF56g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1390,8 +1323,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/keys@7.1.1':
-    resolution: {integrity: sha512-Rx+vzWAXUa/Ko7W6wG1HOG9B3nQFZ5dALz113WoAmBZf7iQvaLG7U4ECDM/ydR+Nbdy6wYww7zQKRIye+1d+Nw==}
+  '@solana/options@8.0.0':
+    resolution: {integrity: sha512-OOrtPfPOuJY2+jNUUUgm6d9pQewhs+fTaR6R6nRAGJOl2IVgmTOMQ6+mpj2nfH36bLXRNuXmJR7SCG64mMi8Dg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1399,8 +1332,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/kit@7.1.0':
-    resolution: {integrity: sha512-UvzQhbn7ITjoBIinGz7rrdPSfkE8/bl+c6TISTLOXiW5hZw16mKOAkK28duP6bJutgQ57L0oJ4HYu5BTzAznOg==}
+  '@solana/plugin-core@8.0.0':
+    resolution: {integrity: sha512-8ciqi0mT7TocVt/ZjW0rzch8jgmaYbZeW6J2EFM2Oxe1vG2QloK+voikRxkYtsHMxGtSLfiTZDnklX24xBSa9Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1408,8 +1341,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/nominal-types@7.1.0':
-    resolution: {integrity: sha512-oN+gGAqBnGc/iGIq5i4Q/+VFyTqbh0wpLnWTtMbFpXmevrdX3IPPBW5Z76ysZtTtv+M4Ha64kqc2upLJBUGM0A==}
+  '@solana/plugin-interfaces@8.0.0':
+    resolution: {integrity: sha512-xi8co+87aAT51XBt0GJDntww172Rke+Bb+hjxPHMoNHd4C1WdMf9VQHwpGhh/km3DYYGx75JBxwpNwPZIbzNxQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1417,8 +1350,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/nominal-types@7.1.1':
-    resolution: {integrity: sha512-do4rmmOlSplVYN92zV6nROJxkiRn0c7juoH1lka2Pmq+cAC3QhQXKYAwWffTFYDJJDO9qCOh00uv2hhSZi6RDw==}
+  '@solana/program-client-core@8.0.0':
+    resolution: {integrity: sha512-LS2cgz6imea+PLCQ9J3wKbacR127YpO8aKo/gl1x60GoBasdT1km5Dw63gsv7HEkmEF0iQZGjA9TBwYZNAOXFw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1426,8 +1359,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/offchain-messages@7.1.0':
-    resolution: {integrity: sha512-nQBqXNLjDvUybc6oRS936gHLGzKwKy9fSlUV4OPo1mLG5V8TcW+jhCc1UOJdmfj0FYDDq5rzqmFTVK4yEu7brw==}
+  '@solana/programs@8.0.0':
+    resolution: {integrity: sha512-7n40XqVlTntQWYGwSiFyY4pQSOmCdLmI13oXWbHeSh/e1f4hJvPrVIpKe/h/liT630mSdjgxy1Je+2c7cV24Sw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1435,8 +1368,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/offchain-messages@7.1.1':
-    resolution: {integrity: sha512-Py0/8HaIF0y+KSXHAWdQYDdZlGNoaqOZonTFuGKyDsrkgvod3wRc0cpZ5I/D/Rei4tVpvjNUfCXLpyoiJAZ7kg==}
+  '@solana/promises@8.0.0':
+    resolution: {integrity: sha512-KYjpZeKOkW4eAserk48349BlWjPorhjP2dkGjYMG0ZRWg67tpby708Yizu1g3S4CAwOAH40EFFYTW6NXaZqcpQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1444,77 +1377,14 @@ packages:
       typescript:
         optional: true
 
-  '@solana/options@7.1.0':
-    resolution: {integrity: sha512-6Z6NYrnDB7qQXE7liHVpf0+5ytJogNw6QGsO8On/csX4f5WGBLxeP0JJQNnkOvuTrBkUMEq6YtTFxp4/Plqx9A==}
+  '@solana/react@8.0.0':
+    resolution: {integrity: sha512-/Kwvg+HWO+SztFz4SjEdHI8mp47YjKSzcs/fSQ6hsP6dBlU5deqi556sEB+ol7xJEvTAMKs5edIO3JXfRpdREg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/plugin-core@7.1.0':
-    resolution: {integrity: sha512-2UhReZOhFoUMcYz+72EDM3UIrrONZBpP8uhofPKNDmKPslDuJHc8q4RRlO1llGgrfV6dMIsk9j8uV4q3DjWu5g==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/plugin-interfaces@7.1.0':
-    resolution: {integrity: sha512-5QXBy1RnbWmHRCIDZRZ0W2lMnWEw65lw9X+geJmiEfbLnTPKZdpYe+5YSClz26RMcp8X2ETovkgp0E8y0Zz0yg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/program-client-core@7.1.0':
-    resolution: {integrity: sha512-81CmiYVovOElru2E7ZpBg3aAaCOdgEB4FqRatxr3EUKcP8xzsM/gti7sZxmZCd6wyLLAQQokNxpLYBjspC4ZEw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/programs@7.1.0':
-    resolution: {integrity: sha512-SiHIxX4lbHD36tOFNWyE9T984+yq9X+EOhxg3P2LKDg7nZep9F6L7Qhgw4R+aXF/Zqpy2q8XzO7NYLeT6piQ3g==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/promises@7.1.0':
-    resolution: {integrity: sha512-4I0tTa0Peh9U6cEJUR3Y0VyQneFGA2C8dL+sw00Dtfr/4hVGr03wmjHUq6CcCiH6e7WqNuznNKsqahe3BgrOMg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/promises@7.1.1':
-    resolution: {integrity: sha512-d3lhCfiFwiVyTRR6zhy1lcjDIh+l0a5gp1WPe64Vfa2gP0myC8P5C1Tknfjrp4d97DF3uBPqKAb5vV8hahNcNA==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/react@7.1.1':
-    resolution: {integrity: sha512-AiENEfcJa04MdmVuvDPxR95LCZAfHqr9B6BOR9WReaR+gcD+P+QunxJ7kd6ifjZQqmLqi/i68U4ukWHq6Ek5Jg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      '@solana/kit': ^7.1.0
+      '@solana/kit': ^8.0.0
       '@tanstack/react-query': ^5.0.0
       react: '>=18'
-      swr: ^2.4.2
+      swr: ^2.5.1
     peerDependenciesMeta:
       '@tanstack/react-query':
         optional: true
@@ -1523,8 +1393,8 @@ packages:
       swr:
         optional: true
 
-  '@solana/rpc-api@7.1.0':
-    resolution: {integrity: sha512-mluuAalyk5mfdi2lnPLDCPj6RElgZ0DCaNZmQZhnVM0SabvWxpBIzvTYqmy56Z/b9yiycfkVG3h6ISMZMddNuA==}
+  '@solana/rpc-api@8.0.0':
+    resolution: {integrity: sha512-NT2fBS9wivcMuNAwFiiiVpQ1EIR29mTzq0j7fnq9T5D4EBrl/OmA7xZXN+Z6TzUPpNLAaLADzPceXHrqqeaRSw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1532,8 +1402,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-parsed-types@7.1.0':
-    resolution: {integrity: sha512-WVHfz/VmqZpPbpyTgqz6W4Yk1rKa7tfjSqa77KbWi+yXDzZ+Oha+bAscXxY/yg/w6auu7/JY5+t7Qd0qIjrGmQ==}
+  '@solana/rpc-parsed-types@8.0.0':
+    resolution: {integrity: sha512-UEzab+gqgWZ84e1SwMoofInmu5Q0a8+DB7YYC+YnzfJJjbEL/qyFPdNpIvKX3DFyHJ+Hg5rjE9iVUVOP6Pqk2w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1541,8 +1411,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-spec-types@7.1.0':
-    resolution: {integrity: sha512-nEKJARQq8x9YQB/TBptw99bNU9KsmsObu51VleXwTi+PCowHbU7yaNad1lxg81iiX9Z4Lwvvo4c5UdVA4xkYFQ==}
+  '@solana/rpc-spec-types@8.0.0':
+    resolution: {integrity: sha512-o9/NGXsY2fBOMsJxt/exjDyV+zPsDDUl0szspDdLuh2w/YUb3U9D2ZvsCmxjtWotgbmIqFn6uKKf1/0pL/Wtdw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1550,8 +1420,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-spec@7.1.0':
-    resolution: {integrity: sha512-vmFN/HNK0bUV+sDPqs7+NV/orY23PByWN82J1Q4PFZKCOCnyFO/A06pd/MCVuPjmcaJ62xFhTcORrit6dTQL3A==}
+  '@solana/rpc-spec@8.0.0':
+    resolution: {integrity: sha512-8Mji0374hnloSXSMgLQSCj+E/c2A8qMCa9IOm1xbdHtDu91q/1fB7v88j9jT/lHmSBbShVJLyGCI9OKzxT1Tiw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1559,8 +1429,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-api@7.1.0':
-    resolution: {integrity: sha512-lzi8sPWuMyT89/L1ebY+MTzOma/6vsRdFTFcY5pe4pO4Sfi59j4p+HeYUu/NS0E6+/7Ng3BHFeTtuKD6QkhPDg==}
+  '@solana/rpc-subscriptions-api@8.0.0':
+    resolution: {integrity: sha512-ILmWLSRMs0cmes78FDln79OCVpRn5WwVg8aIgkH+phR6qsybg9ZA6JmVKPsNjRJzWhnvKw3cnY3YscRNk/uW2A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1568,8 +1438,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-channel-websocket@7.1.0':
-    resolution: {integrity: sha512-eW0JCgwSM7YV1YKkZN4rtfIGhh5WSJkCf2+JV1wscF6Zn4hK/9kr8MJ0Y0LWtoDMIuX0W3RCJnYG4T/Pcm1v6w==}
+  '@solana/rpc-subscriptions-channel-websocket@8.0.0':
+    resolution: {integrity: sha512-5gOIiaA+UsDGTuVIszwUzwlGI0AKOxsStXg5abk9BdWsx8B0iEqRZ0FTXeZxHOs6t4k25yhLFkAeam7i18qKeg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1577,8 +1447,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-spec@7.1.0':
-    resolution: {integrity: sha512-f+s6qIzUHxUTyoZoOvz2uw8Y6tYyUefLxxJtavMZEDXEjsAQ0Zv+yhmPZ5tQCo1JyHGS6EKvaw9AjxVC68NHDA==}
+  '@solana/rpc-subscriptions-spec@8.0.0':
+    resolution: {integrity: sha512-RdKaVmuC1ATsCiiFzb8Fd5uJIouS32TvF+eVCRx/fmqHmbW7J7testCqi/gjITJGjr8JE/7qPJIoUU1dccWzLg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1586,8 +1456,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-subscriptions@7.1.0':
-    resolution: {integrity: sha512-Vjs6d1AagH9r52smhX9zxSwprPKvqsWw8XFmvtGbUNI5lxtX1W4TIukscpXiau7dqe6zH6q6cfs9UtuOgY5sXA==}
+  '@solana/rpc-subscriptions@8.0.0':
+    resolution: {integrity: sha512-Ar2UgTHqx6W1xFJ8JmkZiY2xvcSzrW7FrXF2cg7AiBw89PIeMcpQOUHokaZtI8bN2CHp3f5VT1d4CcKFe0UIJg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1595,8 +1465,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-transformers@7.1.0':
-    resolution: {integrity: sha512-3sSO13m25IkkS1mXnWFZYwgSOSturEGFQMIs37vdqgiJFAYJjmossOozE+fqOY0CI1oebyURhm5gM86ATuHDYw==}
+  '@solana/rpc-transformers@8.0.0':
+    resolution: {integrity: sha512-OA4wEcLte+WJirlYfZcsFcX6Sn5/deWaJ+G1x1VbfDYXwGEzo39JBk7A23VZ9T9MOmDfpgfds7lCjCix9lFZJQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1604,8 +1474,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-transport-http@7.1.0':
-    resolution: {integrity: sha512-9zT58Ahfhd/sdYNMKvVOmPLpIMsdrZOrJlnuK0nmB+D8KWbqswDUV46H2HGxRFjvGgKep/CtOSx4RM+kt14ezQ==}
+  '@solana/rpc-transport-http@8.0.0':
+    resolution: {integrity: sha512-fGk4ym3zApquQnKI2vyO+wdEwfKEKsRQfUunLVgjAMLYSd2dxV4rQ2rFErxzJpJE0gMWE3vBH9JTPm9NXHgiuA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1613,8 +1483,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-types@7.1.0':
-    resolution: {integrity: sha512-pZO8+EroeRv7kb/d42qQeKHvUmm5tBvH0tXe8Kl2QkqG9+BCZ8NXXd+K7GbYWfVz3XtYmV3W/1B67s1DnzRldQ==}
+  '@solana/rpc-types@8.0.0':
+    resolution: {integrity: sha512-OvuMUHeeuK7cySRGs8pMd/qXvYyUiAAeTI6NRgQCR0moRbegQ9DqtQycnS1y9wkpywv8bEjpoJoi8QZfMpx/WQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1622,8 +1492,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc-types@7.1.1':
-    resolution: {integrity: sha512-yHlSUWgynaaqevuqipGhhcZnmFVNs+F6KIlbUZ0kQY6NMVtaSzx5AQrtQjbtAQzNRsRTDYkKuQg8nOruiDoseQ==}
+  '@solana/rpc@8.0.0':
+    resolution: {integrity: sha512-wzo+xjw0oTVOf8jX1dfowegVv8kjpSE7AMoAcBWRiTOOzrLViYiVEPSHvJAow27TTgLoI8ujkfCl+emXFFrA9A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1631,8 +1501,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/rpc@7.1.0':
-    resolution: {integrity: sha512-K9PvA39IQ+Z5/GYuDv4xXDPwk1KAPegnMu97b999yH09lBfsWpkHTGCCmNNy7bJAD346IQ/90/KgIbB/YnMEkw==}
+  '@solana/signers@8.0.0':
+    resolution: {integrity: sha512-yKqD54Hh8a+BBgjdcyRDYukKRG9d2Zj9aLAOuXapIcj1fWG1bWGIf3LEdVAjdoNJPTa2NEb787ouM6QOA+DAMA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1640,8 +1510,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/signers@7.1.0':
-    resolution: {integrity: sha512-sGGEOhPQLn+M9Y5QF3BgzAh9ECoq+XxIOUhyEpCSoUB725oMerir7lgsuyHvSkANhnoGnVxMhy/3b9wzVIazig==}
+  '@solana/subscribable@8.0.0':
+    resolution: {integrity: sha512-/vu8j2WeAklP5h7xBgbrM4zG9/W+lju0HN50f0qMRqcmo1VhQejHFb42MVaHFb3iRUvsuvC2M627DGUFb8CMZw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1649,8 +1519,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/signers@7.1.1':
-    resolution: {integrity: sha512-UfWYnAglm21q5hS3Op1bU5mYiWfx0VesovZcIur0uYPc3EJlfBVikl8pf745x+bB77xG6lIzNbb+99t48SQbkg==}
+  '@solana/sysvars@8.0.0':
+    resolution: {integrity: sha512-z8bZDr/RfvEeQr5t2UVtdG/qzS5yjBnTpcuVvpQcoWqkfzMISb5+dMTc1qiYtnwGz2176QZROgZ7+OQogfDbnw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1658,8 +1528,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/subscribable@7.1.0':
-    resolution: {integrity: sha512-8YnZV34WRN/AHP1B2XUlLIkINI9AYGcv1lqc2pFswS4VEL0c4iXyCfCXg9D1FM/obEhlU73h+ZJK4deg8yasgA==}
+  '@solana/transaction-confirmation@8.0.0':
+    resolution: {integrity: sha512-vz72wtWChtoqzCXmYpQwD0ZRtA1qM10FGg+hwtmUeoxvoq014MAJ5JEJ4PN5X3D5ST/qdmv3TmmFyfdyJ8kfCQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1667,8 +1537,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/subscribable@7.1.1':
-    resolution: {integrity: sha512-l4Wzc2L+7WQPeC/kaCiia1aaUY/SJJdrNHnLibKchS2pb7YbF7J2OygsweHXliWCVpG0jZwcvIVpusgygbZQLw==}
+  '@solana/transaction-introspection@8.0.0':
+    resolution: {integrity: sha512-GkmR+SXN70Amh1f+MvzEGUiqr3/YL/FyEqeT6oCAMTR2AidXfyZIKNkoTB4+1jABeXFFMaYiCfPhKD6+BznnXA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1676,8 +1546,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/sysvars@7.1.0':
-    resolution: {integrity: sha512-8UZsIsHS0JcYTy41QK9eewWj34mSkahsgD5TQPk/M69W34ElQOLKLkooj4iwXdnV2tMlNniKMIDoIQUhGCfhZw==}
+  '@solana/transaction-messages@8.0.0':
+    resolution: {integrity: sha512-/3QXUWIPLDicPLOt2aVczgTRJrWih59mHndLOwCD3i7/phGFnH66cjoyYy7+ootJJJwDlsgMoOmgdGJJHnqyFA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1685,8 +1555,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/transaction-confirmation@7.1.0':
-    resolution: {integrity: sha512-IZd2eEvhIdIaIkZAd6ugeTLB1f8pB5iwu+NmSk2vH0FUGVf3wJui8NzZyj/8+5a6Ps2WUa79JIIizVdvIOzV8A==}
+  '@solana/transactions@8.0.0':
+    resolution: {integrity: sha512-8HQmyVN9qv0v1ylTqOR38T8834oQ+sPLSRpPueTd5yfwiv60CtUwndHg1M+y5n7Q4DP1jJZ0M5YReJ5BpnD2Zg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -1694,53 +1564,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/transaction-introspection@7.1.0':
-    resolution: {integrity: sha512-AKev/afwQpkTjjNPUsYrZ7lwI76wNiZGy5T5m9FBhVrncg8evMjUHhVrnTvLTLkqMGuVgteR2BH9e2S+igwxPg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/transaction-messages@7.1.0':
-    resolution: {integrity: sha512-5JKj7mCppHBzJQF67n5YVaPR3nLNe5+sbgJcSbD2woyR7pdUhjNYyzG2HFeWDghbROpQzy9Dy7Km9iTjw3ry5A==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/transaction-messages@7.1.1':
-    resolution: {integrity: sha512-UBgd/TU0c8blrYDC9sD9P+wgmOOEK4OdODxD8CxB7oumN4ZAENv20u0AdZuvu1n4OwWwc1ikhtKjwg18e4wTIg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/transactions@7.1.0':
-    resolution: {integrity: sha512-J/31jUwrbmJkk4vHnyenbF8iz2dHnhTW0HEzOp86YzVHbm171g5ujL1mmOP4nh8r/UA6xH4QbEJ4kTrID6cN5w==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/transactions@7.1.1':
-    resolution: {integrity: sha512-jop8y4+xiDJlocRLxqN++33Z5PDTe72HwmtgGrcIuGB4zq7U/lUX0uZM1JVcs9d3lJ3wBy2CcLTCyoYb78Swhg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/wallet-account-signer@7.1.1':
-    resolution: {integrity: sha512-i8MG5MKnaU90A3vCnAH56lsAi+RJL3MTOlnZbc5DyufPAgWMTJgdS3SsfmBKNWD38k6Qh4lZ73M4ZS5Kp6lo+g==}
+  '@solana/wallet-account-signer@8.0.0':
+    resolution: {integrity: sha512-Q6x2tke5BQlCAlCDZcJ2LaHzL06l7fTvEgbIwc6CLu7ki6S84NThQ7w7N6jfWgZRz4YU0uYwHg57iZKzbd7+ew==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -3283,261 +3108,176 @@ snapshots:
       oxfmt: 0.63.0
       oxlint: 1.78.0(oxlint-tsgolint@7.0.2001)
 
-  '@solana-program/system@0.12.2(@solana/kit@7.1.0(typescript@7.0.2))':
+  '@solana-program/system@0.12.2(@solana/kit@8.0.0(typescript@7.0.2))':
     dependencies:
-      '@solana/kit': 7.1.0(typescript@7.0.2)
+      '@solana/kit': 8.0.0(typescript@7.0.2)
 
-  '@solana-program/system@0.13.0(@solana/kit@7.1.0(typescript@7.0.2))':
+  '@solana-program/system@0.13.0(@solana/kit@8.0.0(typescript@7.0.2))':
     dependencies:
-      '@solana/kit': 7.1.0(typescript@7.0.2)
+      '@solana/kit': 8.0.0(typescript@7.0.2)
 
-  '@solana-program/token@0.14.0(@solana/kit@7.1.0(typescript@7.0.2))':
+  '@solana-program/token@0.14.0(@solana/kit@8.0.0(typescript@7.0.2))':
     dependencies:
-      '@solana-program/system': 0.12.2(@solana/kit@7.1.0(typescript@7.0.2))
-      '@solana/kit': 7.1.0(typescript@7.0.2)
+      '@solana-program/system': 0.12.2(@solana/kit@8.0.0(typescript@7.0.2))
+      '@solana/kit': 8.0.0(typescript@7.0.2)
 
-  '@solana/accounts@7.1.0(typescript@7.0.2)':
+  '@solana/accounts@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/addresses': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-strings': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-spec': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-types': 7.1.0(typescript@7.0.2)
+      '@solana/addresses': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-strings': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-spec': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-types': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@7.1.0(typescript@7.0.2)':
+  '@solana/addresses@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/assertions': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-strings': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/nominal-types': 7.1.0(typescript@7.0.2)
+      '@solana/assertions': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-strings': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/nominal-types': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@7.1.1(typescript@7.0.2)':
+  '@solana/assertions@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/assertions': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-strings': 7.1.1(typescript@7.0.2)
-      '@solana/errors': 7.1.1(typescript@7.0.2)
-      '@solana/nominal-types': 7.1.1(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
+
+  '@solana/codecs-core@8.0.0(typescript@7.0.2)':
+    dependencies:
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
+
+  '@solana/codecs-data-structures@8.0.0(typescript@7.0.2)':
+    dependencies:
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-numbers': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
+
+  '@solana/codecs-numbers@8.0.0(typescript@7.0.2)':
+    dependencies:
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
+
+  '@solana/codecs-strings@8.0.0(typescript@7.0.2)':
+    dependencies:
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-numbers': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
+
+  '@solana/codecs@8.0.0(typescript@7.0.2)':
+    dependencies:
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-data-structures': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-numbers': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-strings': 8.0.0(typescript@7.0.2)
+      '@solana/fixed-points': 8.0.0(typescript@7.0.2)
+      '@solana/options': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/assertions@7.1.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/assertions@7.1.1(typescript@7.0.2)':
-    dependencies:
-      '@solana/errors': 7.1.1(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/codecs-core@7.1.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/codecs-core@7.1.1(typescript@7.0.2)':
-    dependencies:
-      '@solana/errors': 7.1.1(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/codecs-data-structures@7.1.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-numbers': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/codecs-data-structures@7.1.1(typescript@7.0.2)':
-    dependencies:
-      '@solana/codecs-core': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-numbers': 7.1.1(typescript@7.0.2)
-      '@solana/errors': 7.1.1(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/codecs-numbers@7.1.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/codecs-numbers@7.1.1(typescript@7.0.2)':
-    dependencies:
-      '@solana/codecs-core': 7.1.1(typescript@7.0.2)
-      '@solana/errors': 7.1.1(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/codecs-strings@7.1.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-numbers': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/codecs-strings@7.1.1(typescript@7.0.2)':
-    dependencies:
-      '@solana/codecs-core': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-numbers': 7.1.1(typescript@7.0.2)
-      '@solana/errors': 7.1.1(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/codecs@7.1.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-data-structures': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-numbers': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-strings': 7.1.0(typescript@7.0.2)
-      '@solana/fixed-points': 7.1.0(typescript@7.0.2)
-      '@solana/options': 7.1.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/errors@7.1.0(typescript@7.0.2)':
+  '@solana/errors@8.0.0(typescript@7.0.2)':
     dependencies:
       chalk: 5.6.2
       commander: 15.0.0
     optionalDependencies:
       typescript: 7.0.2
 
-  '@solana/errors@7.1.1(typescript@7.0.2)':
+  '@solana/fast-stable-stringify@8.0.0(typescript@7.0.2)':
+    optionalDependencies:
+      typescript: 7.0.2
+
+  '@solana/fixed-points@8.0.0(typescript@7.0.2)':
     dependencies:
-      chalk: 5.6.2
-      commander: 15.0.0
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
 
-  '@solana/fast-stable-stringify@7.1.0(typescript@7.0.2)':
+  '@solana/functional@8.0.0(typescript@7.0.2)':
     optionalDependencies:
       typescript: 7.0.2
 
-  '@solana/fixed-points@7.1.0(typescript@7.0.2)':
+  '@solana/instruction-plans@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/fixed-points@7.1.1(typescript@7.0.2)':
-    dependencies:
-      '@solana/codecs-core': 7.1.1(typescript@7.0.2)
-      '@solana/errors': 7.1.1(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/functional@7.1.0(typescript@7.0.2)':
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/functional@7.1.1(typescript@7.0.2)':
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/instruction-plans@7.1.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/instructions': 7.1.0(typescript@7.0.2)
-      '@solana/keys': 7.1.0(typescript@7.0.2)
-      '@solana/promises': 7.1.0(typescript@7.0.2)
-      '@solana/transaction-messages': 7.1.0(typescript@7.0.2)
-      '@solana/transactions': 7.1.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/instructions': 8.0.0(typescript@7.0.2)
+      '@solana/keys': 8.0.0(typescript@7.0.2)
+      '@solana/promises': 8.0.0(typescript@7.0.2)
+      '@solana/transaction-messages': 8.0.0(typescript@7.0.2)
+      '@solana/transactions': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/instructions@7.1.0(typescript@7.0.2)':
+  '@solana/instructions@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
 
-  '@solana/instructions@7.1.1(typescript@7.0.2)':
+  '@solana/keys@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/codecs-core': 7.1.1(typescript@7.0.2)
-      '@solana/errors': 7.1.1(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/keys@7.1.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/assertions': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-strings': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/nominal-types': 7.1.0(typescript@7.0.2)
-      '@solana/promises': 7.1.0(typescript@7.0.2)
+      '@solana/assertions': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-strings': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/nominal-types': 8.0.0(typescript@7.0.2)
+      '@solana/promises': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/keys@7.1.1(typescript@7.0.2)':
+  '@solana/kit@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/assertions': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-strings': 7.1.1(typescript@7.0.2)
-      '@solana/errors': 7.1.1(typescript@7.0.2)
-      '@solana/nominal-types': 7.1.1(typescript@7.0.2)
-      '@solana/promises': 7.1.1(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/kit@7.1.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/accounts': 7.1.0(typescript@7.0.2)
-      '@solana/addresses': 7.1.0(typescript@7.0.2)
-      '@solana/codecs': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/functional': 7.1.0(typescript@7.0.2)
-      '@solana/instruction-plans': 7.1.0(typescript@7.0.2)
-      '@solana/instructions': 7.1.0(typescript@7.0.2)
-      '@solana/keys': 7.1.0(typescript@7.0.2)
-      '@solana/offchain-messages': 7.1.0(typescript@7.0.2)
-      '@solana/plugin-core': 7.1.0(typescript@7.0.2)
-      '@solana/plugin-interfaces': 7.1.0(typescript@7.0.2)
-      '@solana/program-client-core': 7.1.0(typescript@7.0.2)
-      '@solana/programs': 7.1.0(typescript@7.0.2)
-      '@solana/promises': 7.1.0(typescript@7.0.2)
-      '@solana/rpc': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-api': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-parsed-types': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-spec-types': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-subscriptions': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-types': 7.1.0(typescript@7.0.2)
-      '@solana/signers': 7.1.0(typescript@7.0.2)
-      '@solana/subscribable': 7.1.0(typescript@7.0.2)
-      '@solana/sysvars': 7.1.0(typescript@7.0.2)
-      '@solana/transaction-confirmation': 7.1.0(typescript@7.0.2)
-      '@solana/transaction-introspection': 7.1.0(typescript@7.0.2)
-      '@solana/transaction-messages': 7.1.0(typescript@7.0.2)
-      '@solana/transactions': 7.1.0(typescript@7.0.2)
+      '@solana/accounts': 8.0.0(typescript@7.0.2)
+      '@solana/addresses': 8.0.0(typescript@7.0.2)
+      '@solana/codecs': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/functional': 8.0.0(typescript@7.0.2)
+      '@solana/instruction-plans': 8.0.0(typescript@7.0.2)
+      '@solana/instructions': 8.0.0(typescript@7.0.2)
+      '@solana/keys': 8.0.0(typescript@7.0.2)
+      '@solana/offchain-messages': 8.0.0(typescript@7.0.2)
+      '@solana/plugin-core': 8.0.0(typescript@7.0.2)
+      '@solana/plugin-interfaces': 8.0.0(typescript@7.0.2)
+      '@solana/program-client-core': 8.0.0(typescript@7.0.2)
+      '@solana/programs': 8.0.0(typescript@7.0.2)
+      '@solana/promises': 8.0.0(typescript@7.0.2)
+      '@solana/rpc': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-api': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-parsed-types': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-spec-types': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-subscriptions': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-types': 8.0.0(typescript@7.0.2)
+      '@solana/signers': 8.0.0(typescript@7.0.2)
+      '@solana/subscribable': 8.0.0(typescript@7.0.2)
+      '@solana/sysvars': 8.0.0(typescript@7.0.2)
+      '@solana/transaction-confirmation': 8.0.0(typescript@7.0.2)
+      '@solana/transaction-introspection': 8.0.0(typescript@7.0.2)
+      '@solana/transaction-messages': 8.0.0(typescript@7.0.2)
+      '@solana/transactions': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
@@ -3545,116 +3285,94 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/nominal-types@7.1.0(typescript@7.0.2)':
+  '@solana/nominal-types@8.0.0(typescript@7.0.2)':
     optionalDependencies:
       typescript: 7.0.2
 
-  '@solana/nominal-types@7.1.1(typescript@7.0.2)':
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/offchain-messages@7.1.0(typescript@7.0.2)':
+  '@solana/offchain-messages@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/addresses': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-data-structures': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-numbers': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-strings': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/keys': 7.1.0(typescript@7.0.2)
-      '@solana/nominal-types': 7.1.0(typescript@7.0.2)
+      '@solana/addresses': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-data-structures': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-numbers': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-strings': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/keys': 8.0.0(typescript@7.0.2)
+      '@solana/nominal-types': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/offchain-messages@7.1.1(typescript@7.0.2)':
+  '@solana/options@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/addresses': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-data-structures': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-numbers': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-strings': 7.1.1(typescript@7.0.2)
-      '@solana/errors': 7.1.1(typescript@7.0.2)
-      '@solana/keys': 7.1.1(typescript@7.0.2)
-      '@solana/nominal-types': 7.1.1(typescript@7.0.2)
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-data-structures': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-numbers': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-strings': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/options@7.1.0(typescript@7.0.2)':
+  '@solana/plugin-core@8.0.0(typescript@7.0.2)':
+    optionalDependencies:
+      typescript: 7.0.2
+
+  '@solana/plugin-interfaces@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-data-structures': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-numbers': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-strings': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
+      '@solana/accounts': 8.0.0(typescript@7.0.2)
+      '@solana/addresses': 8.0.0(typescript@7.0.2)
+      '@solana/instruction-plans': 8.0.0(typescript@7.0.2)
+      '@solana/keys': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-spec': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-subscriptions-spec': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-types': 8.0.0(typescript@7.0.2)
+      '@solana/signers': 8.0.0(typescript@7.0.2)
+      '@solana/transactions': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/plugin-core@7.1.0(typescript@7.0.2)':
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/plugin-interfaces@7.1.0(typescript@7.0.2)':
+  '@solana/program-client-core@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/accounts': 7.1.0(typescript@7.0.2)
-      '@solana/addresses': 7.1.0(typescript@7.0.2)
-      '@solana/instruction-plans': 7.1.0(typescript@7.0.2)
-      '@solana/keys': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-spec': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-subscriptions-spec': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-types': 7.1.0(typescript@7.0.2)
-      '@solana/signers': 7.1.0(typescript@7.0.2)
+      '@solana/accounts': 8.0.0(typescript@7.0.2)
+      '@solana/addresses': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/instruction-plans': 8.0.0(typescript@7.0.2)
+      '@solana/instructions': 8.0.0(typescript@7.0.2)
+      '@solana/plugin-interfaces': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-api': 8.0.0(typescript@7.0.2)
+      '@solana/signers': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/program-client-core@7.1.0(typescript@7.0.2)':
+  '@solana/programs@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/accounts': 7.1.0(typescript@7.0.2)
-      '@solana/addresses': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/instruction-plans': 7.1.0(typescript@7.0.2)
-      '@solana/instructions': 7.1.0(typescript@7.0.2)
-      '@solana/plugin-interfaces': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-api': 7.1.0(typescript@7.0.2)
-      '@solana/signers': 7.1.0(typescript@7.0.2)
+      '@solana/addresses': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/programs@7.1.0(typescript@7.0.2)':
+  '@solana/promises@8.0.0(typescript@7.0.2)':
+    optionalDependencies:
+      typescript: 7.0.2
+
+  '@solana/react@8.0.0(@solana/kit@8.0.0(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)':
     dependencies:
-      '@solana/addresses': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/promises@7.1.0(typescript@7.0.2)':
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/promises@7.1.1(typescript@7.0.2)':
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/react@7.1.1(@solana/kit@7.1.0(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)':
-    dependencies:
-      '@solana/kit': 7.1.0(typescript@7.0.2)
-      '@solana/promises': 7.1.1(typescript@7.0.2)
-      '@solana/signers': 7.1.1(typescript@7.0.2)
-      '@solana/subscribable': 7.1.1(typescript@7.0.2)
-      '@solana/transaction-messages': 7.1.1(typescript@7.0.2)
-      '@solana/transactions': 7.1.1(typescript@7.0.2)
+      '@solana/kit': 8.0.0(typescript@7.0.2)
+      '@solana/promises': 8.0.0(typescript@7.0.2)
+      '@solana/signers': 8.0.0(typescript@7.0.2)
+      '@solana/subscribable': 8.0.0(typescript@7.0.2)
+      '@solana/transaction-messages': 8.0.0(typescript@7.0.2)
+      '@solana/transactions': 8.0.0(typescript@7.0.2)
       '@solana/wallet-standard-features': 1.4.0
       '@wallet-standard/base': 1.1.1
       '@wallet-standard/errors': 0.1.2
@@ -3668,62 +3386,62 @@ snapshots:
       - react-dom
       - typescript
 
-  '@solana/rpc-api@7.1.0(typescript@7.0.2)':
+  '@solana/rpc-api@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/addresses': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-strings': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/keys': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-parsed-types': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-spec': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-transformers': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-types': 7.1.0(typescript@7.0.2)
-      '@solana/transaction-messages': 7.1.0(typescript@7.0.2)
-      '@solana/transactions': 7.1.0(typescript@7.0.2)
+      '@solana/addresses': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-strings': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/keys': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-parsed-types': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-spec': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-transformers': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-types': 8.0.0(typescript@7.0.2)
+      '@solana/transaction-messages': 8.0.0(typescript@7.0.2)
+      '@solana/transactions': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-parsed-types@7.1.0(typescript@7.0.2)':
+  '@solana/rpc-parsed-types@8.0.0(typescript@7.0.2)':
     optionalDependencies:
       typescript: 7.0.2
 
-  '@solana/rpc-spec-types@7.1.0(typescript@7.0.2)':
+  '@solana/rpc-spec-types@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/errors': 7.1.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
 
-  '@solana/rpc-spec@7.1.0(typescript@7.0.2)':
+  '@solana/rpc-spec@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-spec-types': 7.1.0(typescript@7.0.2)
-      '@solana/subscribable': 7.1.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-spec-types': 8.0.0(typescript@7.0.2)
+      '@solana/subscribable': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
 
-  '@solana/rpc-subscriptions-api@7.1.0(typescript@7.0.2)':
+  '@solana/rpc-subscriptions-api@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/addresses': 7.1.0(typescript@7.0.2)
-      '@solana/keys': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-subscriptions-spec': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-transformers': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-types': 7.1.0(typescript@7.0.2)
-      '@solana/transaction-messages': 7.1.0(typescript@7.0.2)
-      '@solana/transactions': 7.1.0(typescript@7.0.2)
+      '@solana/addresses': 8.0.0(typescript@7.0.2)
+      '@solana/keys': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-subscriptions-spec': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-transformers': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-types': 8.0.0(typescript@7.0.2)
+      '@solana/transaction-messages': 8.0.0(typescript@7.0.2)
+      '@solana/transactions': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@7.1.0(typescript@7.0.2)':
+  '@solana/rpc-subscriptions-channel-websocket@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/functional': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-subscriptions-spec': 7.1.0(typescript@7.0.2)
-      '@solana/subscribable': 7.1.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/functional': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-subscriptions-spec': 8.0.0(typescript@7.0.2)
+      '@solana/subscribable': 8.0.0(typescript@7.0.2)
       ws: 8.21.3
     optionalDependencies:
       typescript: 7.0.2
@@ -3731,28 +3449,28 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@solana/rpc-subscriptions-spec@7.1.0(typescript@7.0.2)':
+  '@solana/rpc-subscriptions-spec@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/promises': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-spec-types': 7.1.0(typescript@7.0.2)
-      '@solana/subscribable': 7.1.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/promises': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-spec-types': 8.0.0(typescript@7.0.2)
+      '@solana/subscribable': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
 
-  '@solana/rpc-subscriptions@7.1.0(typescript@7.0.2)':
+  '@solana/rpc-subscriptions@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/fast-stable-stringify': 7.1.0(typescript@7.0.2)
-      '@solana/functional': 7.1.0(typescript@7.0.2)
-      '@solana/promises': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-spec-types': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-subscriptions-api': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-subscriptions-channel-websocket': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-subscriptions-spec': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-transformers': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-types': 7.1.0(typescript@7.0.2)
-      '@solana/subscribable': 7.1.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/fast-stable-stringify': 8.0.0(typescript@7.0.2)
+      '@solana/functional': 8.0.0(typescript@7.0.2)
+      '@solana/promises': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-spec-types': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-subscriptions-api': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-subscriptions-channel-websocket': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-subscriptions-spec': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-transformers': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-types': 8.0.0(typescript@7.0.2)
+      '@solana/subscribable': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
@@ -3760,142 +3478,105 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/rpc-transformers@7.1.0(typescript@7.0.2)':
+  '@solana/rpc-transformers@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/functional': 7.1.0(typescript@7.0.2)
-      '@solana/nominal-types': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-spec-types': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-types': 7.1.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/functional': 8.0.0(typescript@7.0.2)
+      '@solana/nominal-types': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-spec-types': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-types': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-transport-http@7.1.0(typescript@7.0.2)':
+  '@solana/rpc-transport-http@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-spec': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-spec-types': 7.1.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-spec': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-spec-types': 8.0.0(typescript@7.0.2)
       undici-types: 8.10.0
     optionalDependencies:
       typescript: 7.0.2
 
-  '@solana/rpc-types@7.1.0(typescript@7.0.2)':
+  '@solana/rpc-types@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/addresses': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-numbers': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-strings': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/fixed-points': 7.1.0(typescript@7.0.2)
-      '@solana/nominal-types': 7.1.0(typescript@7.0.2)
+      '@solana/addresses': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-numbers': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-strings': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/fixed-points': 8.0.0(typescript@7.0.2)
+      '@solana/nominal-types': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-types@7.1.1(typescript@7.0.2)':
+  '@solana/rpc@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/addresses': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-numbers': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-strings': 7.1.1(typescript@7.0.2)
-      '@solana/errors': 7.1.1(typescript@7.0.2)
-      '@solana/fixed-points': 7.1.1(typescript@7.0.2)
-      '@solana/nominal-types': 7.1.1(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/fast-stable-stringify': 8.0.0(typescript@7.0.2)
+      '@solana/functional': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-api': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-spec': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-spec-types': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-transformers': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-transport-http': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-types': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc@7.1.0(typescript@7.0.2)':
+  '@solana/signers@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/fast-stable-stringify': 7.1.0(typescript@7.0.2)
-      '@solana/functional': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-api': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-spec': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-spec-types': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-transformers': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-transport-http': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-types': 7.1.0(typescript@7.0.2)
+      '@solana/addresses': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/instructions': 8.0.0(typescript@7.0.2)
+      '@solana/keys': 8.0.0(typescript@7.0.2)
+      '@solana/nominal-types': 8.0.0(typescript@7.0.2)
+      '@solana/offchain-messages': 8.0.0(typescript@7.0.2)
+      '@solana/transaction-messages': 8.0.0(typescript@7.0.2)
+      '@solana/transactions': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@7.1.0(typescript@7.0.2)':
+  '@solana/subscribable@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/addresses': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/instructions': 7.1.0(typescript@7.0.2)
-      '@solana/keys': 7.1.0(typescript@7.0.2)
-      '@solana/nominal-types': 7.1.0(typescript@7.0.2)
-      '@solana/offchain-messages': 7.1.0(typescript@7.0.2)
-      '@solana/transaction-messages': 7.1.0(typescript@7.0.2)
-      '@solana/transactions': 7.1.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/promises': 8.0.0(typescript@7.0.2)
+    optionalDependencies:
+      typescript: 7.0.2
+
+  '@solana/sysvars@8.0.0(typescript@7.0.2)':
+    dependencies:
+      '@solana/accounts': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-data-structures': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-numbers': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-types': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@7.1.1(typescript@7.0.2)':
+  '@solana/transaction-confirmation@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/addresses': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.1(typescript@7.0.2)
-      '@solana/errors': 7.1.1(typescript@7.0.2)
-      '@solana/instructions': 7.1.1(typescript@7.0.2)
-      '@solana/keys': 7.1.1(typescript@7.0.2)
-      '@solana/nominal-types': 7.1.1(typescript@7.0.2)
-      '@solana/offchain-messages': 7.1.1(typescript@7.0.2)
-      '@solana/transaction-messages': 7.1.1(typescript@7.0.2)
-      '@solana/transactions': 7.1.1(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/subscribable@7.1.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/promises': 7.1.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/subscribable@7.1.1(typescript@7.0.2)':
-    dependencies:
-      '@solana/errors': 7.1.1(typescript@7.0.2)
-      '@solana/promises': 7.1.1(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/sysvars@7.1.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/accounts': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-data-structures': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-numbers': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-types': 7.1.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/transaction-confirmation@7.1.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/addresses': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-strings': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/keys': 7.1.0(typescript@7.0.2)
-      '@solana/promises': 7.1.0(typescript@7.0.2)
-      '@solana/rpc': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-subscriptions': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-types': 7.1.0(typescript@7.0.2)
-      '@solana/transaction-messages': 7.1.0(typescript@7.0.2)
-      '@solana/transactions': 7.1.0(typescript@7.0.2)
+      '@solana/addresses': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-strings': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/keys': 8.0.0(typescript@7.0.2)
+      '@solana/promises': 8.0.0(typescript@7.0.2)
+      '@solana/rpc': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-subscriptions': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-types': 8.0.0(typescript@7.0.2)
+      '@solana/transaction-messages': 8.0.0(typescript@7.0.2)
+      '@solana/transactions': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
@@ -3903,100 +3584,65 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/transaction-introspection@7.1.0(typescript@7.0.2)':
+  '@solana/transaction-introspection@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/addresses': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-strings': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/instructions': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-types': 7.1.0(typescript@7.0.2)
-      '@solana/transaction-messages': 7.1.0(typescript@7.0.2)
-      '@solana/transactions': 7.1.0(typescript@7.0.2)
+      '@solana/addresses': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-strings': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/instructions': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-types': 8.0.0(typescript@7.0.2)
+      '@solana/transaction-messages': 8.0.0(typescript@7.0.2)
+      '@solana/transactions': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-messages@7.1.0(typescript@7.0.2)':
+  '@solana/transaction-messages@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/addresses': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-data-structures': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-numbers': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/functional': 7.1.0(typescript@7.0.2)
-      '@solana/instructions': 7.1.0(typescript@7.0.2)
-      '@solana/nominal-types': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-types': 7.1.0(typescript@7.0.2)
+      '@solana/addresses': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-data-structures': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-numbers': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/functional': 8.0.0(typescript@7.0.2)
+      '@solana/instructions': 8.0.0(typescript@7.0.2)
+      '@solana/nominal-types': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-types': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-messages@7.1.1(typescript@7.0.2)':
+  '@solana/transactions@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/addresses': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-data-structures': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-numbers': 7.1.1(typescript@7.0.2)
-      '@solana/errors': 7.1.1(typescript@7.0.2)
-      '@solana/functional': 7.1.1(typescript@7.0.2)
-      '@solana/instructions': 7.1.1(typescript@7.0.2)
-      '@solana/nominal-types': 7.1.1(typescript@7.0.2)
-      '@solana/rpc-types': 7.1.1(typescript@7.0.2)
+      '@solana/addresses': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-data-structures': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-numbers': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-strings': 8.0.0(typescript@7.0.2)
+      '@solana/errors': 8.0.0(typescript@7.0.2)
+      '@solana/functional': 8.0.0(typescript@7.0.2)
+      '@solana/instructions': 8.0.0(typescript@7.0.2)
+      '@solana/keys': 8.0.0(typescript@7.0.2)
+      '@solana/nominal-types': 8.0.0(typescript@7.0.2)
+      '@solana/rpc-types': 8.0.0(typescript@7.0.2)
+      '@solana/transaction-messages': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@7.1.0(typescript@7.0.2)':
+  '@solana/wallet-account-signer@8.0.0(typescript@7.0.2)':
     dependencies:
-      '@solana/addresses': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-data-structures': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-numbers': 7.1.0(typescript@7.0.2)
-      '@solana/codecs-strings': 7.1.0(typescript@7.0.2)
-      '@solana/errors': 7.1.0(typescript@7.0.2)
-      '@solana/functional': 7.1.0(typescript@7.0.2)
-      '@solana/instructions': 7.1.0(typescript@7.0.2)
-      '@solana/keys': 7.1.0(typescript@7.0.2)
-      '@solana/nominal-types': 7.1.0(typescript@7.0.2)
-      '@solana/rpc-types': 7.1.0(typescript@7.0.2)
-      '@solana/transaction-messages': 7.1.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/transactions@7.1.1(typescript@7.0.2)':
-    dependencies:
-      '@solana/addresses': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-data-structures': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-numbers': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-strings': 7.1.1(typescript@7.0.2)
-      '@solana/errors': 7.1.1(typescript@7.0.2)
-      '@solana/functional': 7.1.1(typescript@7.0.2)
-      '@solana/instructions': 7.1.1(typescript@7.0.2)
-      '@solana/keys': 7.1.1(typescript@7.0.2)
-      '@solana/nominal-types': 7.1.1(typescript@7.0.2)
-      '@solana/rpc-types': 7.1.1(typescript@7.0.2)
-      '@solana/transaction-messages': 7.1.1(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/wallet-account-signer@7.1.1(typescript@7.0.2)':
-    dependencies:
-      '@solana/addresses': 7.1.1(typescript@7.0.2)
-      '@solana/codecs-core': 7.1.1(typescript@7.0.2)
-      '@solana/keys': 7.1.1(typescript@7.0.2)
-      '@solana/promises': 7.1.1(typescript@7.0.2)
-      '@solana/signers': 7.1.1(typescript@7.0.2)
-      '@solana/transaction-messages': 7.1.1(typescript@7.0.2)
-      '@solana/transactions': 7.1.1(typescript@7.0.2)
+      '@solana/addresses': 8.0.0(typescript@7.0.2)
+      '@solana/codecs-core': 8.0.0(typescript@7.0.2)
+      '@solana/keys': 8.0.0(typescript@7.0.2)
+      '@solana/promises': 8.0.0(typescript@7.0.2)
+      '@solana/signers': 8.0.0(typescript@7.0.2)
+      '@solana/transaction-messages': 8.0.0(typescript@7.0.2)
+      '@solana/transactions': 8.0.0(typescript@7.0.2)
       '@solana/wallet-standard-chains': 1.1.2
       '@solana/wallet-standard-features': 1.4.0
       '@wallet-standard/base': 1.1.1
@@ -4480,9 +4126,9 @@ snapshots:
 
   litesvm@1.3.0(typescript@7.0.2):
     dependencies:
-      '@solana-program/system': 0.12.2(@solana/kit@7.1.0(typescript@7.0.2))
-      '@solana-program/token': 0.14.0(@solana/kit@7.1.0(typescript@7.0.2))
-      '@solana/kit': 7.1.0(typescript@7.0.2)
+      '@solana-program/system': 0.12.2(@solana/kit@8.0.0(typescript@7.0.2))
+      '@solana-program/token': 0.14.0(@solana/kit@8.0.0(typescript@7.0.2))
+      '@solana/kit': 8.0.0(typescript@7.0.2)
     optionalDependencies:
       litesvm-darwin-arm64: 1.3.0
       litesvm-darwin-x64: 1.3.0


### PR DESCRIPTION
Upgrades all packages to `@solana/kit@8.0.0`, with the wallet plugin also moving to `@solana/react@8.0.0` and `@solana/wallet-account-signer@8.0.0`. Kit v8 makes `ClientWithTransactionSending` generic over the result context and moves the `context.signature` guarantee into a `TransactionPlanResultContextWithSignature` default, so `transactionPlanSendingExecutor` now propagates the executor's context type to the sending functions it installs and the executor plugins adopt the same default. Also removes four `@ts-expect-error` directives in the RPC plugin tests that became unused now that version 1 transaction messages are in Kit's public types, and refreshes the RPC and LiteSVM READMEs, which described the context propagation as not yet possible.