### PR TITLE
Support version 1 transactions in the transaction planners

### DIFF
--- a/.changeset/ninety-candies-hide.md
+++ b/.changeset/ninety-candies-hide.md
@@ -1,0 +1,6 @@
+---
+'@solana/kit-plugin-litesvm': minor
+'@solana/kit-plugin-rpc': minor
+---
+
+Support version 1 transactions in the transaction planners. Passing `version: 1` to `litesvmTransactionPlanner` or `rpcTransactionPlanner` no longer throws: the planners now build version 1 transaction messages, write `priorityFeeLamports` to the version 1 resource header when configured, and — for the RPC planner — reserve provisory compute unit and loaded accounts data size limits for the executor to estimate. The default version remains 0.

--- a/packages/kit-plugin-litesvm/README.md
+++ b/packages/kit-plugin-litesvm/README.md
@@ -157,14 +157,17 @@ const transactionPlan = await client.planTransactions(myInstructionPlan);
 
 All options are provided via a `TransactionPlannerConfig` object. Its shape is discriminated by the transaction `version`.
 
-For legacy and version 0 transactions:
+- For legacy and version 0 transactions:
 
-- `version`: The transaction message version to use. Accepts `0` or `'legacy'`. Defaults to `0`.
-- `microLamportsPerComputeUnit`: The priority fee in micro-lamports per compute unit, added as a `setComputeUnitPrice` instruction. Defaults to no priority fees.
+    - `version`: The transaction message version to use. Accepts `0` or `'legacy'`. Defaults to `0`.
+    - `microLamportsPerComputeUnit`: The priority fee in micro-lamports per compute unit, added as a `setComputeUnitPrice` instruction. Defaults to no priority fees.
+
+- For version 1 transactions:
+
+    - `version`: Set to `1` to create version 1 transaction messages.
+    - `priorityFeeLamports`: The total priority fee in lamports, written to the version 1 resource header. Defaults to no priority fees.
 
 Unlike the RPC planner, the LiteSVM planner does not estimate resource limits, since LiteSVM executes transactions locally without a simulation-based estimation step.
-
-Version 1 transactions are defined for forward compatibility but are not yet buildable by `@solana/kit`; passing `version: 1` currently throws. When available, version 1 will accept `priorityFeeLamports` (a flat total in lamports) instead of `microLamportsPerComputeUnit`.
 
 ## `litesvmTransactionPlanSendingExecutor` plugin
 

--- a/packages/kit-plugin-litesvm/src/transaction-planner.ts
+++ b/packages/kit-plugin-litesvm/src/transaction-planner.ts
@@ -7,6 +7,7 @@ import {
     pipe,
     setTransactionMessageComputeUnitPrice,
     setTransactionMessageFeePayerSigner,
+    setTransactionMessagePriorityFeeLamports,
     TransactionPlanner,
 } from '@solana/kit';
 import { transactionPlanner } from '@solana/kit-plugin-instruction-plan';
@@ -27,7 +28,6 @@ import { transactionPlanner } from '@solana/kit-plugin-instruction-plan';
  *
  * @param config - Optional configuration for the planner.
  * @returns A plugin that adds `client.planTransaction` and `client.planTransactions`.
