### PR TITLE
Upgrade to Kit v8.2.0

### DIFF
--- a/.changeset/loud-masks-shake.md
+++ b/.changeset/loud-masks-shake.md
@@ -1,0 +1,13 @@
+---
+'@solana/kit-plugin-instruction-plan': minor
+'@solana/kit-plugin-litesvm': minor
+'@solana/kit-plugin-rpc': minor
+'@solana/kit-plugin-signer': minor
+'@solana/kit-plugin-wallet': minor
+---
+
+Upgrade all packages to `@solana/kit@^8.2.0`.
+
+**BREAKING CHANGES**
+
+**Kit 8.2 is now required.** Upgrade `@solana/kit` from `^8.0.0` to `^8.2.0`.

--- a/examples/token-airdrop/package.json
+++ b/examples/token-airdrop/package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "@solana-program/system": "^0.14.0",
         "@solana-program/token": "^0.16.0",
-        "@solana/kit": "^8.1.0",
+        "@solana/kit": "^8.2.0",
         "@solana/kit-plugin-rpc": "workspace:*",
         "@solana/kit-plugin-signer": "workspace:*"
     },

--- a/examples/transfer-lamports/package.json
+++ b/examples/transfer-lamports/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "@solana-program/system": "^0.14.0",
-        "@solana/kit": "^8.1.0",
+        "@solana/kit": "^8.2.0",
         "@solana/kit-plugin-rpc": "workspace:*",
         "@solana/kit-plugin-signer": "workspace:*"
     },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "@changesets/changelog-github": "^1.0.0",
         "@changesets/cli": "^3.0.1",
         "@solana-config/oxc": "^0.1.1",
-        "@solana/kit": "^8.1.0",
+        "@solana/kit": "^8.2.0",
         "@types/node": "^26",
         "agadoo": "^3.0.0",
         "happy-dom": "^20.11.12",

