### PR TITLE
Add transaction plan signing executor

### DIFF
--- a/.changeset/fiery-donkeys-lead.md
+++ b/.changeset/fiery-donkeys-lead.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-instruction-plan': minor
+---
+
+Add `transactionPlanSigningExecutor`, which installs `signTransaction` and `signTransactions` on clients backed by a transaction planner and signing executor.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/kit-plugin-instruction-plan/README.md
+++ b/packages/kit-plugin-instruction-plan/README.md
@@ -7,7 +7,7 @@
 [npm-image]: https://img.shields.io/npm/v/@solana/kit-plugin-instruction-plan.svg?style=flat&label=%40solana%2Fkit-plugin-instruction-plan
 [npm-url]: https://www.npmjs.com/package/@solana/kit-plugin-instruction-plan
 
-This package provides plugins that add transaction planning and execution to your Kit clients.
+This package provides plugins that add transaction planning, signing and execution to your Kit clients.
 
 ## Installation
 
@@ -94,6 +94,37 @@ const client = createClient()
     ```
 
 For backward compatibility this plugin also sets a `client.transactionPlanExecutor` field, but that field is deprecated in favour of the two functions above.
+
+## `transactionPlanSigningExecutor` plugin
+
+The `transactionPlanSigningExecutor` plugin adds `signTransaction` and `signTransactions` to the client, using the client's planning functions and a transaction plan executor that signs transactions without sending them. Both functions accept transaction messages, instructions, instruction plans or transaction plans as input, planning the input first when it is not already a transaction plan.
+
+Planning goes through the client's `planTransaction` and `planTransactions` functions, so the `transactionPlanner` plugin must be installed first. The result context is inferred from the executor, allowing signing implementations to expose their signed transactions or other signing-specific data.
+
+### Installation
+
+```ts
+import { createClient } from '@solana/kit';
+import { transactionPlanner, transactionPlanSigningExecutor } from '@solana/kit-plugin-instruction-plan';
+
+const client = createClient()
+    .use(transactionPlanner(myTransactionPlanner))
+    .use(transactionPlanSigningExecutor(myTransactionPlanSigningExecutor));
+```
+
+### Features
+
+- `signTransactions`: Plans and signs transaction messages, instructions or instruction plans without sending them.
+
+    ```ts
+    const transactionPlanResult = await client.signTransactions(myInstructionPlan);
+    ```
+
+- `signTransaction`: Same as `signTransactions` but asserts that the result is successful and contains a single transaction. Should the provided input result in multiple transactions, an error will be thrown.
+
+    ```ts
+    const transactionPlanResult = await client.signTransaction(myInstructionPlan);
+    ```
 
 ## Deprecated plugins
 

--- a/packages/kit-plugin-instruction-plan/src/core.ts
+++ b/packages/kit-plugin-instruction-plan/src/core.ts
@@ -5,17 +5,24 @@ import {
     CanceledSingleTransactionPlanResult,
     ClientWithTransactionPlanning,
     ClientWithTransactionSending,
+    ClientWithTransactionSigning,
     createFailedToSendTransactionError,
     createFailedToSendTransactionsError,
+    createFailedToSignTransactionError,
+    createFailedToSignTransactionsError,
     extendClient,
     FailedSingleTransactionPlanResult,
+    InstructionPlanInput,
     isSolanaError,
     isTransactionPlan,
     parseInstructionOrTransactionPlanInput,
     parseInstructionPlanInput,
     singleTransactionPlan,
     SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN,
+    SuccessfulSingleTransactionPlanResult,
+    SingleTransactionPlan,
     TransactionPlanExecutor,
+    TransactionPlanInput,
     TransactionPlanner,
     TransactionPlanResult,
     TransactionPlanResultContext,
@@ -107,6 +114,7 @@ export function transactionPlanner(transactionPlanner: TransactionPlanner) {
  * ```
  *
  * @see {@link transactionPlanner}
+ * @see {@link transactionPlanSigningExecutor}
  */
 export function transactionPlanSendingExecutor<
     TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
@@ -125,6 +133,64 @@ export function transactionPlanSendingExecutor<
             ...getTransactionSendingFunctions(client, transactionPlanExecutor),
             transactionPlanExecutor,
         };