- * @throws If `config.version` is `1`, which `@solana/kit` cannot yet build.
  *
  * @example
  * ```ts
@@ -55,30 +55,44 @@ export function litesvmTransactionPlanner(config: TransactionPlannerConfig = {})
  * construction time, so a dynamic `client.payer` is always respected.
  */
 function createPlanner(client: ClientWithPayer, config: TransactionPlannerConfig): TransactionPlanner {
-    if (config.version === 1) {
-        // The v1 transaction path is defined at the type level for forward
-        // compatibility, but `createTransactionMessage` cannot yet build v1
-        // messages, so we fail loudly rather than silently misbehave.
-        throw new Error(
-            'Version 1 transactions are not yet supported by `litesvmTransactionPlanner`. ' +
-                'Use version 0 or legacy transactions for now.',
-        );
-    }
+    return config.version === 1 ? createV1Planner(client, config) : createLegacyPlanner(client, config);
+}
 
-    const version = config.version ?? 0;
-    const microLamportsPerComputeUnit = config.microLamportsPerComputeUnit;
-
+/**
+ * Creates a planner that builds version 1 transaction messages, writing the
+ * priority fee to the resource header.
+ */
+function createV1Planner(client: ClientWithPayer, config: TransactionPlannerConfigV1): TransactionPlanner {
+    const { priorityFeeLamports } = config;
     return createTransactionPlanner({
-        createTransactionMessage: () => {
-            return pipe(
+        createTransactionMessage: () =>
+            pipe(
+                createTransactionMessage({ version: 1 }),
+                tx => setTransactionMessageFeePayerSigner(client.payer, tx),
+                tx =>
+                    priorityFeeLamports === undefined
+                        ? tx
+                        : setTransactionMessagePriorityFeeLamports(priorityFeeLamports, tx),
+            ),
+    });
+}
+
+/**
+ * Creates a planner that builds legacy or version 0 transaction messages,
+ * expressing the priority fee as a `setComputeUnitPrice` instruction.
+ */
+function createLegacyPlanner(client: ClientWithPayer, config: TransactionPlannerConfigLegacy): TransactionPlanner {
+    const { microLamportsPerComputeUnit, version = 0 } = config;
+    return createTransactionPlanner({
+        createTransactionMessage: () =>
+            pipe(
                 createTransactionMessage({ version }),
                 tx => setTransactionMessageFeePayerSigner(client.payer, tx),
                 tx =>
                     microLamportsPerComputeUnit === undefined
                         ? tx
                         : setTransactionMessageComputeUnitPrice(microLamportsPerComputeUnit, tx),
-            );
-        },
+            ),
     });
 }
 
@@ -111,11 +125,6 @@ export type TransactionPlannerConfigLegacy = {
  * For version 1, priority fees live in a structured resource header rather than
  * a compute budget instruction, and are expressed as a total amount in lamports
  * rather than a per-compute-unit price.
- *
- * @remarks
- * Version 1 transactions are not yet buildable by `@solana/kit`, so this branch
- * is currently inert: passing `version: 1` throws at runtime. The shape is
- * defined now so that enabling version 1 later is not a breaking change.
  */
 export type TransactionPlannerConfigV1 = {
     /**

--- a/packages/kit-plugin-litesvm/test/transaction-planner.test.ts
+++ b/packages/kit-plugin-litesvm/test/transaction-planner.test.ts
@@ -3,6 +3,7 @@ import {
     createClient,
     generateKeyPairSigner,
     getTransactionMessageComputeUnitPrice,
+    getTransactionMessagePriorityFeeLamports,
     Lamports,
     MicroLamports,
     singleInstructionPlan,
@@ -103,13 +104,40 @@ describe('litesvmTransactionPlanner', () => {
         expect(getTransactionMessageComputeUnitPrice(message)).toBe(100n);
     });
 
-    it('throws when configured with version 1 transactions', () => {
-        const payer = {} as TransactionSigner;
-        expect(() =>
-            createClient()
-                .use(() => ({ payer }))
-                .use(litesvmTransactionPlanner({ version: 1 })),
-        ).toThrow(/Version 1 transactions are not yet supported/);
+    it('creates version 1 transaction messages when configured', async () => {
+        const payer = await generateKeyPairSigner();
+        const client = createClient()
+            .use(() => ({ payer }))
+            .use(litesvmTransactionPlanner({ version: 1 }));
+
+        const instructionPlan = singleInstructionPlan(MOCK_INSTRUCTION);
+        const transactionPlan = (await client.transactionPlanner(instructionPlan)) as SingleTransactionPlan;
+        expect(transactionPlan.message.version).toBe(1);
+        expect(transactionPlan.message.feePayer).toBe(payer);
+    });
+
+    it('does not set a priority fee on version 1 transaction messages by default', async () => {
+        const payer = await generateKeyPairSigner();
+        const client = createClient()
+            .use(() => ({ payer }))
+            .use(litesvmTransactionPlanner({ version: 1 }));
+
+        const instructionPlan = singleInstructionPlan(MOCK_INSTRUCTION);
+        const transactionPlan = (await client.transactionPlanner(instructionPlan)) as SingleTransactionPlan;
+        const message = transactionPlan.message as TransactionMessage & { version: 1 };
+        expect(getTransactionMessagePriorityFeeLamports(message)).toBeUndefined();
+    });
+
+    it('sets a priority fee on version 1 transaction messages when configured', async () => {
+        const payer = await generateKeyPairSigner();
+        const client = createClient()
+            .use(() => ({ payer }))
+            .use(litesvmTransactionPlanner({ priorityFeeLamports: 100n as Lamports, version: 1 }));
+
+        const instructionPlan = singleInstructionPlan(MOCK_INSTRUCTION);
+        const transactionPlan = (await client.transactionPlanner(instructionPlan)) as SingleTransactionPlan;
+        const message = transactionPlan.message as TransactionMessage & { version: 1 };
+        expect(getTransactionMessagePriorityFeeLamports(message)).toBe(100n);
     });
 
     it('requires a payer on the client', () => {

--- a/packages/kit-plugin-rpc/README.md
+++ b/packages/kit-plugin-rpc/README.md
@@ -269,13 +269,17 @@ const transactionPlan = await client.planTransactions(myInstructionPlan);
 
 All options are provided via a `TransactionPlannerConfig` object. Its shape is discriminated by the transaction `version`.
 
-For legacy and version 0 transactions:
+- For legacy and version 0 transactions:
 
-- `version`: The transaction message version to use. Accepts `0` or `'legacy'`. Defaults to `0`.
-- `microLamportsPerComputeUnit`: The priority fee in micro-lamports per compute unit, added as a `setComputeUnitPrice` instruction. Defaults to no priority fees.
-- `estimateResourceLimits`: Whether to estimate and set resource limits by simulating before sending. Set to `false` to skip estimation and reserve no provisory limits, which is useful for transactions close to the message size limit. Defaults to `true`.
+    - `version`: The transaction message version to use. Accepts `0` or `'legacy'`. Defaults to `0`.
+    - `microLamportsPerComputeUnit`: The priority fee in micro-lamports per compute unit, added as a `setComputeUnitPrice` instruction. Defaults to no priority fees.
+    - `estimateResourceLimits`: Whether to estimate and set resource limits by simulating before sending. Set to `false` to skip estimation and reserve no provisory limits, which is useful for transactions close to the message size limit. Defaults to `true`.
 
-Version 1 transactions are defined for forward compatibility but are not yet buildable by `@solana/kit`; passing `version: 1` currently throws. When available, version 1 will accept `priorityFeeLamports` (a flat total in lamports) instead of `microLamportsPerComputeUnit`, alongside the shared `estimateResourceLimits` option.
+- For version 1 transactions:
+
+    - `version`: Set to `1` to create version 1 transaction messages.
+    - `priorityFeeLamports`: The total priority fee in lamports, written to the version 1 resource header. Defaults to no priority fees.
+    - `estimateResourceLimits`: Whether to estimate and set resource limits by simulating before sending. For version 1 transactions, estimation covers both the compute unit limit and the loaded accounts data size limit. Defaults to `true`.
 
 ## `rpcTransactionPlanSendingExecutor` plugin
 

--- a/packages/kit-plugin-rpc/src/transaction-planner.ts
+++ b/packages/kit-plugin-rpc/src/transaction-planner.ts
@@ -8,6 +8,7 @@ import {
     pipe,
     setTransactionMessageComputeUnitPrice,
     setTransactionMessageFeePayerSigner,
+    setTransactionMessagePriorityFeeLamports,
     TransactionPlanner,
 } from '@solana/kit';
 import { transactionPlanner } from '@solana/kit-plugin-instruction-plan';
@@ -27,7 +28,6 @@ import { transactionPlanner } from '@solana/kit-plugin-instruction-plan';
  *
  * @param config - Optional configuration for the planner.
  * @returns A plugin that adds `client.planTransaction` and `client.planTransactions`.
- * @throws If `config.version` is `1`, which `@solana/kit` cannot yet build.
  *
  * @example
  * ```ts
