### PR TITLE
Support executing version 1 transactions in `kit-plugin-litesvm`

### DIFF
--- a/.changeset/some-readers-sing.md
+++ b/.changeset/some-readers-sing.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-litesvm': minor
+---
+
+Add version 1 transaction execution support by raising the `litesvm` dependency floor from `^1.3.0` to `^1.4.1`. This upgrades the local SVM to Agave 4.2, aligns litesvm's own `@solana/kit` dependency with v8, and makes transaction plans created with `litesvmTransactionPlanner({ version: 1 })` executable end to end. Since unset resource limits in a version 1 transaction config are treated as zero by the runtime and LiteSVM performs no simulation-based estimation, the planner now writes maximum resource limits to the version 1 resource header by default, overridable via the new `computeUnitLimit` and `loadedAccountsDataSizeLimit` config options.

--- a/packages/kit-plugin-litesvm/README.md
+++ b/packages/kit-plugin-litesvm/README.md
@@ -166,8 +166,10 @@ All options are provided via a `TransactionPlannerConfig` object. Its shape is d
 
     - `version`: Set to `1` to create version 1 transaction messages.
     - `priorityFeeLamports`: The total priority fee in lamports, written to the version 1 resource header. Defaults to no priority fees.
+    - `computeUnitLimit`: The compute unit limit, written to the version 1 resource header. Defaults to the maximum limit of 1,400,000 compute units.
+    - `loadedAccountsDataSizeLimit`: The loaded accounts data size limit in bytes, written to the version 1 resource header. Defaults to the maximum limit of 64 MiB.
 
-Unlike the RPC planner, the LiteSVM planner does not estimate resource limits, since LiteSVM executes transactions locally without a simulation-based estimation step.
+Unlike the RPC planner, the LiteSVM planner does not estimate resource limits, since LiteSVM executes transactions locally without a simulation-based estimation step. Since unset resource limits in a version 1 transaction config are treated as zero by the runtime, the planner writes maximum limits to the resource header by default.
 
 ## `litesvmTransactionPlanSendingExecutor` plugin
 