+        return extendClient(client, additions);
+    };
+}
+
+/**
+ * A plugin that adds `signTransaction` and `signTransactions` functions to the
+ * client, using the client's planning functions and the provided transaction
+ * plan executor.
+ *
+ * Both functions accept transaction messages, instructions, instruction plans
+ * or transaction plans as input, planning the input first when it is not
+ * already a transaction plan. Planning goes through the client's
+ * `planTransaction` and `planTransactions` functions, so the
+ * {@link transactionPlanner} plugin must be installed first.
+ *
+ * Note that `signTransaction` asserts that the transaction plan result is both
+ * successful and contains a single transaction. This differs from
+ * `signTransactions`, which returns the full transaction plan result as
+ * produced by the executor.
+ *
+ * @typeParam TContext - The extra context type provided by the transaction plan
+ * executor on its transaction plan results. It is inferred from the executor.
+ *
+ * @param transactionPlanExecutor - The transaction plan executor used to sign
+ * planned transactions.
+ * @returns A plugin that adds `client.signTransaction` and `client.signTransactions`.
+ * @throws If the client has no `planTransaction` or `planTransactions` set.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from '@solana/kit';
+ * import { transactionPlanner, transactionPlanSigningExecutor } from '@solana/kit-plugin-instruction-plan';
+ *
+ * const client = createClient()
+ *     .use(transactionPlanner(myTransactionPlanner))
+ *     .use(transactionPlanSigningExecutor(myTransactionPlanSigningExecutor));
+ *
+ * const singleResult = await client.signTransaction(myInstructionPlan);
+ * const result = await client.signTransactions(myInstructionPlan);
+ * ```
+ *
+ * @see {@link transactionPlanner}
+ * @see {@link transactionPlanSendingExecutor}
+ */
+export function transactionPlanSigningExecutor<TContext extends TransactionPlanResultContext>(
+    transactionPlanExecutor: TransactionPlanExecutor<TContext>,
+) {
+    return <T extends ClientWithTransactionPlanning>(client: T) => {
+        if (!client.planTransaction || !client.planTransactions) {
+            throw new Error(
+                'Transaction planning functions are required on the client to sign transactions. ' +
+                    'Please add a transaction planner plugin to your client before using this plugin.',
+            );
+        }
+        const additions: ClientWithTransactionSigning<TContext> = getTransactionSigningFunctions(
+            client,
+            transactionPlanExecutor,
+        );
         return extendClient(client, additions);
     };
 }
