### PR TITLE
Add the `rpcTransactionPlanSigningExecutor` plugin

### DIFF
--- a/.changeset/tangy-coats-burn.md
+++ b/.changeset/tangy-coats-burn.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-rpc': minor
+---
+
+Add `rpcTransactionPlanSigningExecutor` for RPC-backed resource estimation and partial signing, and include transaction signing functions in `solanaRpc` clients.

--- a/packages/kit-plugin-rpc/README.md
+++ b/packages/kit-plugin-rpc/README.md
@@ -17,7 +17,7 @@ pnpm install @solana/kit-plugin-rpc
 
 ## `solanaRpc` plugin
 
-The `solanaRpc` plugin sets up a full Solana RPC client in a single call. It installs an RPC connection, RPC Subscriptions, minimum balance computation, transaction planning, and transaction execution on the client.
+The `solanaRpc` plugin sets up a full Solana RPC client in a single call. It installs an RPC connection, RPC Subscriptions, minimum balance computation, transaction planning, transaction signing, and transaction execution on the client.
 
 The client must have a `payer` set before applying this plugin.
 
@@ -42,7 +42,7 @@ All options are provided via a `SolanaRpcConfig` object:
 - `rpcConfig`: Optional configuration forwarded to `createSolanaRpc`.
 - `rpcSubscriptionsConfig`: Optional configuration forwarded to `createSolanaRpcSubscriptions`.
 - `transactionConfig`: Options to configure how transaction messages are created. See the `rpcTransactionPlanner` options below.
-- `maxConcurrency`: Maximum number of concurrent transaction executions. Defaults to 10.
+- `maxConcurrency`: Maximum number of concurrent transaction executions in the sending executor and transaction preparations in the signing executor. The executors have independent limits. Defaults to 10.
 - `skipPreflight`: Whether to always skip preflight simulation. Defaults to `false`.
 
 ### Features
@@ -52,6 +52,7 @@ All options are provided via a `SolanaRpcConfig` object:
 - `getMinimumBalance`: Compute minimum lamports for rent exemption.
 - `planTransaction(s)`: Plan instructions into transaction messages without executing them.
 - `sendTransaction(s)`: Plan and execute instructions, instruction plans, or transaction messages in one call.
+- `signTransaction(s)`: Plan and partially sign instructions, instruction plans, or transaction messages in one call.
 - `transactionPlanner` / `transactionPlanExecutor` (deprecated): Fields kept for backward compatibility. Use `planTransaction(s)` / `sendTransaction(s)` instead.
 
 ## `solanaMainnetRpc` plugin
@@ -273,13 +274,13 @@ All options are provided via a `TransactionPlannerConfig` object. Its shape is d
 
     - `version`: The transaction message version to use. Accepts `0` or `'legacy'`. Defaults to `0`.
     - `microLamportsPerComputeUnit`: The priority fee in micro-lamports per compute unit, added as a `setComputeUnitPrice` instruction. Defaults to no priority fees.
-    - `estimateResourceLimits`: Whether to estimate and set resource limits by simulating before sending. Set to `false` to skip estimation and reserve no provisory limits, which is useful for transactions close to the message size limit. Defaults to `true`.
+    - `estimateResourceLimits`: Whether to estimate and set resource limits by simulating before signing or sending. Set to `false` to skip estimation and reserve no provisory limits, which is useful for transactions close to the message size limit. Defaults to `true`.
 
 - For version 1 transactions:
 
     - `version`: Set to `1` to create version 1 transaction messages.
     - `priorityFeeLamports`: The total priority fee in lamports, written to the version 1 resource header. Defaults to no priority fees.
-    - `estimateResourceLimits`: Whether to estimate and set resource limits by simulating before sending. For version 1 transactions, estimation covers both the compute unit limit and the loaded accounts data size limit. Defaults to `true`.
+    - `estimateResourceLimits`: Whether to estimate and set resource limits by simulating before signing or sending. For version 1 transactions, estimation covers both the compute unit limit and the loaded accounts data size limit. Defaults to `true`.
 
 ## `rpcTransactionPlanSendingExecutor` plugin
 