@@ -63,23 +63,38 @@ export function rpcTransactionPlanner(config: TransactionPlannerConfig = {}) {
  * construction time, so a dynamic `client.payer` is always respected.
  */
 function createPlanner(client: ClientWithPayer, config: TransactionPlannerConfig): TransactionPlanner {
-    if (config.version === 1) {
-        // The v1 transaction path is defined at the type level for forward
-        // compatibility, but `createTransactionMessage` cannot yet build v1
-        // messages, so we fail loudly rather than silently misbehave.
-        throw new Error(
-            'Version 1 transactions are not yet supported by `rpcTransactionPlanner`. ' +
-                'Use version 0 or legacy transactions for now.',
-        );
-    }
+    return config.version === 1 ? createV1Planner(client, config) : createLegacyPlanner(client, config);
+}
 
-    const version = config.version ?? 0;
-    const estimateResourceLimits = config.estimateResourceLimits ?? true;
-    const microLamportsPerComputeUnit = config.microLamportsPerComputeUnit;
-
+/**
+ * Creates a planner that builds version 1 transaction messages, writing the
+ * priority fee to the resource header.
+ */
+function createV1Planner(client: ClientWithPayer, config: TransactionPlannerConfigV1): TransactionPlanner {
+    const { estimateResourceLimits = true, priorityFeeLamports } = config;
     return createTransactionPlanner({
-        createTransactionMessage: () => {
-            return pipe(
+        createTransactionMessage: () =>
+            pipe(
+                createTransactionMessage({ version: 1 }),
+                tx => setTransactionMessageFeePayerSigner(client.payer, tx),
+                tx => (estimateResourceLimits ? fillTransactionMessageProvisoryResourceLimits(tx) : tx),
+                tx =>
+                    priorityFeeLamports === undefined
+                        ? tx
+                        : setTransactionMessagePriorityFeeLamports(priorityFeeLamports, tx),
+            ),
+    });
+}
+
+/**
+ * Creates a planner that builds legacy or version 0 transaction messages,
+ * expressing the priority fee as a `setComputeUnitPrice` instruction.
+ */
+function createLegacyPlanner(client: ClientWithPayer, config: TransactionPlannerConfigLegacy): TransactionPlanner {
+    const { estimateResourceLimits = true, microLamportsPerComputeUnit, version = 0 } = config;
+    return createTransactionPlanner({
+        createTransactionMessage: () =>
+            pipe(
                 createTransactionMessage({ version }),
                 tx => setTransactionMessageFeePayerSigner(client.payer, tx),
                 tx => (estimateResourceLimits ? fillTransactionMessageProvisoryResourceLimits(tx) : tx),
@@ -87,8 +102,7 @@ function createPlanner(client: ClientWithPayer, config: TransactionPlannerConfig
                     microLamportsPerComputeUnit === undefined
                         ? tx
                         : setTransactionMessageComputeUnitPrice(microLamportsPerComputeUnit, tx),
-            );
-        },
+            ),
     });
 }
 
@@ -148,11 +162,6 @@ export type TransactionPlannerConfigLegacy = SharedTransactionPlannerConfig & {
  * For version 1, resource limits and priority fees live in a structured resource
  * header rather than compute budget instructions, and the priority fee is
  * expressed as a total amount in lamports rather than a per-compute-unit price.
- *
- * @remarks
- * Version 1 transactions are not yet buildable by `@solana/kit`, so this branch
- * is currently inert: passing `version: 1` throws at runtime. The shape is
- * defined now so that enabling version 1 later is not a breaking change.
  */
 export type TransactionPlannerConfigV1 = SharedTransactionPlannerConfig & {
     /**

--- a/packages/kit-plugin-rpc/test/transaction-planner.test.ts
+++ b/packages/kit-plugin-rpc/test/transaction-planner.test.ts
@@ -4,6 +4,8 @@ import {
     generateKeyPairSigner,
     getTransactionMessageComputeUnitLimit,
     getTransactionMessageComputeUnitPrice,
+    getTransactionMessageLoadedAccountsDataSizeLimit,
+    getTransactionMessagePriorityFeeLamports,
     Lamports,
     MicroLamports,
     singleInstructionPlan,
@@ -127,13 +129,65 @@ describe('rpcTransactionPlanner', () => {
         expect(getTransactionMessageComputeUnitLimit(transactionPlan.message)).toBeUndefined();
     });
 
-    it('throws when configured with version 1 transactions', () => {
-        const payer = {} as TransactionSigner;
-        expect(() =>
-            createClient()
-                .use(() => ({ payer }))
-                .use(rpcTransactionPlanner({ version: 1 })),
-        ).toThrow(/Version 1 transactions are not yet supported/);
+    it('creates version 1 transaction messages when configured', async () => {
+        const payer = await generateKeyPairSigner();
+        const client = createClient()
+            .use(() => ({ payer }))
+            .use(rpcTransactionPlanner({ version: 1 }));
+
+        const instructionPlan = singleInstructionPlan(MOCK_INSTRUCTION);
+        const transactionPlan = (await client.transactionPlanner(instructionPlan)) as SingleTransactionPlan;
+        expect(transactionPlan.message.version).toBe(1);
+        expect(transactionPlan.message.feePayer).toBe(payer);
+    });
+
+    it('does not set a priority fee on version 1 transaction messages by default', async () => {
+        const payer = await generateKeyPairSigner();
+        const client = createClient()
+            .use(() => ({ payer }))
+            .use(rpcTransactionPlanner({ version: 1 }));
+
+        const instructionPlan = singleInstructionPlan(MOCK_INSTRUCTION);
+        const transactionPlan = (await client.transactionPlanner(instructionPlan)) as SingleTransactionPlan;
+        const message = transactionPlan.message as TransactionMessage & { version: 1 };
+        expect(getTransactionMessagePriorityFeeLamports(message)).toBeUndefined();
+    });
+
+    it('sets a priority fee on version 1 transaction messages when configured', async () => {
+        const payer = await generateKeyPairSigner();
+        const client = createClient()
+            .use(() => ({ payer }))
+            .use(rpcTransactionPlanner({ priorityFeeLamports: 100n as Lamports, version: 1 }));
+
+        const instructionPlan = singleInstructionPlan(MOCK_INSTRUCTION);
+        const transactionPlan = (await client.transactionPlanner(instructionPlan)) as SingleTransactionPlan;
+        const message = transactionPlan.message as TransactionMessage & { version: 1 };
+        expect(getTransactionMessagePriorityFeeLamports(message)).toBe(100n);
+    });
+
+    it('fills provisory resource limits for version 1 transactions by default', async () => {
+        const payer = await generateKeyPairSigner();
+        const client = createClient()
+            .use(() => ({ payer }))
+            .use(rpcTransactionPlanner({ version: 1 }));
+
+        const instructionPlan = singleInstructionPlan(MOCK_INSTRUCTION);
+        const transactionPlan = (await client.transactionPlanner(instructionPlan)) as SingleTransactionPlan;
+        // Provisory limits of 0 are reserved for the executor to estimate.
+        expect(getTransactionMessageComputeUnitLimit(transactionPlan.message)).toBe(0);
+        expect(getTransactionMessageLoadedAccountsDataSizeLimit(transactionPlan.message)).toBe(0);
+    });
+
+    it('does not fill provisory resource limits for version 1 transactions when estimation is disabled', async () => {
+        const payer = await generateKeyPairSigner();
+        const client = createClient()
+            .use(() => ({ payer }))
+            .use(rpcTransactionPlanner({ estimateResourceLimits: false, version: 1 }));
+
+        const instructionPlan = singleInstructionPlan(MOCK_INSTRUCTION);
+        const transactionPlan = (await client.transactionPlanner(instructionPlan)) as SingleTransactionPlan;
+        expect(getTransactionMessageComputeUnitLimit(transactionPlan.message)).toBeUndefined();
+        expect(getTransactionMessageLoadedAccountsDataSizeLimit(transactionPlan.message)).toBeUndefined();
     });
 
     it('requires a payer on the client', () => {


### PR DESCRIPTION
Kit v8 can now build version 1 transaction messages, so `litesvmTransactionPlanner` and `rpcTransactionPlanner` no longer throw when configured with `version: 1`. The planners build v1 messages, write `priorityFeeLamports` to the v1 resource header when configured, and the RPC planner reserves provisory compute unit and loaded accounts data size limits for the executor to estimate. The default version remains 0.