@@ -263,7 +329,49 @@ function getTransactionSendingFunctions<TContext extends TransactionPlanResultCo
     client: ClientWithTransactionPlanning,
     executor: TransactionPlanExecutor<TContext>,
 ): ClientWithTransactionSending<TContext> {
-    const sendTransactions: ClientWithTransactionSending<TContext>['sendTransactions'] = async (input, config = {}) => {
+    const { executeTransaction, executeTransactions } = getTransactionExecutionFunctions(client, executor, {
+        createTransactionError: createFailedToSendTransactionError,
+        createTransactionsError: createFailedToSendTransactionsError,
+    });
+    return { sendTransaction: executeTransaction, sendTransactions: executeTransactions };
+}
+
+function getTransactionSigningFunctions<TContext extends TransactionPlanResultContext>(
+    client: ClientWithTransactionPlanning,
+    executor: TransactionPlanExecutor<TContext>,
+): ClientWithTransactionSigning<TContext> {
+    const { executeTransaction, executeTransactions } = getTransactionExecutionFunctions(client, executor, {
+        createTransactionError: createFailedToSignTransactionError,
+        createTransactionsError: createFailedToSignTransactionsError,
+    });
+    return { signTransaction: executeTransaction, signTransactions: executeTransactions };
+}
+
+type ExecuteTransactionFunction<TContext extends TransactionPlanResultContext> = (
+    input: InstructionPlanInput | SingleTransactionPlan | SingleTransactionPlan['message'],
+    config?: { abortSignal?: AbortSignal },
+) => Promise<SuccessfulSingleTransactionPlanResult<TContext>>;
+
+type ExecuteTransactionsFunction<TContext extends TransactionPlanResultContext> = (
+    input: InstructionPlanInput | TransactionPlanInput,
+    config?: { abortSignal?: AbortSignal },
+) => Promise<TransactionPlanResult<TContext>>;
+
+function getTransactionExecutionFunctions<TContext extends TransactionPlanResultContext>(
+    client: ClientWithTransactionPlanning,
+    executor: TransactionPlanExecutor<TContext>,
+    errorFactories: {
+        createTransactionError: (
+            result: CanceledSingleTransactionPlanResult<TContext> | FailedSingleTransactionPlanResult<TContext>,
+            abortReason?: unknown,
+        ) => Error;
+        createTransactionsError: (result: TransactionPlanResult<TContext>, abortReason?: unknown) => Error;
+    },
+): {
+    executeTransaction: ExecuteTransactionFunction<TContext>;
+    executeTransactions: ExecuteTransactionsFunction<TContext>;
+} {
+    const executeTransactions: ExecuteTransactionsFunction<TContext> = async (input, config = {}) => {
         const plan = parseInstructionOrTransactionPlanInput(input);
         config?.abortSignal?.throwIfAborted();
         const transactionPlan = isTransactionPlan(plan) ? plan : await client.planTransactions(plan, config);
@@ -274,14 +382,14 @@ function getTransactionSendingFunctions<TContext extends TransactionPlanResultCo
             if (!isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)) {
                 throw error;
             }
-            throw createFailedToSendTransactionsError(
-                error.context.transactionPlanResult as TransactionPlanResult,
+            throw errorFactories.createTransactionsError(
+                error.context.transactionPlanResult as TransactionPlanResult<TContext>,
                 error.context.abortReason,
             );
         }
     };
 
-    const sendTransaction: ClientWithTransactionSending<TContext>['sendTransaction'] = async (input, config = {}) => {
+    const executeTransaction: ExecuteTransactionFunction<TContext> = async (input, config = {}) => {
         const plan = parseInstructionOrTransactionPlanInput(input);
         config?.abortSignal?.throwIfAborted();
         const transactionPlan = isTransactionPlan(plan)
@@ -297,14 +405,14 @@ function getTransactionSendingFunctions<TContext extends TransactionPlanResultCo
                 throw error;
             }
             assertIsSingleTransactionPlanResult(error.context.transactionPlanResult as TransactionPlanResult);
-            throw createFailedToSendTransactionError(
+            throw errorFactories.createTransactionError(
                 error.context.transactionPlanResult as
-                    | CanceledSingleTransactionPlanResult
-                    | FailedSingleTransactionPlanResult,
+                    | CanceledSingleTransactionPlanResult<TContext>
+                    | FailedSingleTransactionPlanResult<TContext>,
                 error.context.abortReason,
             );
         }
     };
 
-    return { sendTransaction, sendTransactions };
+    return { executeTransaction, executeTransactions };
 }