@@ -381,6 +382,73 @@ const client = createClient()
         }),
     );
 ```
+
+## `rpcTransactionPlanSigningExecutor` plugin
+
+Adds `signTransaction` and `signTransactions` to the client, using an executor that sets a blockhash, estimates resource limits, and applies every available transaction signer without requiring the transaction to be fully signed.
+
+### Usage
+
+The client must have `rpc` configured and a transaction planner installed before installing this plugin.
+
+```ts
+import { createClient } from '@solana/kit';
+import { rpcTransactionPlanSigningExecutor, rpcTransactionPlanner, solanaRpcConnection } from '@solana/kit-plugin-rpc';
+import { generatedPayer } from '@solana/kit-plugin-signer';
+
+const client = await createClient()
+    .use(solanaRpcConnection({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
+    .use(generatedPayer())
+    .use(rpcTransactionPlanner())
+    .use(rpcTransactionPlanSigningExecutor());
+
+const transactionPlanResult = await client.signTransactions(myInstructionPlan);
+```
+
+`solanaRpc` installs this plugin automatically alongside the sending executor.
+
+Before signing, the executor replaces any lifetime already set on an input transaction message with a fresh blockhash lifetime. A transaction-modifying signer may replace the transaction lifetime during signing, but a durable nonce set directly on the input message is not preserved.
+
+### Options
+
+All options are provided via a `RpcTransactionPlanSigningExecutorConfig` object:
+
+- `estimateResourceLimits`: Whether to estimate and set resource limits by simulating before signing (default: `true`). This should match the `estimateResourceLimits` option on the planner; `solanaRpc` keeps them in sync automatically.
+- `getComputeUnitLimitFromEstimate`: A `(estimatedComputeUnits: number) => number` function that maps estimated compute unit consumption to the limit to set. It uses the same default buffer and 1.4M-unit cap as the sending executor.
+- `maxConcurrency`: Maximum number of transactions prepared and signed concurrently across all calls to this installed signing executor (default: 10). This bounds resource limit simulations and signer requests together, and is independent from the sending executor.
+
+### Result context
+
+A successful transaction result carries the prepared message, the partially or fully signed transaction, and its Base64-encoded wire representation in its `context`. The exported `RpcSignContext` type describes this shape. Its `signature` is optional because it is only available when the fee payer signed.
+
+```ts
+const result = await client.signTransaction(myInstructionPlan);
+
+result.context.message;
+result.context.transaction;
+result.context.transactionBase64;
+if (result.context.signature) {
+    console.log(`Transaction signature: ${result.context.signature}`);
+}
+```
+
+The executor queues every transaction plan leaf without waiting for sequential execution constraints, then prepares and signs up to `maxConcurrency` transactions at a time. The returned result still preserves the original plan's nesting, order, and divisibility. If one transaction fails to sign, the executor still attempts every other transaction and includes all outcomes in the signing error's transaction plan result.
+
+### Sequential dependencies
+
+The signing executor prepares and simulates transaction plan leaves independently, up to `maxConcurrency` at a time. It does not execute earlier transactions, so resource limit estimation can fail when a transaction depends on account or state changes produced by an earlier transaction in a sequential plan.
+
+Use `sendTransactions` when those dependencies must execute in order. When only signing is needed and simulation is unsuitable, set `estimateResourceLimits: false` on both the planner and signing executor and provide explicit resource limits where needed.
+
+```ts
+const client = await createClient()
+    .use(solanaRpcConnection({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
+    .use(generatedPayer())
+    .use(rpcTransactionPlanner({ estimateResourceLimits: false }))
+    .use(rpcTransactionPlanSigningExecutor({ estimateResourceLimits: false }));
+```
+
+With `solanaRpc`, set `transactionConfig.estimateResourceLimits` to `false` to configure both.
 
 ## Deprecated plugins
 

--- a/packages/kit-plugin-rpc/src/solana-rpc.ts
+++ b/packages/kit-plugin-rpc/src/solana-rpc.ts
@@ -19,7 +19,7 @@ import {
 import { rpcAirdrop } from './airdrop';
 import { rpcGetMinimumBalance } from './get-minimum-balance';
 import { rpcSubscriptionsConnection } from './rpc';
-import { rpcTransactionPlanSendingExecutor } from './transaction-plan-executor';
+import { rpcTransactionPlanSendingExecutor, rpcTransactionPlanSigningExecutor } from './transaction-plan-executor';
 import { rpcTransactionPlanner, TransactionPlannerConfig } from './transaction-planner';
 
 /**
@@ -74,8 +74,11 @@ export type SolanaRpcConfig<TClusterUrl extends ClusterUrl = ClusterUrl> = Solan
      */
     getComputeUnitLimitFromEstimate?: (estimatedComputeUnits: number) => number;
     /**
-     * The maximum number of concurrent transaction executions allowed.
-     * Defaults to 10.
+     * The maximum number of transactions handled concurrently by each
+     * installed executor. This limits transaction execution in the sending
+     * executor and transaction preparation and signing in the signing
+     * executor. The executors maintain independent concurrency budgets.
+     * Defaults to 10 for each executor.
      */
     maxConcurrency?: number;
     /**
@@ -106,15 +109,16 @@ export type SolanaRpcConfig<TClusterUrl extends ClusterUrl = ClusterUrl> = Solan
 
 /**
  * Enhances a client with a full Solana RPC setup including RPC connection,
- * RPC Subscriptions, minimum balance computation, transaction planning, and
- * transaction execution.
+ * RPC Subscriptions, minimum balance computation, transaction planning,
+ * transaction signing, and transaction execution.
  *
  * The client must have a `payer` set before applying this plugin.
  *
  * @param config - Configuration for the Solana RPC connection.
  * @return A plugin that adds `client.rpc`, `client.rpcSubscriptions`,
  * `client.getMinimumBalance`, `client.planTransaction`, `client.planTransactions`,
- * `client.sendTransaction` and `client.sendTransactions`.
+ * `client.signTransaction`, `client.signTransactions`, `client.sendTransaction`
+ * and `client.sendTransactions`.
  *
  * @example
  * ```ts
@@ -139,6 +143,11 @@ export function solanaRpc<TClusterUrl extends ClusterUrl>(config: SolanaRpcConfi
             solanaRpcConnection<TClusterUrl>(config),
             rpcGetMinimumBalance(),
             rpcTransactionPlanner(config.transactionConfig),
+            rpcTransactionPlanSigningExecutor({
+                estimateResourceLimits: config.transactionConfig?.estimateResourceLimits,
+                getComputeUnitLimitFromEstimate: config.getComputeUnitLimitFromEstimate,
+                maxConcurrency: config.maxConcurrency,
+            }),
             rpcTransactionPlanSendingExecutor({
                 estimateResourceLimits: config.transactionConfig?.estimateResourceLimits,
                 getComputeUnitLimitFromEstimate: config.getComputeUnitLimitFromEstimate,

--- a/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
+++ b/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
@@ -4,6 +4,7 @@ import {
     ClientWithRpcSubscriptions,
     ClientWithTransactionPlanning,
     createTransactionPlanExecutor,
+    createTransactionPlanExecutorWithConcurrentLeaves,
     estimateAndSetResourceLimitsFactory,
     estimateResourceLimitsFactory,
     GetEpochInfoApi,
@@ -11,6 +12,7 @@ import {
     GetSignatureStatusesApi,
     getSignatureFromTransaction,
     isSolanaError,
+    partiallySignTransactionMessageWithSigners,
     pipe,
     ResourceLimitsEstimate,
     SendableTransaction,
@@ -29,9 +31,16 @@ import {
     TransactionMessageWithFeePayer,
     TransactionPlanExecutor,
     TransactionPlanExecutorConfig,
+    TransactionWithinSizeLimit,
     TransactionWithLifetime,
+    Base64EncodedWireTransaction,
+    getBase64EncodedWireTransaction,
 } from '@solana/kit';
-import { transactionPlanExecutor, transactionPlanSendingExecutor } from '@solana/kit-plugin-instruction-plan';
+import {
+    transactionPlanExecutor,
+    transactionPlanSendingExecutor,
+    transactionPlanSigningExecutor,
+} from '@solana/kit-plugin-instruction-plan';
 
 /**
  * A plugin that adds `sendTransaction` and `sendTransactions` to the client
@@ -79,7 +88,48 @@ export function rpcTransactionPlanSendingExecutor(config: RpcTransactionPlanExec
             ClientWithTransactionPlanning,
     >(
         client: T,
-    ) => transactionPlanSendingExecutor(createExecutor(client, config))(client);
+    ) => transactionPlanSendingExecutor(createSendingExecutor(client, config))(client);
+}
+
+/**
+ * A plugin that adds `signTransaction` and `signTransactions` to the client
+ * using a transaction plan executor backed by RPC.
+ *
+ * The executor fetches a blockhash, estimates resource limits when needed, and
+ * partially signs every transaction in the plan. Transaction plan execution
+ * constraints are ignored during signing, while transaction preparation and
+ * signing respect `maxConcurrency`.
+ *
+ * Since signing goes through the client's planning functions,
+ * {@link rpcTransactionPlanner} or another `transactionPlanner` plugin must be
+ * installed first.
+ *
+ * @param config - Optional configuration for the signing executor.
+ * @returns A plugin that adds `client.signTransaction` and `client.signTransactions`.
+ * @throws If the client has no RPC or no transaction planning functions set.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from '@solana/kit';
+ * import { rpcTransactionPlanSigningExecutor, rpcTransactionPlanner, solanaRpcConnection } from '@solana/kit-plugin-rpc';
+ * import { generatedPayer } from '@solana/kit-plugin-signer';
+ *
+ * const client = await createClient()
+ *     .use(solanaRpcConnection({ rpcUrl: 'https://api.mainnet-beta.solana.com' }))
+ *     .use(generatedPayer())
+ *     .use(rpcTransactionPlanner())
+ *     .use(rpcTransactionPlanSigningExecutor());
+ *
+ * const result = await client.signTransactions(myInstructionPlan);
+ * ```
+ *
+ * @see {@link rpcTransactionPlanner}
+ * @see {@link rpcTransactionPlanSendingExecutor}
+ */
+export function rpcTransactionPlanSigningExecutor(config: RpcTransactionPlanSigningExecutorConfig = {}) {
+    return <T extends ClientWithRpc<GetLatestBlockhashApi & SimulateTransactionApi> & ClientWithTransactionPlanning>(
+        client: T,
+    ) => transactionPlanSigningExecutor(createSigningExecutor(client, config))(client);
 }
 
 /**
@@ -122,7 +172,7 @@ export function rpcTransactionPlanExecutor(config: RpcTransactionPlanExecutorCon
             ClientWithRpcSubscriptions<SignatureNotificationsApi & SlotNotificationsApi>,
     >(
         client: T,
-    ) => transactionPlanExecutor(createExecutor(client, config))(client);
+    ) => transactionPlanExecutor(createSendingExecutor(client, config))(client);
 }
 
 /**
@@ -194,6 +244,33 @@ export type RpcTransactionPlanExecutorConfig = {
 };
 
 /**
+ * Configuration for {@link rpcTransactionPlanSigningExecutor}.
+ *
+ * Signing uses the same resource limit estimation options as
+ * {@link rpcTransactionPlanSendingExecutor}, but it has no preflight behavior
+ * because transactions are not sent.
+ *
+ * @see {@link rpcTransactionPlanSigningExecutor}
+ */
+export type RpcTransactionPlanSigningExecutorConfig = {
+    /**
+     * Whether to estimate and set resource limits by simulating each transaction
+     * before signing. Defaults to `true`.
+     */
+    estimateResourceLimits?: boolean;
+    /**
+     * Maps estimated compute unit consumption to the limit set on the
+     * transaction. The result is capped at 1,400,000 compute units.
+     */
+    getComputeUnitLimitFromEstimate?: (estimatedComputeUnits: number) => number;
+    /**
+     * The maximum number of transactions prepared and signed concurrently
+     * across all calls to this signing executor. Defaults to 10.
+     */
+    maxConcurrency?: number;
+};
+
+/**
  * The context carried by transaction plan results from
  * {@link rpcTransactionPlanSendingExecutor}.
  *
@@ -226,11 +303,45 @@ export type RpcSendContext = {
 };
 
 /**
+ * The context carried by transaction plan results from
+ * {@link rpcTransactionPlanSigningExecutor}.
+ *
+ * The executor records the transaction message after setting its blockhash and
+ * resource limits, plus the transaction after applying every available signer
+ * and its Base64-encoded wire representation. The signature is present when
+ * the fee payer signed, even if other required signatures are still missing.
+ *
+ * @remarks
+ * These properties are only guaranteed on successful results. Failed and
+ * canceled results carry the values recorded before signing stopped.
+ *
+ * @example
+ * ```ts
+ * import { SuccessfulSingleTransactionPlanResult } from '@solana/kit';
+ * import { RpcSignContext } from '@solana/kit-plugin-rpc';
+ *
+ * function inspectSignedTransaction(result: SuccessfulSingleTransactionPlanResult<RpcSignContext>) {
+ *     console.log(result.context.transactionBase64);
+ * }
+ * ```
+ *
+ * @see {@link rpcTransactionPlanSigningExecutor}
+ */
+export type RpcSignContext = {
+    message: TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithBlockhashLifetime;
+    signature?: Signature;
+    transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime;
+    transactionBase64: Base64EncodedWireTransaction;
+};
+
+type LatestBlockhashResponse = ReturnType<GetLatestBlockhashApi['getLatestBlockhash']>;
+
+/**
  * Creates the transaction plan executor installed by
  * {@link rpcTransactionPlanSendingExecutor}, which signs and sends planned
  * transaction messages using the client's RPC and RPC Subscriptions.
  */
-function createExecutor(
+function createSendingExecutor(
     client: ClientWithRpc<
         GetEpochInfoApi & GetLatestBlockhashApi & GetSignatureStatusesApi & SendTransactionApi & SimulateTransactionApi
     > &
@@ -299,6 +410,82 @@ function createExecutor(
     } satisfies TransactionPlanExecutorConfig<RpcSendContext>);
 }
 
+/** Creates the transaction plan executor installed by {@link rpcTransactionPlanSigningExecutor}. */
+function createSigningExecutor(
+    client: ClientWithRpc<GetLatestBlockhashApi & SimulateTransactionApi>,
+    config: RpcTransactionPlanSigningExecutorConfig,
+): TransactionPlanExecutor<RpcSignContext> {
+    if (!client.rpc) {
+        throw new Error(
+            'An RPC instance is required on the client to create the RPC transaction plan signing executor. ' +
+                'Please add the RPC plugin to your client before using this plugin.',
+        );
+    }
+
+    const shouldEstimateResourceLimits = config.estimateResourceLimits ?? true;
+    const getComputeUnitLimitFromEstimate =
+        config.getComputeUnitLimitFromEstimate ?? getDefaultComputeUnitLimitFromEstimate;
+    const estimateResourceLimits = estimateResourceLimitsFactory({ rpc: client.rpc });
+    const estimateAndSetResourceLimits = estimateAndSetResourceLimitsFactory(
+        bufferAndRecoverResourceLimits(
+            estimateResourceLimits,
+            getComputeUnitLimitFromEstimate,
+            /* skipPreflight */ false,
+        ),
+    );
+
+    const executeTransactionMessage = limitFunction(
+        async (
+            context: Partial<RpcSignContext>,
+            transactionMessage: TransactionMessage & TransactionMessageWithFeePayer,
+            executorConfig: NonNullable<Parameters<TransactionPlanExecutor<RpcSignContext>>[1]>,
+            getLatestBlockhashPromise: () => Promise<LatestBlockhashResponse>,
+        ) => {
+            // The executor has already reported this leaf as failed if the signal
+            // aborted while this call was waiting for a concurrency slot, so bail
+            // out before making orphaned RPC requests on its behalf.
+            executorConfig.abortSignal?.throwIfAborted();
+            // Fetch lazily so plans without leaves do not make an orphaned RPC request.
+            const { value: latestBlockhash } = await getLatestBlockhashPromise();
+            let message = setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, transactionMessage);
+            context.message = message;
+            if (shouldEstimateResourceLimits) {
+                message = await estimateAndSetResourceLimits(message, executorConfig);
+                context.message = message;
+            }
+
+            const transaction = await partiallySignTransactionMessageWithSigners(message, executorConfig);
+            context.transaction = transaction;
+            const transactionBase64 = getBase64EncodedWireTransaction(transaction);
+            context.transactionBase64 = transactionBase64;
+            const signature = Object.values(transaction.signatures)[0]
+                ? getSignatureFromTransaction(transaction)
+                : undefined;
+            if (signature) {
+                context.signature = signature;
+            }
+            return {
+                ...(signature ? { signature } : {}),
+                message,
+                transaction,
+                transactionBase64,
+            };
+        },
+        config.maxConcurrency ?? 10,
+    );
+
+    return async (transactionPlan, executorConfig = {}) => {
+        let latestBlockhashPromise: Promise<LatestBlockhashResponse> | undefined;
+        const getLatestBlockhashPromise = () =>
+            (latestBlockhashPromise ??= client.rpc.getLatestBlockhash().send(executorConfig));
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves<RpcSignContext>({
+            executeTransactionMessage: (context, transactionMessage) =>
+                executeTransactionMessage(context, transactionMessage, executorConfig, getLatestBlockhashPromise),
+        });
+        return await executor(transactionPlan, executorConfig);
+    };
+}
+
 /**
  * The minimum compute unit buffer added on top of the estimate by
  * {@link getDefaultComputeUnitLimitFromEstimate}.
@@ -348,8 +535,8 @@ function getDefaultComputeUnitLimitFromEstimate(estimatedComputeUnits: number): 
  * The returned estimator is intended to be passed to
  * {@link estimateAndSetResourceLimitsFactory}, which only calls it when a
  * resource limit actually needs estimating. The `onSimulate` callback is
- * therefore invoked exactly once an estimation simulation has been performed
- * and we are proceeding to send (i.e. not on a non-recoverable failure).
+ * optional. When provided, it is invoked exactly once after a simulation has
+ * produced limits (i.e. not on a non-recoverable failure).
  *
  * The `getComputeUnitLimitFromEstimate` function is applied to the compute unit
  * limit only, to account for variations between simulation and execution. It is
@@ -365,14 +552,14 @@ function getDefaultComputeUnitLimitFromEstimate(estimatedComputeUnits: number): 
  *   {@link estimateResourceLimitsFactory}.
  * @param getComputeUnitLimitFromEstimate - Maps the estimated compute units to the limit to set.
  * @param skipPreflight - Whether to recover from failed simulations using consumed resources.
- * @param onSimulate - Called once a simulation has been performed and an estimate produced.
+ * @param onSimulate - Optionally called once a simulation has been performed and an estimate produced.
  * @returns An estimator that applies a compute unit buffer and recovery behaviour.
  */
 function bufferAndRecoverResourceLimits(
     estimateResourceLimits: ReturnType<typeof estimateResourceLimitsFactory>,
     getComputeUnitLimitFromEstimate: (estimatedComputeUnits: number) => number,
     skipPreflight: boolean,
-    onSimulate: () => void,
+    onSimulate?: () => void,
 ): ReturnType<typeof estimateResourceLimitsFactory> {
     return async (transactionMessage, config) => {
         let estimate: ResourceLimitsEstimate<typeof transactionMessage>;
@@ -401,9 +588,9 @@ function bufferAndRecoverResourceLimits(
 
         // Reaching this point means a simulation was performed (either it
         // succeeded, or it failed and we recovered from it) and we are
-        // proceeding to send, so signal it. A non-recoverable failure throws
+        // continuing, so signal it. A non-recoverable failure throws
         // above and never gets here.
-        onSimulate();
+        onSimulate?.();
 
         // Apply the compute unit buffer to the estimated compute unit limit,
         // rounding up to an integer and capping at the per-transaction maximum.

--- a/packages/kit-plugin-rpc/test/index.test.ts
+++ b/packages/kit-plugin-rpc/test/index.test.ts
@@ -153,6 +153,8 @@ describe('solanaRpc', () => {
         expect(client).toHaveProperty('transactionPlanExecutor');
         expect(client.planTransaction).toBeTypeOf('function');
         expect(client.planTransactions).toBeTypeOf('function');
+        expect(client.signTransaction).toBeTypeOf('function');
+        expect(client.signTransactions).toBeTypeOf('function');
         expect(client.sendTransaction).toBeTypeOf('function');
         expect(client.sendTransactions).toBeTypeOf('function');
     });

--- a/packages/kit-plugin-rpc/test/transaction-plan-executor.test.ts
+++ b/packages/kit-plugin-rpc/test/transaction-plan-executor.test.ts
@@ -1,27 +1,51 @@
 import {
     Address,
+    address,
     createClient,
     createTransactionMessage,
+    flattenTransactionPlanResult,
     generateKeyPairSigner,
+    getBase64EncodedWireTransaction,
     getSignatureFromTransaction,
     getTransactionMessageComputeUnitLimit,
+    isSolanaError,
+    Nonce,
+    nonDivisibleSequentialTransactionPlan,
     parallelTransactionPlan,
     pipe,
     Rpc,
     RpcSubscriptions,
     sendAndConfirmTransactionFactory,
+    sequentialTransactionPlan,
     setTransactionMessageComputeUnitLimit,
+    setTransactionMessageFeePayer,
     setTransactionMessageFeePayerSigner,
     setTransactionMessageLoadedAccountsDataSizeLimit,
     singleInstructionPlan,
     singleTransactionPlan,
     SingleTransactionPlanResult,
+    SOLANA_ERROR__FAILED_TO_SIGN_TRANSACTIONS,
+    SOLANA_ERROR__INVARIANT_VIOLATION__INVALID_TRANSACTION_PLAN_KIND,
     SolanaRpcApi,
     SolanaRpcSubscriptionsApi,
+    TransactionPlan,
+    TransactionPlanResult,
+    Transaction,
+    TransactionModifyingSigner,
+    TransactionPartialSigner,
+    TransactionSigner,
+    TransactionWithinSizeLimit,
+    TransactionWithLifetime,
 } from '@solana/kit';
-import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { assert, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 
-import { rpcTransactionPlanExecutor, rpcTransactionPlanner, rpcTransactionPlanSendingExecutor } from '../src';
+import {
+    RpcSignContext,
+    rpcTransactionPlanExecutor,
+    rpcTransactionPlanner,
+    rpcTransactionPlanSendingExecutor,
+    rpcTransactionPlanSigningExecutor,
+} from '../src';
 
 const MOCK_BLOCKHASH = { blockhash: '11111111111111111111111111111111', lastValidBlockHeight: 0n };
 const MOCK_INSTRUCTION = {
@@ -698,6 +722,329 @@ describe('rpcTransactionPlanSendingExecutor', () => {
                 // @ts-expect-error Missing RPC Subscriptions on the client.
                 .use(rpcTransactionPlanSendingExecutor()),
         ).toThrow();
+    });
+});
+
+describe('rpcTransactionPlanSigningExecutor', () => {
+    it('does not request a blockhash for an empty plan', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn().mockRejectedValue(new Error('RPC unavailable'));
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: vi.fn() }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const client = createClient()
+            .use(() => ({ payer, rpc }))
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSigningExecutor());
+
+        await expect(client.signTransactions([])).resolves.toBeDefined();
+
+        expect(getLatestBlockhash).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown nested transaction plan kind with an invariant error', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn();
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: vi.fn() }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const client = createClient()
+            .use(() => ({ payer, rpc }))
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSigningExecutor());
+        const malformedPlan = parallelTransactionPlan([{ kind: 'unknown' } as unknown as TransactionPlan]);
+
+        const error = await client.signTransactions(malformedPlan).catch((error: unknown) => error);
+
+        expect(isSolanaError(error, SOLANA_ERROR__INVARIANT_VIOLATION__INVALID_TRANSACTION_PLAN_KIND)).toBe(true);
+        expect(getLatestBlockhash).not.toHaveBeenCalled();
+    });
+
+    it('adds signing functions and returns a signed transaction with its prepared message and signature', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        const simulateTransaction = vi.fn().mockResolvedValue({ value: { unitsConsumed: 42n } });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const client = createClient()
+            .use(() => ({ payer, rpc }))
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSigningExecutor());
+
+        expect(client.signTransaction).toBeTypeOf('function');
+        expect(client.signTransactions).toBeTypeOf('function');
+        expect(client).not.toHaveProperty('sendTransaction');
+        expect(client).not.toHaveProperty('transactionPlanExecutor');
+
+        const result = await client.signTransaction(singleInstructionPlan(MOCK_INSTRUCTION));
+
+        expect(result.context.message.lifetimeConstraint).toEqual(MOCK_BLOCKHASH);
+        expect(getTransactionMessageComputeUnitLimit(result.context.message)).toBe(342);
+        expect(result.context.transaction).toBeDefined();
+        expect(result.context.transactionBase64).toBe(getBase64EncodedWireTransaction(result.context.transaction));
+        expect(result.context.signature).toBe(getSignatureFromTransaction(result.context.transaction));
+        expect(getLatestBlockhash).toHaveBeenCalledOnce();
+        expect(simulateTransaction).toHaveBeenCalledOnce();
+        expect(sendAndConfirmTransactionFactory).not.toHaveBeenCalled();
+    });
+
+    it('returns a partially signed transaction without a signature when the fee payer did not sign', async () => {
+        const payer = await generateKeyPairSigner();
+        const unsignedFeePayer = address('11111111111111111111111111111111');
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        const simulateTransaction = vi.fn();
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const client = createClient()
+            .use(() => ({ payer, rpc }))
+            .use(rpcTransactionPlanner({ estimateResourceLimits: false }))
+            .use(rpcTransactionPlanSigningExecutor({ estimateResourceLimits: false }));
+        const message = setTransactionMessageFeePayer(unsignedFeePayer, createTransactionMessage({ version: 0 }));
+
+        const result = await client.signTransaction(message);
+
+        expect(result.context.transaction.signatures[unsignedFeePayer]).toBeNull();
+        expect(result.context.transactionBase64).toBe(getBase64EncodedWireTransaction(result.context.transaction));
+        expect(result.context.signature).toBeUndefined();
+        expect(simulateTransaction).not.toHaveBeenCalled();
+    });
+
+    it('preserves a lifetime changed by a transaction-modifying signer', async () => {
+        const nonceAccountAddress = address('11111111111111111111111111111111');
+        const lifetimeConstraint = {
+            nonce: MOCK_BLOCKHASH.blockhash as Nonce,
+            nonceAccountAddress,
+        };
+        const modifyingPayer = {
+            address: nonceAccountAddress,
+            modifyAndSignTransactions: vi.fn(
+                (transactions: readonly (Transaction | (Transaction & TransactionWithLifetime))[]) =>
+                    Promise.resolve(
+                        transactions.map(
+                            transaction =>
+                                ({
+                                    ...transaction,
+                                    lifetimeConstraint,
+                                }) as Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
+                        ),
+                    ),
+            ),
+        } satisfies TransactionModifyingSigner;
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: vi.fn() }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const client = createClient()
+            .use(() => ({ payer: modifyingPayer, rpc }))
+            .use(rpcTransactionPlanner({ estimateResourceLimits: false }))
+            .use(rpcTransactionPlanSigningExecutor({ estimateResourceLimits: false }));
+        const message = setTransactionMessageFeePayerSigner(modifyingPayer, createTransactionMessage({ version: 0 }));
+
+        const result = await client.signTransaction(message);
+
+        expect(result.context.message.lifetimeConstraint).toEqual(MOCK_BLOCKHASH);
+        expect(result.context.transaction.lifetimeConstraint).toEqual(lifetimeConstraint);
+        expect(modifyingPayer.modifyAndSignTransactions).toHaveBeenCalledOnce();
+    });
+
+    it('preserves nested transaction plan shape while signing all leaves with one blockhash', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: vi.fn() }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const client = createClient()
+            .use(() => ({ payer, rpc }))
+            .use(rpcTransactionPlanner({ estimateResourceLimits: false }))
+            .use(rpcTransactionPlanSigningExecutor({ estimateResourceLimits: false }));
+        const message = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
+        const transactionPlan = parallelTransactionPlan([
+            nonDivisibleSequentialTransactionPlan([message, message]),
+            sequentialTransactionPlan([message, message]),
+        ]);
+
+        const result = await client.signTransactions(transactionPlan);
+
+        expect(result.kind).toBe('parallel');
+        assert(result.kind === 'parallel');
+        expect(result.plans[0]).toMatchObject({ divisible: false, kind: 'sequential' });
+        expect(result.plans[1]).toMatchObject({ divisible: true, kind: 'sequential' });
+        expect(flattenTransactionPlanResult(result)).toHaveLength(4);
+        expect(flattenTransactionPlanResult(result).every(leaf => leaf.status === 'successful')).toBe(true);
+        expect(getLatestBlockhash).toHaveBeenCalledOnce();
+    });
+
+    it('shares the transaction concurrency limit across simultaneous signing calls', async () => {
+        const keyPairPayer = await generateKeyPairSigner();
+        let signingCalls = 0;
+        const signingResolvers: Array<() => void> = [];
+        const payer: TransactionPartialSigner = {
+            address: keyPairPayer.address,
+            signTransactions(transactions, config) {
+                signingCalls++;
+                return new Promise((resolve, reject) => {
+                    signingResolvers.push(() => {
+                        void keyPairPayer.signTransactions(transactions, config).then(resolve, reject);
+                    });
+                });
+            },
+        };
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        const simulateTransaction = vi.fn().mockResolvedValue({ value: { unitsConsumed: 42n } });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const client = createClient()
+            .use(() => ({ payer, rpc }))
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSigningExecutor({ maxConcurrency: 2 }));
+        const singlePlan = await client.planTransactions(singleInstructionPlan(MOCK_INSTRUCTION));
+        const transactionPlan = sequentialTransactionPlan([singlePlan, singlePlan]);
+
+        const firstPromise = client.signTransactions(transactionPlan);
+        const secondPromise = client.signTransactions(transactionPlan);
+
+        await vi.waitFor(() => expect(signingCalls).toBe(2));
+        expect(simulateTransaction).toHaveBeenCalledTimes(2);
+        signingResolvers[0]();
+        await vi.waitFor(() => expect(signingCalls).toBe(3));
+        expect(simulateTransaction).toHaveBeenCalledTimes(3);
+        signingResolvers[1]();
+        await vi.waitFor(() => expect(signingCalls).toBe(4));
+        expect(simulateTransaction).toHaveBeenCalledTimes(4);
+        signingResolvers[2]();
+        signingResolvers[3]();
+        await Promise.all([firstPromise, secondPromise]);
+        expect(getLatestBlockhash).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not prepare or sign queued leaves after the abort signal fires', async () => {
+        const keyPairPayer = await generateKeyPairSigner();
+        let signingCalls = 0;
+        const signingReleasers: Array<() => void> = [];
+        const payer: TransactionPartialSigner = {
+            address: keyPairPayer.address,
+            signTransactions() {
+                signingCalls++;
+                return new Promise((_resolve, reject) => {
+                    signingReleasers.push(() => reject(new Error('released')));
+                });
+            },
+        };
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        const simulateTransaction = vi.fn().mockResolvedValue({ value: { unitsConsumed: 42n } });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const client = createClient()
+            .use(() => ({ payer, rpc }))
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSigningExecutor({ maxConcurrency: 1 }));
+        const singlePlan = await client.planTransactions(singleInstructionPlan(MOCK_INSTRUCTION));
+        const transactionPlan = sequentialTransactionPlan([singlePlan, singlePlan]);
+        const abortController = new AbortController();
+
+        const pendingError = client
+            .signTransactions(transactionPlan, { abortSignal: abortController.signal })
+            .catch((error: unknown) => error);
+        await vi.waitFor(() => expect(signingCalls).toBe(1));
+        abortController.abort();
+        const error = await pendingError;
+        assert(isSolanaError(error, SOLANA_ERROR__FAILED_TO_SIGN_TRANSACTIONS));
+
+        // Free the concurrency slot held by the first leaf so the queued second
+        // leaf gets its turn, then verify it bails out without doing any work.
+        signingReleasers[0]();
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await new Promise(resolve => setTimeout(resolve, 0));
+        expect(signingCalls).toBe(1);
+        expect(simulateTransaction).toHaveBeenCalledOnce();
+    });
+
+    it('attempts every sequential leaf and reports successful siblings when one signer fails', async () => {
+        const payer = await generateKeyPairSigner();
+        const signingError = new Error('signing failed');
+        const failingPayer = {
+            address: address('11111111111111111111111111111111'),
+            signTransactions: vi.fn().mockRejectedValue(signingError),
+        } satisfies TransactionSigner;
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: vi.fn() }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const client = createClient()
+            .use(() => ({ payer, rpc }))
+            .use(rpcTransactionPlanner({ estimateResourceLimits: false }))
+            .use(rpcTransactionPlanSigningExecutor({ estimateResourceLimits: false }));
+        const failingMessage = setTransactionMessageFeePayerSigner(
+            failingPayer,
+            createTransactionMessage({ version: 0 }),
+        );
+        const successfulMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
+        const transactionPlan = sequentialTransactionPlan([failingMessage, successfulMessage]);
+
+        const error = await client.signTransactions(transactionPlan).catch((error: unknown) => error);
+
+        assert(isSolanaError(error, SOLANA_ERROR__FAILED_TO_SIGN_TRANSACTIONS));
+        const result = (error.context as { transactionPlanResult: TransactionPlanResult<RpcSignContext> })
+            .transactionPlanResult;
+        expect(flattenTransactionPlanResult(result).map(leaf => leaf.status)).toEqual(['failed', 'successful']);
+        expect(failingPayer.signTransactions).toHaveBeenCalledOnce();
+    });
+
+    it('preserves the context recorded before a signer failure on the failed result', async () => {
+        const signingError = new Error('signing failed');
+        const failingPayer = {
+            address: address('11111111111111111111111111111111'),
+            signTransactions: vi.fn().mockRejectedValue(signingError),
+        } satisfies TransactionSigner;
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        const simulateTransaction = vi.fn().mockResolvedValue({ value: { unitsConsumed: 42n } });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const client = createClient()
+            .use(() => ({ payer: failingPayer, rpc }))
+            .use(rpcTransactionPlanner({ estimateResourceLimits: false }))
+            .use(rpcTransactionPlanSigningExecutor());
+        const message = setTransactionMessageFeePayerSigner(failingPayer, createTransactionMessage({ version: 0 }));
+
+        const error = await client.signTransactions(message).catch((error: unknown) => error);
+
+        assert(isSolanaError(error, SOLANA_ERROR__FAILED_TO_SIGN_TRANSACTIONS));
+        const result = (error.context as { transactionPlanResult: TransactionPlanResult<RpcSignContext> })
+            .transactionPlanResult;
+        const [failedLeaf] = flattenTransactionPlanResult(result);
+        assert(failedLeaf.status === 'failed');
+        expect(failedLeaf.error).toBe(signingError);
+        expect(failedLeaf.context.message?.lifetimeConstraint).toEqual(MOCK_BLOCKHASH);
+        expect(getTransactionMessageComputeUnitLimit(failedLeaf.context.message!)).toBe(342);
+        expect(failedLeaf.context.transaction).toBeUndefined();
+        expect(failedLeaf.context.transactionBase64).toBeUndefined();
+        expect(failedLeaf.context.signature).toBeUndefined();
+    });
+
+    it('requires an RPC API on the client', async () => {
+        const payer = await generateKeyPairSigner();
+        expect(() =>
+            createClient()
+                .use(() => ({ payer }))
+                .use(rpcTransactionPlanner())
+                // @ts-expect-error Missing RPC on the client.
+                .use(rpcTransactionPlanSigningExecutor()),
+        ).toThrow(/An RPC instance is required/);
     });
 });
 


