### PR TITLE
Add the `litesvmTransactionPlanSigningExecutor` plugin

### DIFF
--- a/.changeset/major-years-rest.md
+++ b/.changeset/major-years-rest.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-litesvm': minor
+---
+
+Add `litesvmTransactionPlanSigningExecutor` for partial signing and informational LiteSVM simulation metadata, and include transaction signing functions in `litesvm` clients.

--- a/packages/kit-plugin-instruction-plan/README.md
+++ b/packages/kit-plugin-instruction-plan/README.md
@@ -150,5 +150,5 @@ const client = createClient()
 
 For ready-to-use transaction planner and executor implementations, see:
 
-- [`@solana/kit-plugin-rpc`](https://www.npmjs.com/package/@solana/kit-plugin-rpc) — provides the `rpcTransactionPlanner` and `rpcTransactionPlanSendingExecutor` plugins for RPC-based transaction planning and execution.
-- [`@solana/kit-plugin-litesvm`](https://www.npmjs.com/package/@solana/kit-plugin-litesvm) — provides the `litesvmTransactionPlanner` and `litesvmTransactionPlanSendingExecutor` plugins for LiteSVM-based transaction planning and execution.
+- [`@solana/kit-plugin-rpc`](https://www.npmjs.com/package/@solana/kit-plugin-rpc) — provides RPC-backed transaction planning, signing, and sending plugins.
+- [`@solana/kit-plugin-litesvm`](https://www.npmjs.com/package/@solana/kit-plugin-litesvm) — provides LiteSVM-backed transaction planning, signing, and sending plugins.

--- a/packages/kit-plugin-litesvm/README.md
+++ b/packages/kit-plugin-litesvm/README.md
@@ -17,7 +17,7 @@ pnpm install @solana/kit-plugin-litesvm
 
 ## `litesvm` plugin
 
-The `litesvm` plugin sets up a full LiteSVM client in a single call. It installs an SVM connection, airdrop support, minimum balance computation, transaction planning, and transaction execution on the client.
+The `litesvm` plugin sets up a full LiteSVM client in a single call. It installs an SVM connection, airdrop support, minimum balance computation, transaction planning, transaction signing, and transaction execution on the client.
 
 The client must have a `payer` set before applying this plugin.
 
@@ -47,6 +47,7 @@ All options are provided via a `LiteSvmConfig` object:
 - `airdrop`: Request SOL from the LiteSVM faucet.
 - `getMinimumBalance`: Compute minimum lamports for rent exemption.
 - `planTransaction(s)`: Plan instructions into transaction messages without executing them.
+- `signTransaction(s)`: Plan and partially sign instructions, instruction plans, or transaction messages without sending them.
 - `sendTransaction(s)`: Plan and execute instructions, instruction plans, or transaction messages in one call.
 - `transactionPlanner` / `transactionPlanExecutor` (deprecated): Fields kept for backward compatibility. Use `planTransaction(s)` / `sendTransaction(s)` instead.
 
@@ -216,6 +217,69 @@ function logComputeUnits(result: SuccessfulSingleTransactionPlanResult<LiteSvmSe
 Because the context is filled in as execution progresses, a transaction that fails or is canceled part way through carries only what was recorded before it stopped. Failed and canceled results therefore type the context as partial — only successful results guarantee every field.
 
 The `sendTransaction` and `sendTransactions` functions installed by this plugin propagate this context type, so their results carry a typed `LiteSvmSendContext` without any annotation needed.
+
+## `litesvmTransactionPlanSigningExecutor` plugin
+
+Adds `signTransaction` and `signTransactions` to the client, using an executor that sets a fresh LiteSVM blockhash lifetime and partially signs every transaction without sending it. Fully signed transactions are simulated without committing state changes, and their LiteSVM `TransactionMetadata` is included in the result context.
+
+### Usage
+
+The client must have an `svm` instance configured and a transaction planner installed before installing this plugin.
+
+```ts
+import { createClient } from '@solana/kit';
+import {
+    litesvmConnection,
+    litesvmTransactionPlanner,
+    litesvmTransactionPlanSigningExecutor,
+} from '@solana/kit-plugin-litesvm';
+import { generatedPayer } from '@solana/kit-plugin-signer';
+
+const client = await createClient()
+    .use(litesvmConnection())
+    .use(generatedPayer())
+    .use(litesvmTransactionPlanner())
+    .use(litesvmTransactionPlanSigningExecutor());
+
+const transactionPlanResult = await client.signTransactions(myInstructionPlan);
+```
+
+### Result context
+
+Each successful leaf includes the prepared message, partially signed transaction, and its Base64-encoded wire representation. The signature is present when the fee payer signed. If all required signatures are present, the executor also simulates the transaction and includes its `TransactionMetadata` or `FailedTransactionMetadata`. A failed simulation is informational and does not make signing fail. A genuinely partial transaction cannot be simulated while LiteSVM signature verification is enabled, so `transactionMetadata` is omitted.
+
+```ts
+import { SuccessfulSingleTransactionPlanResult } from '@solana/kit';
+import { isFailedTransaction, LiteSvmSignContext } from '@solana/kit-plugin-litesvm';
+
+function inspectSignedTransaction(result: SuccessfulSingleTransactionPlanResult<LiteSvmSignContext>) {
+    console.log(result.context.transactionBase64);
+    const metadata = result.context.transactionMetadata;
+    if (metadata && !isFailedTransaction(metadata)) {
+        console.log(metadata.logs());
+    }
+}
+```
+
+The executor replaces any lifetime already set on an input transaction message with LiteSVM's latest blockhash lifetime. A transaction-modifying signer may replace the transaction lifetime during signing, but a durable nonce set directly on the input message is not preserved.
+
+### Sequential dependencies
+
+Signing does not execute transaction plan dependencies. All leaves begin preparation independently, while the returned result still preserves the original plan shape. A fully signed transaction is simulated against the current LiteSVM state, so its simulation can fail if it depends on state changes from an earlier transaction in the plan. The signing result remains successful in that case and carries the `FailedTransactionMetadata` for inspection.
+
+```ts
+import { flattenTransactionPlanResult } from '@solana/kit';
+import { isFailedTransaction } from '@solana/kit-plugin-litesvm';
+
+const signedTransactions = await client.signTransactions(transactionPlan);
+// No transaction in the plan has been committed to the LiteSVM state.
+
+for (const result of flattenTransactionPlanResult(signedTransactions)) {
+    if (result.context.transactionMetadata && isFailedTransaction(result.context.transactionMetadata)) {
+        console.log(result.context.transactionMetadata.err());
+    }
+}
+```
 
 ## Deprecated plugins
 

--- a/packages/kit-plugin-litesvm/src/litesvm.ts
+++ b/packages/kit-plugin-litesvm/src/litesvm.ts
@@ -3,9 +3,13 @@ import { ClientWithPayer, pipe } from '@solana/kit';
 import { litesvmAirdrop } from './airdrop';
 import { litesvmGetMinimumBalance } from './get-minimum-balance';
 import { litesvmConnection } from './litesvm-connection';
-import { litesvmTransactionPlanSendingExecutor } from './transaction-plan-executor';
+import {
+    litesvmTransactionPlanSendingExecutor,
+    litesvmTransactionPlanSigningExecutor,
+} from './transaction-plan-executor';
 import { litesvmTransactionPlanner, TransactionPlannerConfig } from './transaction-planner';
 
+/** Configuration for the {@link litesvm} plugin. */
 export type LiteSvmConfig = {
     /**
      * Options to configure how transaction messages are created such as
@@ -16,14 +20,15 @@ export type LiteSvmConfig = {
 
 /**
  * Enhances a client with a full LiteSVM setup including an SVM connection,
- * airdrop support, minimum balance computation, transaction planning, and
- * transaction execution.
+ * airdrop support, minimum balance computation, transaction planning,
+ * transaction signing, and transaction execution.
  *
  * The client must have a `payer` set before applying this plugin.
  *
  * @return A plugin that adds `client.svm`, `client.rpc`, `client.airdrop`,
  * `client.getMinimumBalance`, `client.planTransaction`, `client.planTransactions`,
- * `client.sendTransaction` and `client.sendTransactions`.
+ * `client.signTransaction`, `client.signTransactions`, `client.sendTransaction`
+ * and `client.sendTransactions`.
  *
  * @example
  * ```ts
@@ -46,6 +51,7 @@ export function litesvm(config: LiteSvmConfig = {}) {
             litesvmAirdrop(),
             litesvmGetMinimumBalance(),
             litesvmTransactionPlanner(config.transactionConfig),
+            litesvmTransactionPlanSigningExecutor(),
             litesvmTransactionPlanSendingExecutor(),
         );
 }

--- a/packages/kit-plugin-litesvm/src/transaction-plan-executor.ts
+++ b/packages/kit-plugin-litesvm/src/transaction-plan-executor.ts
@@ -1,7 +1,12 @@
 import {
+    Base64EncodedWireTransaction,
     ClientWithTransactionPlanning,
     createTransactionPlanExecutor,
+    createTransactionPlanExecutorWithConcurrentLeaves,
+    getBase64EncodedWireTransaction,
     getSignatureFromTransaction,
+    isFullySignedTransaction,
+    partiallySignTransactionMessageWithSigners,
     pipe,
     SendableTransaction,
     Signature,
@@ -12,9 +17,14 @@ import {
     TransactionMessageWithFeePayer,
     TransactionPlanExecutor,
     TransactionPlanExecutorConfig,
+    TransactionWithinSizeLimit,
     TransactionWithLifetime,
 } from '@solana/kit';
-import { transactionPlanExecutor, transactionPlanSendingExecutor } from '@solana/kit-plugin-instruction-plan';
+import {
+    transactionPlanExecutor,
+    transactionPlanSendingExecutor,
+    transactionPlanSigningExecutor,
+} from '@solana/kit-plugin-instruction-plan';
 import type { FailedTransactionMetadata, LiteSVM, TransactionMetadata } from 'litesvm';
 
 import { getSolanaErrorFromLiteSvmFailure, isFailedTransaction } from './transaction-error';
@@ -58,7 +68,48 @@ import { getSolanaErrorFromLiteSvmFailure, isFailedTransaction } from './transac
  */
 export function litesvmTransactionPlanSendingExecutor() {
     return <T extends ClientWithTransactionPlanning & { svm: LiteSVM }>(client: T) =>
-        transactionPlanSendingExecutor(createExecutor(client))(client);
+        transactionPlanSendingExecutor(createSendingExecutor(client))(client);
+}
+
+/**
+ * A plugin that adds `signTransaction` and `signTransactions` to the client
+ * using a transaction plan executor backed by LiteSVM.
+ *
+ * The executor sets each message's lifetime from LiteSVM, partially signs every
+ * transaction in the plan, and simulates fully signed transactions to collect
+ * transaction metadata without committing state changes. Transaction plan
+ * execution constraints are ignored during signing, so every transaction is
+ * prepared and signed concurrently. A failed simulation is recorded as
+ * {@link FailedTransactionMetadata} but does not make signing fail.
+ *
+ * Since signing goes through the client's planning functions,
+ * {@link litesvmTransactionPlanner} or another `transactionPlanner` plugin must
+ * be installed first.
+ *
+ * @returns A plugin that adds `client.signTransaction` and `client.signTransactions`.
+ * @throws If the client has no LiteSVM instance or no transaction planning functions set.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from '@solana/kit';
+ * import { litesvmConnection, litesvmTransactionPlanner, litesvmTransactionPlanSigningExecutor } from '@solana/kit-plugin-litesvm';
+ * import { generatedPayer } from '@solana/kit-plugin-signer';
+ *
+ * const client = await createClient()
+ *     .use(litesvmConnection())
+ *     .use(generatedPayer())
+ *     .use(litesvmTransactionPlanner())
+ *     .use(litesvmTransactionPlanSigningExecutor());
+ *
+ * const result = await client.signTransactions(myInstructionPlan);
+ * ```
+ *
+ * @see {@link litesvmTransactionPlanner}
+ * @see {@link litesvmTransactionPlanSendingExecutor}
+ */
+export function litesvmTransactionPlanSigningExecutor() {
+    return <T extends ClientWithTransactionPlanning & { svm: LiteSVM }>(client: T) =>
+        transactionPlanSigningExecutor(createSigningExecutor(client))(client);
 }
 
 /**
@@ -95,7 +146,7 @@ export function litesvmTransactionPlanSendingExecutor() {
  * ```
  */
 export function litesvmTransactionPlanExecutor() {
-    return <T extends { svm: LiteSVM }>(client: T) => transactionPlanExecutor(createExecutor(client))(client);
+    return <T extends { svm: LiteSVM }>(client: T) => transactionPlanExecutor(createSendingExecutor(client))(client);
 }
 
 /**
@@ -141,11 +192,53 @@ export type LiteSvmSendContext = {
 };
 
 /**
+ * The context carried by transaction plan results from
+ * {@link litesvmTransactionPlanSigningExecutor}.
+ *
+ * The executor records the transaction message after setting its blockhash,
+ * plus the transaction after applying every available signer and its
+ * Base64-encoded wire representation. The signature is present when the fee
+ * payer signed. Fully signed transactions are also simulated, in which case
+ * the simulation metadata is present. A failed simulation remains a successful
+ * signing result with {@link FailedTransactionMetadata} in the context.
+ *
+ * @remarks
+ * These properties are only guaranteed on successful results. Failed and
+ * canceled results carry the values recorded before signing or simulation
+ * stopped. A partially signed transaction cannot be simulated while LiteSVM
+ * signature verification is enabled, so its successful context omits
+ * `transactionMetadata`.
+ *
+ * @example
+ * ```ts
+ * import { SuccessfulSingleTransactionPlanResult } from '@solana/kit';
+ * import { isFailedTransaction, LiteSvmSignContext } from '@solana/kit-plugin-litesvm';
+ *
+ * function inspectSignedTransaction(result: SuccessfulSingleTransactionPlanResult<LiteSvmSignContext>) {
+ *     console.log(result.context.transactionBase64);
+ *     const metadata = result.context.transactionMetadata;
+ *     if (metadata && !isFailedTransaction(metadata)) {
+ *         console.log(metadata.logs());
+ *     }
+ * }
+ * ```
+ *
+ * @see {@link litesvmTransactionPlanSigningExecutor}
+ */
+export type LiteSvmSignContext = {
+    message: TransactionMessage & TransactionMessageWithBlockhashLifetime & TransactionMessageWithFeePayer;
+    signature?: Signature;
+    transaction: Transaction & TransactionWithinSizeLimit & TransactionWithLifetime;
+    transactionBase64: Base64EncodedWireTransaction;
+    transactionMetadata?: FailedTransactionMetadata | TransactionMetadata;
+};
+
+/**
  * Creates the transaction plan executor installed by
  * {@link litesvmTransactionPlanSendingExecutor}, which signs planned
  * transaction messages and sends them to the client's LiteSVM instance.
  */
-function createExecutor(client: { svm: LiteSVM }): TransactionPlanExecutor<LiteSvmSendContext> {
+function createSendingExecutor(client: { svm: LiteSVM }): TransactionPlanExecutor<LiteSvmSendContext> {
     if (!client.svm) {
         throw new Error(
             'A LiteSVM instance is required on the client to create the LiteSVM transaction plan executor. ' +
@@ -173,4 +266,47 @@ function createExecutor(client: { svm: LiteSVM }): TransactionPlanExecutor<LiteS
             return context as LiteSvmSendContext;
         },
     } satisfies TransactionPlanExecutorConfig<LiteSvmSendContext>);
+}
+
+/** Creates the transaction plan executor installed by {@link litesvmTransactionPlanSigningExecutor}. */
+function createSigningExecutor(client: { svm: LiteSVM }): TransactionPlanExecutor<LiteSvmSignContext> {
+    if (!client.svm) {
+        throw new Error(
+            'A LiteSVM instance is required on the client to create the LiteSVM transaction plan signing executor. ' +
+                'Please add the LiteSVM plugin to your client before using this plugin.',
+        );
+    }
+
+    return createTransactionPlanExecutorWithConcurrentLeaves<LiteSvmSignContext>({
+        executeTransactionMessage: async (context, transactionMessage, executorConfig = {}) => {
+            const message = client.svm.setTransactionMessageLifetimeUsingLatestBlockhash(transactionMessage);
+            context.message = message;
+            const transaction = await partiallySignTransactionMessageWithSigners(message, executorConfig);
+            context.transaction = transaction;
+            const transactionBase64 = getBase64EncodedWireTransaction(transaction);
+            context.transactionBase64 = transactionBase64;
+            const signature = Object.values(transaction.signatures)[0]
+                ? getSignatureFromTransaction(transaction)
+                : undefined;
+            if (signature) {
+                context.signature = signature;
+            }
+            let transactionMetadata: FailedTransactionMetadata | TransactionMetadata | undefined;
+            if (isFullySignedTransaction(transaction)) {
+                const simulationResult = client.svm.simulateTransaction(transaction);
+                transactionMetadata = isFailedTransaction(simulationResult)
+                    ? simulationResult
+                    : simulationResult.meta();
+                context.transactionMetadata = transactionMetadata;
+            }
+
+            return {
+                ...(signature ? { signature } : {}),
+                ...(transactionMetadata !== undefined ? { transactionMetadata } : {}),
+                message,
+                transaction,
+                transactionBase64,
+            };
+        },
+    } satisfies TransactionPlanExecutorConfig<LiteSvmSignContext>);
 }

--- a/packages/kit-plugin-litesvm/test/litesvm.test.ts
+++ b/packages/kit-plugin-litesvm/test/litesvm.test.ts
@@ -28,6 +28,8 @@ describe('litesvm', () => {
         expect(client).toHaveProperty('transactionPlanExecutor');
         expect(client.planTransaction).toBeTypeOf('function');
         expect(client.planTransactions).toBeTypeOf('function');
+        expect(client.signTransaction).toBeTypeOf('function');
+        expect(client.signTransactions).toBeTypeOf('function');
         expect(client.sendTransaction).toBeTypeOf('function');
         expect(client.sendTransactions).toBeTypeOf('function');
     });

--- a/packages/kit-plugin-litesvm/test/transaction-plan-executor.test.ts
+++ b/packages/kit-plugin-litesvm/test/transaction-plan-executor.test.ts
@@ -1,37 +1,64 @@
 import { getTransferSolInstruction } from '@solana-program/system';
 import {
     Address,
+    address,
     appendTransactionMessageInstruction,
     createClient,
     createTransactionMessage,
     extendClient,
+    flattenTransactionPlanResult,
     generateKeyPairSigner,
+    getBase64EncodedWireTransaction,
     getSignatureFromTransaction,
     isSolanaError,
     lamports,
+    Nonce,
+    parallelTransactionPlan,
     passthroughFailedTransactionPlanExecution,
+    sequentialTransactionPlan,
+    setTransactionMessageFeePayer,
     setTransactionMessageFeePayerSigner,
+    setTransactionMessageLifetimeUsingBlockhash,
     singleInstructionPlan,
     singleTransactionPlan,
     SingleTransactionPlan,
     SingleTransactionPlanResult,
     SOLANA_ERROR__INSTRUCTION_ERROR__INVALID_INSTRUCTION_DATA,
+    SOLANA_ERROR__FAILED_TO_SIGN_TRANSACTIONS,
     SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN,
     SOLANA_ERROR__TRANSACTION_ERROR__ACCOUNT_NOT_FOUND,
     SolanaError,
+    Transaction,
+    TransactionModifyingSigner,
+    TransactionPlanResult,
+    TransactionSigner,
+    TransactionWithinSizeLimit,
+    TransactionWithLifetime,
+    type Blockhash,
 } from '@solana/kit';
 import type { FailedTransactionMetadata, LiteSVM, TransactionMetadata } from 'litesvm';
-import { describe, expect, it, vi } from 'vitest';
+import { assert, describe, expect, it, vi } from 'vitest';
 
 import {
+    isFailedTransaction,
     litesvmConnection,
     litesvmTransactionPlanExecutor,
     litesvmTransactionPlanner,
     litesvmTransactionPlanSendingExecutor,
+    litesvmTransactionPlanSigningExecutor,
+    type LiteSvmSignContext,
     type LiteSvmSendContext,
 } from '../src';
 
 const MOCK_INSTRUCTION = { programAddress: '11111111111111111111111111111111' as Address };
+const MOCK_BLOCKHASH = {
+    blockhash: '11111111111111111111111111111111' as Blockhash,
+    lastValidBlockHeight: 0n,
+};
+
+function createMockSetLifetime() {
+    return vi.fn().mockImplementation(message => setTransactionMessageLifetimeUsingBlockhash(MOCK_BLOCKHASH, message));
+}
 
 describe('litesvmTransactionPlanSendingExecutor', () => {
     describe('with mocks', () => {
@@ -362,6 +389,272 @@ describe('litesvmTransactionPlanSendingExecutor', () => {
             expect(metadata).toBeDefined();
             expect(metadata.err()).toBeDefined();
         });
+    });
+});
+
+describe('litesvmTransactionPlanSigningExecutor', () => {
+    it('adds signing functions without adding sending functions', async () => {
+        const payer = await generateKeyPairSigner();
+        const svm = {} as LiteSVM;
+        const client = createClient()
+            .use(() => ({ payer, svm }))
+            .use(litesvmTransactionPlanner())
+            .use(litesvmTransactionPlanSigningExecutor());
+
+        expect(client.signTransaction).toBeTypeOf('function');
+        expect(client.signTransactions).toBeTypeOf('function');
+        expect(client).not.toHaveProperty('sendTransaction');
+        expect(client).not.toHaveProperty('transactionPlanExecutor');
+    });
+
+    it('partially signs and simulates a fully signed transaction without sending it', async () => {
+        const payer = await generateKeyPairSigner();
+        const setTransactionMessageLifetimeUsingLatestBlockhash = createMockSetLifetime();
+        const transactionMetadata = { logs: () => ['simulated'] } as TransactionMetadata;
+        const simulateTransaction = vi.fn().mockReturnValue({ meta: () => transactionMetadata });
+        const sendTransaction = vi.fn();
+        const svm = {
+            sendTransaction,
+            setTransactionMessageLifetimeUsingLatestBlockhash,
+            simulateTransaction,
+        } as unknown as LiteSVM;
+        const client = createClient()
+            .use(() => ({ payer, svm }))
+            .use(litesvmTransactionPlanner())
+            .use(litesvmTransactionPlanSigningExecutor());
+
+        const result = await client.signTransaction(singleInstructionPlan(MOCK_INSTRUCTION));
+
+        expect(result.context.message.lifetimeConstraint).toEqual(MOCK_BLOCKHASH);
+        expect(result.context.transaction).toBeDefined();
+        expect(result.context.transactionBase64).toBe(getBase64EncodedWireTransaction(result.context.transaction));
+        expect(result.context.signature).toBe(getSignatureFromTransaction(result.context.transaction));
+        expect(result.context.transactionMetadata).toBe(transactionMetadata);
+        expect(setTransactionMessageLifetimeUsingLatestBlockhash).toHaveBeenCalledOnce();
+        expect(simulateTransaction).toHaveBeenCalledExactlyOnceWith(result.context.transaction);
+        expect(sendTransaction).not.toHaveBeenCalled();
+    });
+
+    it('returns a partial transaction without simulation metadata when signatures are missing', async () => {
+        const payer = await generateKeyPairSigner();
+        const unsignedFeePayer = address('11111111111111111111111111111111');
+        const simulateTransaction = vi.fn();
+        const svm = {
+            setTransactionMessageLifetimeUsingLatestBlockhash: createMockSetLifetime(),
+            simulateTransaction,
+        } as unknown as LiteSVM;
+        const client = createClient()
+            .use(() => ({ payer, svm }))
+            .use(litesvmTransactionPlanner())
+            .use(litesvmTransactionPlanSigningExecutor());
+        const message = setTransactionMessageFeePayer(unsignedFeePayer, createTransactionMessage({ version: 0 }));
+
+        const result = await client.signTransaction(message);
+
+        expect(result.context.transaction.signatures[unsignedFeePayer]).toBeNull();
+        expect(result.context.transactionBase64).toBe(getBase64EncodedWireTransaction(result.context.transaction));
+        expect(result.context.signature).toBeUndefined();
+        expect(result.context.transactionMetadata).toBeUndefined();
+        expect(result.context).not.toHaveProperty('transactionMetadata');
+        expect(simulateTransaction).not.toHaveBeenCalled();
+    });
+
+    it('retains failed simulation metadata in a successful result context', async () => {
+        const payer = await generateKeyPairSigner();
+        const transactionMetadata = { err: () => 2 } as FailedTransactionMetadata;
+        const svm = {
+            setTransactionMessageLifetimeUsingLatestBlockhash: createMockSetLifetime(),
+            simulateTransaction: vi.fn().mockReturnValue(transactionMetadata),
+        } as unknown as LiteSVM;
+        const client = createClient()
+            .use(() => ({ payer, svm }))
+            .use(litesvmTransactionPlanner())
+            .use(litesvmTransactionPlanSigningExecutor());
+        const message = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
+
+        const result = await client.signTransaction(message);
+
+        expect(result.context.transactionMetadata).toBe(transactionMetadata);
+    });
+
+    it('does not fail sequential plans when their simulations fail', async () => {
+        const payer = await generateKeyPairSigner();
+        const transactionMetadata = { err: () => 2 } as FailedTransactionMetadata;
+        const svm = {
+            setTransactionMessageLifetimeUsingLatestBlockhash: createMockSetLifetime(),
+            simulateTransaction: vi.fn().mockReturnValue(transactionMetadata),
+        } as unknown as LiteSVM;
+        const client = createClient()
+            .use(() => ({ payer, svm }))
+            .use(litesvmTransactionPlanner())
+            .use(litesvmTransactionPlanSigningExecutor());
+        const message = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
+
+        const result = await client.signTransactions(sequentialTransactionPlan([message, message]));
+        const leaves = flattenTransactionPlanResult(result);
+
+        expect(leaves.map(leaf => leaf.status)).toEqual(['successful', 'successful']);
+        expect(leaves.map(leaf => leaf.context.transactionMetadata)).toEqual([
+            transactionMetadata,
+            transactionMetadata,
+        ]);
+    });
+
+    it('preserves a lifetime changed by a transaction-modifying signer', async () => {
+        const nonceAccountAddress = address('11111111111111111111111111111111');
+        const lifetimeConstraint = {
+            nonce: '11111111111111111111111111111111' as Nonce,
+            nonceAccountAddress,
+        };
+        const modifyingPayer = {
+            address: nonceAccountAddress,
+            modifyAndSignTransactions: vi.fn(
+                (transactions: readonly (Transaction | (Transaction & TransactionWithLifetime))[]) =>
+                    Promise.resolve(
+                        transactions.map(
+                            transaction =>
+                                ({
+                                    ...transaction,
+                                    lifetimeConstraint,
+                                }) as Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
+                        ),
+                    ),
+            ),
+        } satisfies TransactionModifyingSigner;
+        const svm = {
+            setTransactionMessageLifetimeUsingLatestBlockhash: createMockSetLifetime(),
+            simulateTransaction: vi.fn(),
+        } as unknown as LiteSVM;
+        const client = createClient()
+            .use(() => ({ payer: modifyingPayer, svm }))
+            .use(litesvmTransactionPlanner())
+            .use(litesvmTransactionPlanSigningExecutor());
+        const message = setTransactionMessageFeePayerSigner(modifyingPayer, createTransactionMessage({ version: 0 }));
+
+        const result = await client.signTransaction(message);
+
+        expect(result.context.message.lifetimeConstraint).toEqual(MOCK_BLOCKHASH);
+        expect(result.context.transaction.lifetimeConstraint).toEqual(lifetimeConstraint);
+        expect(modifyingPayer.modifyAndSignTransactions).toHaveBeenCalledOnce();
+    });
+
+    it('attempts every sequential leaf and reports successful siblings when one signer fails', async () => {
+        const payer = await generateKeyPairSigner();
+        const signingError = new Error('signing failed');
+        const failingPayer = {
+            address: address('11111111111111111111111111111111'),
+            signTransactions: vi.fn().mockRejectedValue(signingError),
+        } satisfies TransactionSigner;
+        const svm = {
+            setTransactionMessageLifetimeUsingLatestBlockhash: createMockSetLifetime(),
+            simulateTransaction: vi.fn().mockReturnValue({ meta: () => ({}) }),
+        } as unknown as LiteSVM;
+        const client = createClient()
+            .use(() => ({ payer, svm }))
+            .use(litesvmTransactionPlanner())
+            .use(litesvmTransactionPlanSigningExecutor());
+        const failingMessage = setTransactionMessageFeePayerSigner(
+            failingPayer,
+            createTransactionMessage({ version: 0 }),
+        );
+        const successfulMessage = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
+        const transactionPlan = sequentialTransactionPlan([failingMessage, successfulMessage]);
+
+        const error = await client.signTransactions(transactionPlan).catch((error: unknown) => error);
+
+        assert(isSolanaError(error, SOLANA_ERROR__FAILED_TO_SIGN_TRANSACTIONS));
+        const result = (error.context as { transactionPlanResult: TransactionPlanResult<LiteSvmSignContext> })
+            .transactionPlanResult;
+        expect(flattenTransactionPlanResult(result).map(leaf => leaf.status)).toEqual(['failed', 'successful']);
+        expect(failingPayer.signTransactions).toHaveBeenCalledOnce();
+    });
+
+    it('preserves the context recorded before a signer failure on the failed result', async () => {
+        const signingError = new Error('signing failed');
+        const failingPayer = {
+            address: address('11111111111111111111111111111111'),
+            signTransactions: vi.fn().mockRejectedValue(signingError),
+        } satisfies TransactionSigner;
+        const svm = {
+            setTransactionMessageLifetimeUsingLatestBlockhash: createMockSetLifetime(),
+            simulateTransaction: vi.fn(),
+        } as unknown as LiteSVM;
+        const client = createClient()
+            .use(() => ({ payer: failingPayer, svm }))
+            .use(litesvmTransactionPlanner())
+            .use(litesvmTransactionPlanSigningExecutor());
+        const message = setTransactionMessageFeePayerSigner(failingPayer, createTransactionMessage({ version: 0 }));
+
+        const error = await client.signTransactions(message).catch((error: unknown) => error);
+
+        assert(isSolanaError(error, SOLANA_ERROR__FAILED_TO_SIGN_TRANSACTIONS));
+        const result = (error.context as { transactionPlanResult: TransactionPlanResult<LiteSvmSignContext> })
+            .transactionPlanResult;
+        const [failedLeaf] = flattenTransactionPlanResult(result);
+        assert(failedLeaf.status === 'failed');
+        expect(failedLeaf.error).toBe(signingError);
+        expect(failedLeaf.context.message?.lifetimeConstraint).toEqual(MOCK_BLOCKHASH);
+        expect(failedLeaf.context.transaction).toBeUndefined();
+        expect(failedLeaf.context.transactionBase64).toBeUndefined();
+        expect(failedLeaf.context.signature).toBeUndefined();
+    });
+
+    it('preserves nested transaction plan shape while signing every leaf', async () => {
+        const payer = await generateKeyPairSigner();
+        const svm = {
+            setTransactionMessageLifetimeUsingLatestBlockhash: createMockSetLifetime(),
+            simulateTransaction: vi.fn().mockReturnValue({ meta: () => ({}) }),
+        } as unknown as LiteSVM;
+        const client = createClient()
+            .use(() => ({ payer, svm }))
+            .use(litesvmTransactionPlanner())
+            .use(litesvmTransactionPlanSigningExecutor());
+        const message = setTransactionMessageFeePayerSigner(payer, createTransactionMessage({ version: 0 }));
+        const transactionPlan = parallelTransactionPlan([
+            sequentialTransactionPlan([message, message]),
+            sequentialTransactionPlan([message, message]),
+        ]);
+
+        const result = await client.signTransactions(transactionPlan);
+
+        expect(result.kind).toBe('parallel');
+        expect(flattenTransactionPlanResult(result)).toHaveLength(4);
+        expect(flattenTransactionPlanResult(result).every(leaf => leaf.status === 'successful')).toBe(true);
+    });
+
+    if (__NODEJS__) {
+        it('simulates a real fully signed transaction without committing state', async () => {
+            const payer = await generateKeyPairSigner();
+            const destination = await generateKeyPairSigner();
+            const client = createClient()
+                .use(litesvmConnection())
+                .use(client => extendClient(client, { payer }))
+                .use(litesvmTransactionPlanner())
+                .use(litesvmTransactionPlanSigningExecutor());
+            client.svm.airdrop(payer.address, lamports(1_000_000_000n));
+            const instruction = getTransferSolInstruction({
+                amount: lamports(100_000_000n),
+                destination: destination.address,
+                source: payer,
+            });
+
+            const result = await client.signTransaction(instruction);
+
+            expect(result.context.transactionMetadata).toBeDefined();
+            expect(isFailedTransaction(result.context.transactionMetadata!)).toBe(false);
+            expect(client.svm.getBalance(destination.address)).toBeNull();
+        });
+    }
+
+    it('requires an svm instance on the client', async () => {
+        const payer = await generateKeyPairSigner();
+        expect(() =>
+            createClient()
+                .use(() => ({ payer }))
+                .use(litesvmTransactionPlanner())
+                // @ts-expect-error Missing svm on the client.
+                .use(litesvmTransactionPlanSigningExecutor()),
+        ).toThrow(/A LiteSVM instance is required/);
     });
 });
 


### PR DESCRIPTION
This PR adds `client.signTransaction(s)` for the `solanaLitesvm` client, using a new `litesvmTransactionPlanSigningExecutor` plugin. This follows from the equivalent plugin for RPC: #395 

This plugin performs most of the same functionality as the `litesvmTransactionPlanSendingExecutor`, it attaches a blockhash lifetime using `client.svm`, and partially signs the transaction(s). It does not attempt to send the transactions, so that the app is able to do that separately.

As with the RPC version, it uses `createTransactionPlanExecutorWithConcurrentLeaves` which ignores sequential dependencies in the input transaction plan.

Unlike the RPC version, no concurrency limit is used, matching the behaviour of liteSVM send. 

The returned context is the same as the litesvm send one, except `signature` is optional and `transactionBase64` is added. This doesn't have the same multisig use case as RPC but can be useful for debugging, so I think it fits the litesvm use case well. 