--- a/packages/kit-plugin-instruction-plan/test/core.test.ts
+++ b/packages/kit-plugin-instruction-plan/test/core.test.ts
@@ -16,6 +16,8 @@ import {
     singleTransactionPlan,
     SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION,
     SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS,
+    SOLANA_ERROR__FAILED_TO_SIGN_TRANSACTION,
+    SOLANA_ERROR__FAILED_TO_SIGN_TRANSACTIONS,
     SOLANA_ERROR__INSTRUCTION_PLANS__UNEXPECTED_TRANSACTION_PLAN,
     SOLANA_ERROR__INSTRUCTION_PLANS__UNEXPECTED_TRANSACTION_PLAN_RESULT,
     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
@@ -29,14 +31,16 @@ import {
     TransactionPlanExecutor,
     TransactionPlanner,
     TransactionPlanResult,
+    TransactionPlanResultContext,
 } from '@solana/kit';
-import { assert, describe, expect, it, vi } from 'vitest';
+import { assert, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import {
     planAndSendTransactions,
     transactionPlanExecutor,
     transactionPlanner,
     transactionPlanSendingExecutor,
+    transactionPlanSigningExecutor,
 } from '../src';
 
 describe('transactionPlanner', () => {
@@ -131,6 +135,159 @@ describe('transactionPlanSendingExecutor', () => {
         expect(() => createClient().use(transactionPlanSendingExecutor(vi.fn()))).toThrow(
             /Transaction planning functions are required/,
         );
+    });
+});
+
+describe('transactionPlanSigningExecutor', () => {
+    function createSigningTestClient<TContext extends TransactionPlanResultContext>(
+        planner: TransactionPlanner,
+        executor: TransactionPlanExecutor<TContext>,
+    ) {
+        return createClient().use(transactionPlanner(planner)).use(transactionPlanSigningExecutor(executor));
+    }
+
+    it('adds signTransaction and signTransactions to the client', () => {
+        const client = createSigningTestClient(vi.fn(), vi.fn());
+        expect(client).toHaveProperty('signTransaction');
+        expect(client).toHaveProperty('signTransactions');
+    });
+
+    it('requires transaction planning functions on the client', () => {
+        // @ts-expect-error Missing planning functions on the client.
+        expect(() => createClient().use(transactionPlanSigningExecutor(vi.fn()))).toThrow(
+            /Transaction planning functions are required/,
+        );
+    });
+
+    it('plans and signs a single instruction while preserving the executor context type', async () => {
+        const instruction = {} as Instruction;
+        const message = {} as TransactionMessage & TransactionMessageWithFeePayer;
+        const result = successfulSingleTransactionPlanResult(message, { signedTransaction: 'signed' });
+        const planner = vi.fn().mockResolvedValue(singleTransactionPlan(message));
+        const executor: TransactionPlanExecutor<{ signedTransaction: string }> = vi.fn().mockResolvedValue(result);
+        const client = createSigningTestClient(planner, executor);
+
+        const signedResult = await client.signTransaction(instruction);
+        expectTypeOf(signedResult.context.signedTransaction).toEqualTypeOf<string>();
+
+        expect(signedResult).toBe(result);
+        expect(planner).toHaveBeenCalledExactlyOnceWith(singleInstructionPlan(instruction), {
+            abortSignal: undefined,
+        });
+        expect(executor).toHaveBeenCalledExactlyOnceWith(singleTransactionPlan(message), {
+            abortSignal: undefined,
+        });
+    });
+
+    it('rejects when signTransaction receives a multi-transaction result', async () => {
+        const instruction = {} as Instruction;
+        const message = {} as TransactionMessage & TransactionMessageWithFeePayer;
+        const transactionPlan = singleTransactionPlan(message);
+        const transactionPlanResult = sequentialTransactionPlanResult([
+            successfulSingleTransactionPlanResult(message, { signedTransaction: 'signed' }),
+        ]);
+        const planner = vi.fn().mockResolvedValue(transactionPlan);
+        const executor = vi.fn().mockResolvedValue(transactionPlanResult);
+        const client = createSigningTestClient(planner, executor);
+
+        await expect(client.signTransaction(instruction)).rejects.toThrow(
+            new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__UNEXPECTED_TRANSACTION_PLAN_RESULT, {
+                actualKind: 'sequential',
+                expectedKind: 'successful single',
+                transactionPlanResult,
+            }),
+        );
+    });
+
+    it('plans and signs multiple instructions', async () => {
+        const instructionPlan = sequentialInstructionPlan([{} as Instruction, {} as Instruction]);
+        const transactionPlan = sequentialTransactionPlan([
+            {} as TransactionMessage & TransactionMessageWithFeePayer,
+            {} as TransactionMessage & TransactionMessageWithFeePayer,
+        ]);
+        const result = sequentialTransactionPlanResult([]);
+        const planner = vi.fn().mockResolvedValue(transactionPlan);
+        const executor = vi.fn().mockResolvedValue(result);
+        const client = createSigningTestClient(planner, executor);
+
+        await expect(client.signTransactions(instructionPlan)).resolves.toBe(result);
+        expect(planner).toHaveBeenCalledExactlyOnceWith(instructionPlan, { abortSignal: undefined });
+        expect(executor).toHaveBeenCalledExactlyOnceWith(transactionPlan, { abortSignal: undefined });
+    });
+
+    it('signs transaction plans without calling the planner', async () => {
+        const transactionPlan = sequentialTransactionPlan([
+            {} as TransactionMessage & TransactionMessageWithFeePayer,
+            {} as TransactionMessage & TransactionMessageWithFeePayer,
+        ]);
+        const result = sequentialTransactionPlanResult([]);
+        const planner = vi.fn();
+        const executor = vi.fn().mockResolvedValue(result);
+        const client = createSigningTestClient(planner, executor);
+
+        await client.signTransactions(transactionPlan);
+
+        expect(planner).not.toHaveBeenCalled();
+        expect(executor).toHaveBeenCalledExactlyOnceWith(transactionPlan, { abortSignal: undefined });
+    });
+
+    it('passes the abort signal to the planner and executor', async () => {
+        const message = {} as TransactionMessage & TransactionMessageWithFeePayer;
+        const result = successfulSingleTransactionPlanResult(message, {});
+        const planner = vi.fn().mockResolvedValue(singleTransactionPlan(message));
+        const executor = vi.fn().mockResolvedValue(result);
+        const client = createSigningTestClient(planner, executor);
+        const abortSignal = new AbortController().signal;
+
+        await client.signTransaction({} as Instruction, { abortSignal });
+
+        expect(planner).toHaveBeenCalledExactlyOnceWith(expect.any(Object), { abortSignal });
+        expect(executor).toHaveBeenCalledExactlyOnceWith(singleTransactionPlan(message), { abortSignal });
+    });
+
+    it('does not call the planner or executor if the abort signal is already triggered', async () => {
+        const planner = vi.fn();
+        const executor = vi.fn();
+        const client = createSigningTestClient(planner, executor);
+        const abortController = new AbortController();
+        abortController.abort();
+
+        await client.signTransactions({} as Instruction, { abortSignal: abortController.signal }).catch(() => {});
+
+        expect(planner).not.toHaveBeenCalled();
+        expect(executor).not.toHaveBeenCalled();
+    });
+
+    it('re-wraps a failed-to-execute error into a failed-to-sign-transaction error', async () => {
+        const message = setTransactionMessageFeePayer('1111' as Address, createTransactionMessage({ version: 0 }));
+        const failedResult = failedSingleTransactionPlanResult(message, new Error('signing failed'));
+        const executor = vi.fn().mockRejectedValue(createFailedToExecuteTransactionPlanError(failedResult));
+        const client = createSigningTestClient(vi.fn(), executor);
+
+        const thrownError = await client.signTransaction(message).catch((error: unknown) => error);
+
+        assert(isSolanaError(thrownError, SOLANA_ERROR__FAILED_TO_SIGN_TRANSACTION));
+    });
+
+    it('re-wraps a failed-to-execute error into a failed-to-sign-transactions error', async () => {
+        const message = {} as TransactionMessage & TransactionMessageWithFeePayer;
+        const transactionPlan = singleTransactionPlan(message);
+        const failedResult = failedSingleTransactionPlanResult(message, new Error('signing failed'));
+        const executor = vi.fn().mockRejectedValue(createFailedToExecuteTransactionPlanError(failedResult));
+        const client = createSigningTestClient(vi.fn(), executor);
+
+        const thrownError = await client.signTransactions(transactionPlan).catch((error: unknown) => error);
+
+        assert(isSolanaError(thrownError, SOLANA_ERROR__FAILED_TO_SIGN_TRANSACTIONS));
+    });
+
+    it('re-throws non-Solana errors unchanged', async () => {
+        const message = setTransactionMessageFeePayer('1111' as Address, createTransactionMessage({ version: 0 }));
+        const genericError = new Error('something went wrong');
+        const executor = vi.fn().mockRejectedValue(genericError);
+        const client = createSigningTestClient(vi.fn(), executor);
+
+        await expect(client.signTransaction(message)).rejects.toBe(genericError);
     });
 });
 


### PR DESCRIPTION
Add a transaction plan signing plugin that installs Kit's `ClientWithTransactionSigning` methods to `kit-plugin-instruction-plan`.

This is the same idea as the sending one, it takes an executor and installs its functionality as the `signTransaction(s)` functions. This executor will be provided by the rpc and LiteSVM plugins calling it.

The common transaction execution flow is shared with the sending plugin. This refactor isn't really necessary for only two implementations, but I think it makes sense because it demonstrates how we split the logic between the input executor and these client functions, and I think any other addition should use the same pattern.

Note: Also added AGENTS.md as a symlink from CLAUDE.md, same as we do in Kit 