### PR DESCRIPTION
This PR adds `client.signTransaction(s)` for the `solanaRpc` client, using a new `rpcTransactionPlanSigningExecutor` plugin. A follow-up similar PR will add the same for LiteSVM.

This plugin performs most of the same functionality as the `rpcTransactionPlanSendingExecutor`, it attaches a newly fetched blockhash lifetime (memoized, the same for each transaction), performs resource estimation using simulation, and partially signs the transaction(s). It does not attempt to send the transactions, so that the app is able to do that separately.

It does not use `createTransactionPlanExecutor`, and instead ignores sequential dependencies in the input transaction plans: since we are not executing the transactions these dependencies are irrelevant. All leaf single transaction plans are handled in parallel, but with a maximum concurrency (the same approach used for send). This means that signing doesn't fan out infinitely by default, since some signers may require user input or calling services with rate limiting.

The returned `TransactionPlanResult` has the same shape as the input, so sequential dependencies/divisibility/etc are maintained. 

Noted in the readme, but because we are not executing transactions, if there are genuine sequential dependencies then simulation of later transactions will fail, and `estimateResourceLimits: false` will need to be used. This is a disadvantage compared to send, which is able to ensure that sequential dependencies are sent + confirmed first.

Unlike the send path, signing uses `partiallySignTransactionMessageWithSigners` and does not require all signers to be present. The returned transaction plans have a context containing a transaction message, a transaction, and optionally a signature. If the fee payer has signed then `signature` is populated, else it is omitted.

Note that like the send path, the lifetime is replaced with the fresh blockhash, replacing for example a durable nonce lifetime. We could skip our lifetime replacement for sign, and allow an existing durable nonce lifetime to remain. But I think given that we know there are plans to replace and deprecate durable nonces, it's ok not to do that here.

Also note that the executor concurrency is separate from send, meaning that an app might be concurrently handling sign and send operations. I think this is generally the right approach, it doesn't make sense to queue signing before a send + confirm that might take much longer. But it does mean that if an RPC has a limited requests per second, this is not necessarily an effective way to manage that. This isn't new, you could always have RPC requests outside of the `client.sendTransaction(s)` flow causing it to hit a limit. It may be useful to add a `requestsPerSecond` to `solanaRpc` which rate-limits the `client.rpc` to make this easier and robust, I'll open an issue.