--- a/packages/kit-plugin-litesvm/package.json
+++ b/packages/kit-plugin-litesvm/package.json
@@ -53,7 +53,7 @@
     },
     "dependencies": {
         "@solana/kit-plugin-instruction-plan": "workspace:*",
-        "litesvm": "^1.3.0"
+        "litesvm": "^1.4.1"
     },
     "devDependencies": {
         "@solana-program/system": "^0.13.0"

--- a/packages/kit-plugin-litesvm/src/transaction-planner.ts
+++ b/packages/kit-plugin-litesvm/src/transaction-planner.ts
@@ -5,12 +5,20 @@ import {
     Lamports,
     MicroLamports,
     pipe,
+    setTransactionMessageComputeUnitLimit,
     setTransactionMessageComputeUnitPrice,
     setTransactionMessageFeePayerSigner,
+    setTransactionMessageLoadedAccountsDataSizeLimit,
     setTransactionMessagePriorityFeeLamports,
     TransactionPlanner,
 } from '@solana/kit';
 import { transactionPlanner } from '@solana/kit-plugin-instruction-plan';
+
+/** The maximum compute unit limit a transaction can request from the runtime. */
+const MAX_COMPUTE_UNIT_LIMIT = 1_400_000;
+
+/** The maximum loaded accounts data size a transaction can request from the runtime, i.e. 64 MiB. */
+const MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES = 64 * 1024 * 1024;
 
 /**
  * A plugin that provides a default transaction planner using LiteSVM.
@@ -21,7 +29,9 @@ import { transactionPlanner } from '@solana/kit-plugin-instruction-plan';
  *
  * Unlike the RPC planner, the LiteSVM planner does not estimate resource limits,
  * since LiteSVM executes transactions locally without a simulation-based
- * estimation step.
+ * estimation step. For version 1 transactions — whose unset resource limits are
+ * treated as zero by the runtime — the planner writes maximum limits to the
+ * resource header by default, which can be overridden via the config.
  *
  * The fee payer is read from `client.payer` lazily, at plan time, so that a
  * dynamic payer (such as a connected wallet) is always respected.
@@ -60,14 +70,25 @@ function createPlanner(client: ClientWithPayer, config: TransactionPlannerConfig
 
 /**
  * Creates a planner that builds version 1 transaction messages, writing the
- * priority fee to the resource header.
+ * resource limits and priority fee to the resource header.
+ *
+ * Unset resource limits in a version 1 transaction config are treated as zero
+ * by the runtime, and LiteSVM performs no simulation-based estimation step, so
+ * the planner writes maximum limits by default to keep local testing
+ * frictionless. Both limits can be overridden via the config.
  */
 function createV1Planner(client: ClientWithPayer, config: TransactionPlannerConfigV1): TransactionPlanner {
-    const { priorityFeeLamports } = config;
+    const {
+        computeUnitLimit = MAX_COMPUTE_UNIT_LIMIT,
+        loadedAccountsDataSizeLimit = MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
+        priorityFeeLamports,
+    } = config;
     return createTransactionPlanner({
         createTransactionMessage: () =>
             pipe(
                 createTransactionMessage({ version: 1 }),
+                tx => setTransactionMessageComputeUnitLimit(computeUnitLimit, tx),
+                tx => setTransactionMessageLoadedAccountsDataSizeLimit(loadedAccountsDataSizeLimit, tx),
                 tx => setTransactionMessageFeePayerSigner(client.payer, tx),
                 tx =>
                     priorityFeeLamports === undefined
@@ -127,6 +148,23 @@ export type TransactionPlannerConfigLegacy = {
  * rather than a per-compute-unit price.
  */
 export type TransactionPlannerConfigV1 = {
+    /**
+     * The compute unit limit to set on the transaction, written to the
+     * version 1 resource header.
+     *
+     * Unset limits are treated as zero by the runtime and LiteSVM performs no
+     * estimation step, so this defaults to the maximum limit of 1,400,000
+     * compute units.
+     */
+    computeUnitLimit?: number;
+    /**
+     * The loaded accounts data size limit to set on the transaction, in bytes,
+     * written to the version 1 resource header.
+     *
+     * Unset limits are treated as zero by the runtime and LiteSVM performs no
+     * estimation step, so this defaults to the maximum limit of 64 MiB.
+     */
+    loadedAccountsDataSizeLimit?: number;
     /**
      * The total priority fee to set on the transaction, in lamports, written to
      * the version 1 resource header.

--- a/packages/kit-plugin-litesvm/test/transaction-plan-executor.test.ts
+++ b/packages/kit-plugin-litesvm/test/transaction-plan-executor.test.ts
@@ -13,6 +13,7 @@ import {
     setTransactionMessageFeePayerSigner,
     singleInstructionPlan,
     singleTransactionPlan,
+    SingleTransactionPlan,
     SingleTransactionPlanResult,
     SOLANA_ERROR__INSTRUCTION_ERROR__INVALID_INSTRUCTION_DATA,
     SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN,
@@ -234,6 +235,29 @@ describe('litesvmTransactionPlanSendingExecutor', () => {
             const transactionPlan = await client.transactionPlanner(instructionPlan);
             const result = (await client.transactionPlanExecutor(transactionPlan)) as SingleTransactionPlanResult;
             expect(result.kind).toBe('single');
+        });
+
+        it('plans and executes a version 1 transaction', async () => {
+            const payer = await generateKeyPairSigner();
+            const destination = await generateKeyPairSigner();
+            const client = createClient()
+                .use(litesvmConnection())
+                .use(client => extendClient(client, { payer }))
+                .use(litesvmTransactionPlanner({ version: 1 }))
+                .use(litesvmTransactionPlanSendingExecutor());
+            client.svm.airdrop(payer.address, lamports(1_000_000_000n)); // 1 SOL
+
+            const instruction = getTransferSolInstruction({
+                amount: lamports(100_000_000n), // 0.1 SOL
+                destination: destination.address,
+                source: payer,
+            });
+            const instructionPlan = singleInstructionPlan(instruction);
+            const transactionPlan = (await client.transactionPlanner(instructionPlan)) as SingleTransactionPlan;
+            expect(transactionPlan.message.version).toBe(1);
+            const result = (await client.transactionPlanExecutor(transactionPlan)) as SingleTransactionPlanResult;
+            expect(result.status).toBe('successful');
+            expect(client.svm.getBalance(destination.address)).toBe(lamports(100_000_000n));
         });
 
         it('throws a SolanaError when a real transaction fails with an instruction error', async () => {

--- a/packages/kit-plugin-litesvm/test/transaction-planner.test.ts
+++ b/packages/kit-plugin-litesvm/test/transaction-planner.test.ts
@@ -2,7 +2,9 @@ import {
     Address,
     createClient,
     generateKeyPairSigner,
+    getTransactionMessageComputeUnitLimit,
     getTransactionMessageComputeUnitPrice,
+    getTransactionMessageLoadedAccountsDataSizeLimit,
     getTransactionMessagePriorityFeeLamports,
     Lamports,
     MicroLamports,
@@ -140,6 +142,40 @@ describe('litesvmTransactionPlanner', () => {
         expect(getTransactionMessagePriorityFeeLamports(message)).toBe(100n);
     });
 
+    it('sets maximum resource limits on version 1 transaction messages by default', async () => {
+        const payer = await generateKeyPairSigner();
+        const client = createClient()
+            .use(() => ({ payer }))
+            .use(litesvmTransactionPlanner({ version: 1 }));
+
+        // Unset resource limits in a version 1 transaction config are treated
+        // as zero by the runtime, so the planner defaults to maximum limits.
+        const instructionPlan = singleInstructionPlan(MOCK_INSTRUCTION);
+        const transactionPlan = (await client.transactionPlanner(instructionPlan)) as SingleTransactionPlan;
+        const message = transactionPlan.message as TransactionMessage & { version: 1 };
+        expect(getTransactionMessageComputeUnitLimit(message)).toBe(1_400_000);
+        expect(getTransactionMessageLoadedAccountsDataSizeLimit(message)).toBe(64 * 1024 * 1024);
+    });
+
+    it('sets custom resource limits on version 1 transaction messages when configured', async () => {
+        const payer = await generateKeyPairSigner();
+        const client = createClient()
+            .use(() => ({ payer }))
+            .use(
+                litesvmTransactionPlanner({
+                    computeUnitLimit: 200_000,
+                    loadedAccountsDataSizeLimit: 1024 * 1024,
+                    version: 1,
+                }),
+            );
+
+        const instructionPlan = singleInstructionPlan(MOCK_INSTRUCTION);
+        const transactionPlan = (await client.transactionPlanner(instructionPlan)) as SingleTransactionPlan;
+        const message = transactionPlan.message as TransactionMessage & { version: 1 };
+        expect(getTransactionMessageComputeUnitLimit(message)).toBe(200_000);
+        expect(getTransactionMessageLoadedAccountsDataSizeLimit(message)).toBe(1024 * 1024);
+    });
+
     it('requires a payer on the client', () => {
         // @ts-expect-error TypeScript fails but we don't throw an error at runtime.
         expect(() => createClient().use(litesvmTransactionPlanner())).not.toThrow();
@@ -155,5 +191,12 @@ describe('litesvmTransactionPlanner', () => {
         assertType<TransactionPlannerConfig>({ priorityFeeLamports: 1n as Lamports, version: 1 });
         // @ts-expect-error `microLamportsPerComputeUnit` is only valid for legacy and version 0.
         assertType<TransactionPlannerConfig>({ microLamportsPerComputeUnit: 1n as MicroLamports, version: 1 });
+
+        // Version 1 accepts resource limits but legacy and version 0 do not.
+        assertType<TransactionPlannerConfig>({ computeUnitLimit: 1, loadedAccountsDataSizeLimit: 1, version: 1 });
+        // @ts-expect-error `computeUnitLimit` is only valid for version 1.
+        assertType<TransactionPlannerConfig>({ computeUnitLimit: 1, version: 0 });
+        // @ts-expect-error `loadedAccountsDataSizeLimit` is only valid for version 1.
+        assertType<TransactionPlannerConfig>({ loadedAccountsDataSizeLimit: 1, version: 0 });
     });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: workspace:*
         version: link:../kit-plugin-instruction-plan
       litesvm:
-        specifier: ^1.3.0
-        version: 1.3.0(typescript@7.0.2)
+        specifier: ^1.4.1
+        version: 1.4.1(typescript@7.0.2)
     devDependencies:
       '@solana-program/system':
         specifier: ^0.13.0
@@ -1151,8 +1151,19 @@ packages:
     peerDependencies:
       '@solana/kit': ^8.0.0
 
+  '@solana-program/system@0.14.0':
+    resolution: {integrity: sha512-Pjs2RINZHYmk/pqWNBCuQmfNjZT9woPJ/w7QkzzCSwcqcokbARtxsnIdgj4lJVxvr1DuxG8JGIbKnq6z1QRY6Q==}
+    peerDependencies:
+      '@solana/kit': ^8.0.0
+
   '@solana-program/token@0.14.0':
     resolution: {integrity: sha512-zpLMr6JZndlsQCQvrm0gezfwdr1lmzOGqN6v2WIYXjtDmbF+xg6zh/MAp2UFHRpv3uDmylEdjtQo05pa2OeaYg==}
+    engines: {node: '>=24.0.0'}
+    peerDependencies:
+      '@solana/kit': ^8.0.0
+
+  '@solana-program/token@0.16.0':
+    resolution: {integrity: sha512-VuFIu5vXsw1zwqls4/sGB88234oucmpuig553A33UnrbYnPZ8yXmqLYULBD92/k1pCGnMK+NMLWvsKzlZQ/1Kw==}
     engines: {node: '>=24.0.0'}
     peerDependencies:
       '@solana/kit': ^8.0.0
@@ -2062,44 +2073,38 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  litesvm-darwin-arm64@1.3.0:
-    resolution: {integrity: sha512-fj6cV/ofjMXdl5CwjyyLTQnZObfVH5HYDScQ6O44iRqxASmgEyEh4sC8a7M0YZ1rcli9nu2cWl5ARGura89I7Q==}
+  litesvm-darwin-arm64@1.4.1:
+    resolution: {integrity: sha512-6dofWLOxtknSL0W6N9W3f/kdnitsJ3xR0oE1W37CLcfd5kX4qCMVbaejZWJkLo4G2JzAk+hFZi965Z2OPyJACg==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
 
-  litesvm-darwin-x64@1.3.0:
-    resolution: {integrity: sha512-ZYEddnc+tAn8sVYpzvww0oHFiekbCSv+0OZiA6eUDtcSx9uzeRDmPPQ9eI6vgyews2LefBDSENmUb70GHY6Cqg==}
+  litesvm-darwin-x64@1.4.1:
+    resolution: {integrity: sha512-Rjyg6SfnSKAO5/vMpnZpIHTcBWEUzjFj/GshXwzdyiWorrpC0poQjK3OJ9RJneJW2YDd+oUsGZCfwAplTXPGfg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
-  litesvm-linux-arm64-gnu@1.3.0:
-    resolution: {integrity: sha512-kmmKeef96pJI4AJGCvjzMCW6QHuzFrMF1i6dE6OcrtWHaz0Ag+TFaKOU35H1bjH/fDBwoJUV9UbaIbdWht81tA==}
+  litesvm-linux-arm64-gnu@1.4.1:
+    resolution: {integrity: sha512-hyL/tcuFisAwNEwVzDGjtDRuLYDc+8PoX9QZU/M46vsLrdU2WCBU3g4WdV5z0z1nPl16TzcHVboqydyBy3ImFQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
 
-  litesvm-linux-arm64-musl@1.3.0:
-    resolution: {integrity: sha512-FO9p6rx+/3h7R3CU7lkOebL+jy8UEDngSrENHu7pj9EOr78QVyE3Fm0O+WMnwXpMoCSgW0XLhu1cI9NHAbzCTA==}
+  litesvm-linux-arm64-musl@1.4.1:
+    resolution: {integrity: sha512-Folc4nWAXwkWvwK5iqf3C74eNAPRERg8Yn2QGVW+6pMgCXtaQt77PuIB9m32mLo+W+LZxiU+t3et0ZiFEm4YgQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
 
-  litesvm-linux-x64-gnu@1.3.0:
-    resolution: {integrity: sha512-yXC8ZAdIei9JQ2xw5/BocOTu/7EqZuFPyhgENQ1mYDhjNpoyUbIuGCWnqtria14mDda0aV9yVev8plGUrUpjUw==}
+  litesvm-linux-x64-gnu@1.4.1:
+    resolution: {integrity: sha512-sAKax22lAMS0DpWQcT6ICt8vs6phEjRJXT84LhhftnlNkcU03b0RJziFDr34LUTrkY5SMi/uqZEy0T86Xokg+w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
 
-  litesvm-linux-x64-musl@1.3.0:
-    resolution: {integrity: sha512-oedromp1gTjShXmKmxZ1FYtnfM824vRcrPSPvGM0CrqJqKK61m1+tFwNRAVsDlpmWKvO/zsz90ctbgAUo/3TXg==}
-    engines: {node: '>= 20'}
-    cpu: [x64]
-    os: [linux]
-
-  litesvm@1.3.0:
-    resolution: {integrity: sha512-tMu9sBIqSbF1gQluXEUtGmXPfZlMc10tOoBVeDokgK77nl/CcuC506sEoFKM5Rq58Dkb070lBMVBLc43TbMUzQ==}
+  litesvm@1.4.1:
+    resolution: {integrity: sha512-SGMdN6c44m5Deo27nZX7GIn42e/OlfQ4jIv0JIVxR3F5vU8ZbbjsLRGUj3b/r5jCITyN22u14JnuP+mhDyNLlg==}
     engines: {node: '>= 20'}
 
   load-tsconfig@0.2.5:
@@ -3112,9 +3117,18 @@ snapshots:
     dependencies:
       '@solana/kit': 8.0.0(typescript@7.0.2)
 
+  '@solana-program/system@0.14.0(@solana/kit@8.0.0(typescript@7.0.2))':
+    dependencies:
+      '@solana/kit': 8.0.0(typescript@7.0.2)
+
   '@solana-program/token@0.14.0(@solana/kit@8.0.0(typescript@7.0.2))':
     dependencies:
       '@solana-program/system': 0.12.2(@solana/kit@8.0.0(typescript@7.0.2))
+      '@solana/kit': 8.0.0(typescript@7.0.2)
+
+  '@solana-program/token@0.16.0(@solana/kit@8.0.0(typescript@7.0.2))':
+    dependencies:
+      '@solana-program/system': 0.14.0(@solana/kit@8.0.0(typescript@7.0.2))
       '@solana/kit': 8.0.0(typescript@7.0.2)
 
   '@solana/accounts@8.0.0(typescript@7.0.2)':
@@ -4102,36 +4116,32 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  litesvm-darwin-arm64@1.3.0:
+  litesvm-darwin-arm64@1.4.1:
     optional: true
 
-  litesvm-darwin-x64@1.3.0:
+  litesvm-darwin-x64@1.4.1:
     optional: true
 
-  litesvm-linux-arm64-gnu@1.3.0:
+  litesvm-linux-arm64-gnu@1.4.1:
     optional: true
 
-  litesvm-linux-arm64-musl@1.3.0:
+  litesvm-linux-arm64-musl@1.4.1:
     optional: true
 
-  litesvm-linux-x64-gnu@1.3.0:
+  litesvm-linux-x64-gnu@1.4.1:
     optional: true
 
-  litesvm-linux-x64-musl@1.3.0:
-    optional: true
-
-  litesvm@1.3.0(typescript@7.0.2):
+  litesvm@1.4.1(typescript@7.0.2):
     dependencies:
-      '@solana-program/system': 0.12.2(@solana/kit@8.0.0(typescript@7.0.2))
-      '@solana-program/token': 0.14.0(@solana/kit@8.0.0(typescript@7.0.2))
+      '@solana-program/system': 0.14.0(@solana/kit@8.0.0(typescript@7.0.2))
+      '@solana-program/token': 0.16.0(@solana/kit@8.0.0(typescript@7.0.2))
       '@solana/kit': 8.0.0(typescript@7.0.2)
     optionalDependencies:
-      litesvm-darwin-arm64: 1.3.0
-      litesvm-darwin-x64: 1.3.0
-      litesvm-linux-arm64-gnu: 1.3.0
-      litesvm-linux-arm64-musl: 1.3.0
-      litesvm-linux-x64-gnu: 1.3.0
-      litesvm-linux-x64-musl: 1.3.0
+      litesvm-darwin-arm64: 1.4.1
+      litesvm-darwin-x64: 1.4.1
+      litesvm-linux-arm64-gnu: 1.4.1
+      litesvm-linux-arm64-musl: 1.4.1
+      litesvm-linux-x64-gnu: 1.4.1
     transitivePeerDependencies:
       - bufferutil
       - fastestsmallesttextencoderdecoder


### PR DESCRIPTION
This PR raises the `litesvm` floor to `^1.4.1`, which brings Agave 4.2, aligns litesvm's `@solana/kit` dependency with v8, and includes the node bindings fix (LiteSVM/litesvm#412) that unblocks sending version 1 transactions from JavaScript. With execution unblocked, it also completes the v1 story for the LiteSVM planner: unset resource limits in a v1 transaction config are treated as zero by the runtime and LiteSVM performs no simulation-based estimation, so `litesvmTransactionPlanner({ version: 1 })` now writes maximum resource limits to the resource header by default, overridable via the new `computeUnitLimit` and `loadedAccountsDataSizeLimit` config options. A new end-to-end test plans and executes a v1 transfer against a real LiteSVM instance.