### PR TITLE
Stop executing queued transactions after abort in the sending executor

### DIFF
--- a/.changeset/sixty-paths-take.md
+++ b/.changeset/sixty-paths-take.md
@@ -1,0 +1,7 @@
+---
+'@solana/kit-plugin-rpc': patch
+---
+
+Stop preparing and sending queued transactions after the abort signal fires.
+
+When a transaction plan had more leaves than `maxConcurrency`, leaves waiting for a concurrency slot would still fetch a blockhash, estimate resource limits, sign and send once a slot freed up — even if the plan execution had already been aborted. The sending executor now bails out of queued executions as soon as the abort signal is aborted.

--- a/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
+++ b/packages/kit-plugin-rpc/src/transaction-plan-executor.ts
@@ -367,6 +367,10 @@ function createSendingExecutor(
 
     return createTransactionPlanExecutor<RpcSendContext>({
         executeTransactionMessage: limitFunction(async (context, transactionMessage, executorConfig) => {
+            // The executor has already reported this leaf as failed if the signal
+            // aborted while this call was waiting for a concurrency slot, so bail
+            // out before making orphaned RPC requests on its behalf.
+            executorConfig?.abortSignal?.throwIfAborted();
             const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send(executorConfig);
 
             // `estimateAndSetResourceLimits` only invokes our estimator when a

--- a/packages/kit-plugin-rpc/test/transaction-plan-executor.test.ts
+++ b/packages/kit-plugin-rpc/test/transaction-plan-executor.test.ts
@@ -24,6 +24,7 @@ import {
     singleInstructionPlan,
     singleTransactionPlan,
     SingleTransactionPlanResult,
+    SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS,
     SOLANA_ERROR__FAILED_TO_SIGN_TRANSACTIONS,
     SOLANA_ERROR__INVARIANT_VIOLATION__INVALID_TRANSACTION_PLAN_KIND,
     SolanaRpcApi,
@@ -702,6 +703,49 @@ describe('rpcTransactionPlanSendingExecutor', () => {
         resolvers[2]();
         resolvers[3]();
         await promise;
+    });
+
+    it('does not prepare or send queued transactions after the abort signal fires', async () => {
+        const payer = await generateKeyPairSigner();
+        const getLatestBlockhash = vi.fn().mockResolvedValue({ value: MOCK_BLOCKHASH });
+        const simulateTransaction = vi.fn().mockResolvedValue({ value: { unitsConsumed: 42n } });
+        const rpc = {
+            getLatestBlockhash: () => ({ send: getLatestBlockhash }),
+            simulateTransaction: () => ({ send: simulateTransaction }),
+        } as unknown as Rpc<SolanaRpcApi>;
+        const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        const sendReleasers: Array<() => void> = [];
+        const sendAndConfirmTransaction = vi.fn().mockImplementation(() => {
+            return new Promise<void>((_resolve, reject) => {
+                sendReleasers.push(() => reject(new Error('released')));
+            });
+        });
+        (sendAndConfirmTransactionFactory as Mock).mockReturnValueOnce(sendAndConfirmTransaction);
+
+        const client = createClient()
+            .use(() => ({ payer, rpc, rpcSubscriptions }))
+            .use(rpcTransactionPlanner())
+            .use(rpcTransactionPlanSendingExecutor({ maxConcurrency: 1 }));
+        const singlePlan = await client.transactionPlanner(singleInstructionPlan(MOCK_INSTRUCTION));
+        const transactionPlan = parallelTransactionPlan([singlePlan, singlePlan]);
+        const abortController = new AbortController();
+
+        const pendingError = client
+            .sendTransactions(transactionPlan, { abortSignal: abortController.signal })
+            .catch((error: unknown) => error);
+        await vi.waitFor(() => expect(sendAndConfirmTransaction).toHaveBeenCalledOnce());
+        abortController.abort();
+        // Fail the in-flight transaction so the overall call settles.
+        sendReleasers[0]();
+        const error = await pendingError;
+        assert(isSolanaError(error, SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS));
+
+        // The concurrency slot held by the first transaction is now free, so the
+        // queued second one gets its turn; verify it bails out without doing any work.
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await new Promise(resolve => setTimeout(resolve, 0));
+        expect(getLatestBlockhash).toHaveBeenCalledOnce();
+        expect(sendAndConfirmTransaction).toHaveBeenCalledOnce();
     });
 
     it('requires an RPC API on the client', () => {


### PR DESCRIPTION
When a transaction plan has more leaves than `maxConcurrency`, leaves waiting for a concurrency slot in `rpcTransactionPlanSendingExecutor` would still fetch a blockhash, estimate resource limits, sign and send once a slot freed up, even after the plan execution had been aborted. The executor has already reported those leaves at that point, so this work was orphaned: its RPC requests and signer calls served no result. The executor now checks the abort signal as soon as a queued execution acquires its slot and bails out before doing any work. 

This was identified as part of writing the RPC signing executor, pre-existing on the send executor.