--- a/packages/kit-plugin-instruction-plan/package.json
+++ b/packages/kit-plugin-instruction-plan/package.json
@@ -53,7 +53,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^8.0.0"
+        "@solana/kit": "^8.2.0"
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-plugin-litesvm/package.json
+++ b/packages/kit-plugin-litesvm/package.json
@@ -59,7 +59,7 @@
         "@solana-program/system": "^0.14.0"
     },
     "peerDependencies": {
-        "@solana/kit": "^8.0.0"
+        "@solana/kit": "^8.2.0"
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-plugin-rpc/package.json
+++ b/packages/kit-plugin-rpc/package.json
@@ -55,7 +55,7 @@
         "@solana/kit-plugin-instruction-plan": "workspace:*"
     },
     "peerDependencies": {
-        "@solana/kit": "^8.0.0"
+        "@solana/kit": "^8.2.0"
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-plugin-signer/package.json
+++ b/packages/kit-plugin-signer/package.json
@@ -54,7 +54,7 @@
         "test:unit": "vitest run"
     },
     "peerDependencies": {
-        "@solana/kit": "^8.0.0"
+        "@solana/kit": "^8.2.0"
     },
     "browserslist": [
         "supports bigint and not dead",

--- a/packages/kit-plugin-wallet/package.json
+++ b/packages/kit-plugin-wallet/package.json
@@ -90,7 +90,7 @@
         "react-dom": "^19.2.8"
     },
     "peerDependencies": {
-        "@solana/kit": "^8.0.0",
+        "@solana/kit": "^8.2.0",
         "@solana/react": "^8.1.0",
         "react": "^19.2.8"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@solana/kit': ^8.1.0
+  '@solana/kit': ^8.2.0
 
 importers:
 
@@ -21,7 +21,7 @@ importers:
         specifier: ^0.1.1
         version: 0.1.1(oxfmt@0.65.0)(oxlint@1.80.0(oxlint-tsgolint@7.0.2001))
       '@solana/kit':
-        specifier: ^8.1.0
+        specifier: ^8.2.0
         version: 8.2.0(typescript@7.0.2)
       '@types/node':
         specifier: ^26
@@ -69,7 +69,7 @@ importers:
         specifier: ^0.16.0
         version: 0.16.0(@solana/kit@8.2.0(typescript@7.0.2))
       '@solana/kit':
-        specifier: ^8.1.0
+        specifier: ^8.2.0
         version: 8.2.0(typescript@7.0.2)
       '@solana/kit-plugin-rpc':
         specifier: workspace:*
@@ -84,7 +84,7 @@ importers:
         specifier: ^0.14.0
         version: 0.14.0(@solana/kit@8.2.0(typescript@7.0.2))
       '@solana/kit':
-        specifier: ^8.1.0
+        specifier: ^8.2.0
         version: 8.2.0(typescript@7.0.2)
       '@solana/kit-plugin-rpc':
         specifier: workspace:*
@@ -96,13 +96,13 @@ importers:
   packages/kit-plugin-instruction-plan:
     dependencies:
       '@solana/kit':
-        specifier: ^8.1.0
+        specifier: ^8.2.0
         version: 8.2.0(typescript@7.0.2)
 
   packages/kit-plugin-litesvm:
     dependencies:
       '@solana/kit':
-        specifier: ^8.1.0
+        specifier: ^8.2.0
         version: 8.2.0(typescript@7.0.2)
       '@solana/kit-plugin-instruction-plan':
         specifier: workspace:*
@@ -118,7 +118,7 @@ importers:
   packages/kit-plugin-rpc:
     dependencies:
       '@solana/kit':
-        specifier: ^8.1.0
+        specifier: ^8.2.0
         version: 8.2.0(typescript@7.0.2)
       '@solana/kit-plugin-instruction-plan':
         specifier: workspace:*
@@ -127,13 +127,13 @@ importers:
   packages/kit-plugin-signer:
     dependencies:
       '@solana/kit':
-        specifier: ^8.1.0
+        specifier: ^8.2.0
         version: 8.2.0(typescript@7.0.2)
 
   packages/kit-plugin-wallet:
     dependencies:
       '@solana/kit':
-        specifier: ^8.1.0
+        specifier: ^8.2.0
         version: 8.2.0(typescript@7.0.2)
       '@solana/wallet-account-signer':
         specifier: ^8.1.0
@@ -1140,13 +1140,13 @@ packages:
   '@solana-program/system@0.14.0':
     resolution: {integrity: sha512-Pjs2RINZHYmk/pqWNBCuQmfNjZT9woPJ/w7QkzzCSwcqcokbARtxsnIdgj4lJVxvr1DuxG8JGIbKnq6z1QRY6Q==}
     peerDependencies:
-      '@solana/kit': ^8.1.0
+      '@solana/kit': ^8.2.0
 
   '@solana-program/token@0.16.0':
     resolution: {integrity: sha512-VuFIu5vXsw1zwqls4/sGB88234oucmpuig553A33UnrbYnPZ8yXmqLYULBD92/k1pCGnMK+NMLWvsKzlZQ/1Kw==}
     engines: {node: '>=24.0.0'}
     peerDependencies:
-      '@solana/kit': ^8.1.0
+      '@solana/kit': ^8.2.0
 
   '@solana/accounts@8.2.0':
     resolution: {integrity: sha512-An3BICrQJQ7jR5EIgXzYnaKyCE7+ZusW9xX8m6Vj7U2cKo8t6Y3PTQ+aMjEajwzsQfxEL8QnpClFC9hdoIu7MA==}
@@ -1502,7 +1502,7 @@ packages:
     resolution: {integrity: sha512-CeaFWDkdGpIAsCvriUpIjndu5S7MwdpWaRXM7xkXveycn/zXX7LJv7/o5Bl5KB1AcQ5EnvWMA4fQYo6BFcn1ew==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      '@solana/kit': ^8.1.0
+      '@solana/kit': ^8.2.0
       '@tanstack/react-query': ^5.0.0
       react: '>=18'
       swr: ^2.5.1


### PR DESCRIPTION
Upgrade every workspace and example manifest to `@solana/kit@^8.2.0`, refresh the lockfile, and align the peer dependency floor across all published plugins.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>