### PR TITLE
Add `signOffchainMessage` wallet action

### DIFF
--- a/.changeset/sunny-peas-cross.md
+++ b/.changeset/sunny-peas-cross.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-wallet': minor
+---
+
+Add `client.wallet.signOffchainMessage` (and the `useSignOffchainMessage` React hook), exposing the wallet-standard `solana:signOffchainMessage` feature. The action signs a Solana offchain message with the connected account and verifies the wallet's response before resolving — decoding the returned bytes, asserting they encode exactly the requested message and signer set, and checking the signature — then resolves with a Kit `OffchainMessageEnvelope`. The input is an object carrying the format `version` (currently always `1`), the `message` text, and an optional `requiredSigners` list for multi-signer messages.

--- a/packages/kit-plugin-wallet/README.md
+++ b/packages/kit-plugin-wallet/README.md
@@ -159,6 +159,30 @@ All wallet state is accessed via `client.wallet.getState()`, which returns a ref
     const signature = await client.wallet.signMessage(new TextEncoder().encode('Hello'));
     ```
 
+- **`signOffchainMessage(input, options?)`** — Sign a [Solana offchain message](https://github.com/solana-foundation/SRFCs/discussions/3) with the connected account, via the wallet's `solana:signOffchainMessage` feature. The input carries the format `version` (currently always `1`) alongside the `message` text, so future format versions can be added without changing the call shape.
+
+    The wallet constructs the specification preamble and body it signs, so the plugin verifies the response before resolving: it decodes the returned bytes, asserts they encode exactly the message and signer set you requested, and checks the signature against the connected account's public key. A wallet that signs something else rejects with a Kit `SolanaError` (`CONTENT_DOES_NOT_MATCH_EXPECTED`, `REQUIRED_SIGNATORIES_DO_NOT_MATCH_EXPECTED`, or `SIGNATURE_VERIFICATION_FAILURE`).
+
+    Resolves with a Kit `OffchainMessageEnvelope` (`{ content, signatures }`) built from the verified bytes:
+
+    ```ts
+    const envelope = await client.wallet.signOffchainMessage({
+        message: 'Sign in to Example App',
+        version: 1,
+    });
+    ```
+
+    For messages that require multiple signers, pass every signer's address (including the connected account's) as `requiredSigners`. The envelope then carries this wallet's signature alongside `null` entries for the others; collect their signatures elsewhere and verify the completed envelope with Kit's `verifyOffchainMessageEnvelope`:
+
+    ```ts
+    const envelope = await client.wallet.signOffchainMessage({
+        message: 'Escrow release approved',
+        requiredSigners: [aliceAddress, bobAddress], // connected account = alice
+        version: 1,
+    });
+    envelope.signatures[bobAddress]; // null — to be collected from Bob's wallet
+    ```
+
 - **`signIn(wallet, input)`** — Sign In With Solana (SIWS-as-connect). Connects the wallet, calls `solana:signIn`, and sets up full connection state. Pass `{}` for `input` if no sign-in customization is needed. To sign in with the already-connected wallet, pass `getState().connected.wallet`.
 
     ```ts
@@ -181,13 +205,14 @@ The **state** hooks subscribe via `useSyncExternalStore`, each to a single slice
 
 The **action** hooks wrap the async wallet actions with `useAction` from `@solana/react`, returning its result (`dispatch`, `dispatchAsync`, `data`, `error`, `status`, `isRunning`, `reset`, …). The hook manages the `AbortSignal` internally, so an in-flight call is aborted when a newer one is dispatched:
 
-| Hook               | Wraps                                                                     |
-| ------------------ | ------------------------------------------------------------------------- |
-| `useConnect`       | `client.wallet.connect` — `dispatch(wallet)`                              |
-| `useDisconnect`    | `client.wallet.disconnect` — `dispatch()`                                 |
-| `useSignIn`        | `client.wallet.signIn` — `dispatch(wallet, input)`                        |
-| `useSignMessage`   | `client.wallet.signMessage` — `dispatch(message)`                         |
-| `useSelectAccount` | `client.wallet.selectAccount` — returns the synchronous callback directly |
+| Hook                     | Wraps                                                                                    |
+| ------------------------ | ---------------------------------------------------------------------------------------- |
+| `useConnect`             | `client.wallet.connect` — `dispatch(wallet)`                                             |
+| `useDisconnect`          | `client.wallet.disconnect` — `dispatch()`                                                |
+| `useSignIn`              | `client.wallet.signIn` — `dispatch(wallet, input)`                                       |
+| `useSignMessage`         | `client.wallet.signMessage` — `dispatch(message)`                                        |
+| `useSignOffchainMessage` | `client.wallet.signOffchainMessage` — `dispatch({ message, requiredSigners?, version })` |
+| `useSelectAccount`       | `client.wallet.selectAccount` — returns the synchronous callback directly                |
 
 Each component receives the `client` and passes it to the hooks it uses:
 

--- a/packages/kit-plugin-wallet/src/react/index.ts
+++ b/packages/kit-plugin-wallet/src/react/index.ts
@@ -1,4 +1,4 @@
-import type { ReadonlyUint8Array, SignatureBytes } from '@solana/kit';
+import type { OffchainMessageEnvelope, ReadonlyUint8Array, SignatureBytes } from '@solana/kit';
 import { type ActionResult, useAction } from '@solana/react';
 import type { SolanaSignInInput, SolanaSignInOutput } from '@solana/wallet-standard-features';
 import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui';
@@ -6,7 +6,13 @@ import type { ReactNode } from 'react';
 import { useSyncExternalStore } from 'react';
 
 import { isWalletWarmingUp } from '../status';
-import type { ClientWithWallet, WalletNamespace, WalletState, WalletStatus } from '../types';
+import type {
+    ClientWithWallet,
+    WalletNamespace,
+    WalletSignOffchainMessageInput,
+    WalletState,
+    WalletStatus,
+} from '../types';
 
 // -- State hooks ------------------------------------------------------------
 
@@ -247,6 +253,37 @@ export function useSignIn(
 export function useSignMessage(client: ClientWithWallet): ActionResult<[message: ReadonlyUint8Array], SignatureBytes> {
     const { wallet } = client;
     return useAction((abortSignal, message: ReadonlyUint8Array) => wallet.signMessage(message, { abortSignal }));
+}
+
+/**
+ * Signs a Solana offchain message with the connected account from a React component.
+ *
+ * Wraps `client.wallet.signOffchainMessage` with {@link useAction}. The action decodes and
+ * verifies the wallet's response before resolving — see
+ * `WalletNamespace.signOffchainMessage` for the guarantees and failure modes.
+ *
+ * `dispatch`/`dispatchAsync` take a `WalletSignOffchainMessageInput` — the format `version`
+ * (currently always `1`), the `message` text, and optionally the full list of required signer
+ * addresses (defaulting to the connected account) — and resolve with the verified
+ * `OffchainMessageEnvelope`.
+ *
+ * @param client - A client with a wallet plugin installed (e.g. `walletSigner()`).
+ *
+ * @example
+ * ```tsx
+ * const { dispatch } = useSignOffchainMessage(client);
+ * dispatch({ message: 'Sign in to Example App', version: 1 });
+ * ```
+ *
+ * @see {@link useSignMessage}
+ */
+export function useSignOffchainMessage(
+    client: ClientWithWallet,
+): ActionResult<[input: WalletSignOffchainMessageInput], OffchainMessageEnvelope> {
+    const { wallet } = client;
+    return useAction((abortSignal, input: WalletSignOffchainMessageInput) =>
+        wallet.signOffchainMessage(input, { abortSignal }),
+    );
 }
 
 /**

--- a/packages/kit-plugin-wallet/src/store.ts
+++ b/packages/kit-plugin-wallet/src/store.ts
@@ -1,9 +1,20 @@
 import {
+    type Address,
+    assertOffchainMessageV1Equal,
+    getAddressEncoder,
+    getOffchainMessageDecoder,
+    getPublicKeyFromAddress,
+    type OffchainMessageBytes,
+    type OffchainMessageEnvelope,
     type ReadonlyUint8Array,
     type SignatureBytes,
+    SOLANA_ERROR__OFFCHAIN_MESSAGE__ADDRESSES_CANNOT_SIGN_OFFCHAIN_MESSAGE,
+    SOLANA_ERROR__OFFCHAIN_MESSAGE__SIGNATURE_VERIFICATION_FAILURE,
+    SOLANA_ERROR__OFFCHAIN_MESSAGE__UNEXPECTED_VERSION,
     SOLANA_ERROR__WALLET__ACCOUNT_NOT_AVAILABLE,
     SOLANA_ERROR__WALLET__NOT_CONNECTED,
     SolanaError,
+    verifySignature,
 } from '@solana/kit';
 import { createSignerFromWalletAccount } from '@solana/wallet-account-signer';
 import {
@@ -13,6 +24,8 @@ import {
     type SolanaSignInOutput,
     SolanaSignMessage,
     type SolanaSignMessageFeature,
+    SolanaSignOffchainMessage,
+    type SolanaSignOffchainMessageFeature,
 } from '@solana/wallet-standard-features';
 import { getWallets } from '@wallet-standard/app';
 import {
@@ -37,6 +50,7 @@ import type {
     WalletNamespace,
     WalletPluginConfig,
     WalletSigner,
+    WalletSignOffchainMessageInput,
     WalletState,
     WalletStatus,
     WalletStorage,
@@ -91,6 +105,10 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
             signIn: () => Promise.reject(new SolanaError(SOLANA_ERROR__WALLET__NOT_CONNECTED, { operation: 'signIn' })),
             signMessage: () =>
                 Promise.reject(new SolanaError(SOLANA_ERROR__WALLET__NOT_CONNECTED, { operation: 'signMessage' })),
+            signOffchainMessage: () =>
+                Promise.reject(
+                    new SolanaError(SOLANA_ERROR__WALLET__NOT_CONNECTED, { operation: 'signOffchainMessage' }),
+                ),
             subscribe: () => () => {},
             subscribeSigner: () => () => {},
             whenReady: () => Promise.resolve(),
@@ -725,6 +743,82 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
         return output.signature as SignatureBytes;
     }
 
+    async function signOffchainMessage(
+        input: WalletSignOffchainMessageInput,
+        options?: WalletActionOptions,
+    ): Promise<OffchainMessageEnvelope> {
+        options?.abortSignal?.throwIfAborted();
+        const { message, version } = input;
+        const { account } = state;
+        if (!account) {
+            throw new SolanaError(SOLANA_ERROR__WALLET__NOT_CONNECTED, { operation: 'signOffchainMessage' });
+        }
+        // getWalletAccountFeature throws a WalletStandardError when either the wallet or the account does not
+        // support it, before any state is touched.
+        const signOffchainMessageFeature = getWalletAccountFeature(
+            account,
+            SolanaSignOffchainMessage,
+        ) as SolanaSignOffchainMessageFeature[typeof SolanaSignOffchainMessage];
+
+        const signerAddress = account.address as Address;
+        const requiredSigners = input.requiredSigners ?? [signerAddress];
+        if (!requiredSigners.includes(signerAddress)) {
+            // The feature requires the signing account's key to appear in
+            // `requiredSigners`
+            throw new SolanaError(SOLANA_ERROR__OFFCHAIN_MESSAGE__ADDRESSES_CANNOT_SIGN_OFFCHAIN_MESSAGE, {
+                expectedAddresses: requiredSigners,
+                unexpectedAddresses: [signerAddress],
+            });
+        }
+
+        // Dematerialize the UiWalletAccount handle into the wallet's own
+        // WalletAccount object: the handle is a copy made by the wallet-ui
+        // registry, and wallets may compare the input account by reference
+        // against their own account.
+        const walletAccount = getWalletAccountForUiWalletAccount(account);
+        const addressEncoder = getAddressEncoder();
+        const [output] = await signOffchainMessageFeature.signOffchainMessage({
+            account: walletAccount,
+            message,
+            messageVersion: version,
+            requiredSigners: requiredSigners.map(signer => addressEncoder.encode(signer)),
+        });
+
+        // We verify the message content and signatures before returning the result to the app
+        // This is stronger than `signMessage`, which only returns the signature
+        // It's also distinct from transactions, where we use the signer API
+        const receivedMessage = getOffchainMessageDecoder().decode(output.signedOffchainMessage);
+        if (receivedMessage.version !== version) {
+            throw new SolanaError(SOLANA_ERROR__OFFCHAIN_MESSAGE__UNEXPECTED_VERSION, {
+                actualVersion: receivedMessage.version,
+                expectedVersion: version,
+            });
+        }
+        assertOffchainMessageV1Equal(receivedMessage, {
+            content: message,
+            requiredSignatories: requiredSigners.map(address => ({ address })),
+            version,
+        });
+
+        // Verify the signature returned by the wallet
+        const content = output.signedOffchainMessage as OffchainMessageBytes;
+        const signature = output.signature as SignatureBytes;
+        const signerPublicKey = await getPublicKeyFromAddress(signerAddress);
+        if (!(await verifySignature(signerPublicKey, signature, content))) {
+            throw new SolanaError(SOLANA_ERROR__OFFCHAIN_MESSAGE__SIGNATURE_VERIFICATION_FAILURE, {
+                signatoriesWithInvalidSignatures: [signerAddress],
+                signatoriesWithMissingSignatures: [],
+            });
+        }
+
+        // Create a signatures map for `requiredSignatories`, with the signer's signature included, and any other required signer null
+        const signatures: Record<Address, SignatureBytes | null> = {};
+        for (const { address } of receivedMessage.requiredSignatories) {
+            signatures[address] = address === signerAddress ? signature : null;
+        }
+        return Object.freeze({ content, signatures: Object.freeze(signatures) });
+    }
+
     // -- Sign In With Solana (SIWS-as-connect) ------------------------------
 
     async function signIn(
@@ -971,6 +1065,7 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
         selectAccount,
         signIn,
         signMessage,
+        signOffchainMessage,
         subscribe: (listener: () => void) => {
             listeners.add(listener);
             return () => {

--- a/packages/kit-plugin-wallet/src/types.ts
+++ b/packages/kit-plugin-wallet/src/types.ts
@@ -1,4 +1,11 @@
-import type { MessageSigner, ReadonlyUint8Array, SignatureBytes, TransactionSigner } from '@solana/kit';
+import type {
+    Address,
+    MessageSigner,
+    OffchainMessageEnvelope,
+    ReadonlyUint8Array,
+    SignatureBytes,
+    TransactionSigner,
+} from '@solana/kit';
 import type { SolanaChain } from '@solana/wallet-standard-chains';
 import type { SolanaSignInInput, SolanaSignInOutput } from '@solana/wallet-standard-features';
 import type { IdentifierString } from '@wallet-standard/base';
@@ -87,6 +94,7 @@ export type WalletState = {
  * @see {@link WalletNamespace.disconnect}
  * @see {@link WalletNamespace.signMessage}
  * @see {@link WalletNamespace.signIn}
+ * @see {@link WalletNamespace.signOffchainMessage}
  */
 export type WalletActionOptions = {
     /**
@@ -102,6 +110,33 @@ export type WalletActionOptions = {
      * undoing what the wallet already did.
      */
     abortSignal?: AbortSignal;
+};
+
+/**
+ * Message input accepted by {@link WalletNamespace.signOffchainMessage},
+ * discriminated on `version`.
+ *
+ * Only version 1 of the Solana offchain message format is currently
+ * supported; future format versions would be added as new union members
+ * carrying their own version-specific fields.
+ */
+export type WalletSignOffchainMessageInput = {
+    /**
+     * UTF-8 message text to sign.
+     */
+    readonly message: string;
+    /**
+     * Addresses of every account that must sign the message for it to be
+     * valid. The list must include the connected account's
+     * address. Order does not matter.
+     *
+     * @default [the connected account's address]
+     */
+    readonly requiredSigners?: readonly Address[];
+    /**
+     * Version of the Solana offchain message format to sign.
+     */
+    readonly version: 1;
 };
 
 /**
@@ -343,6 +378,63 @@ export type WalletNamespace = {
      *   dispatched do not take effect.
      */
     signMessage: (message: ReadonlyUint8Array, options?: WalletActionOptions) => Promise<SignatureBytes>;
+
+    /**
+     * Sign a Solana offchain message with the connected account.
+     *
+     * Calls the wallet's `solana:signOffchainMessage` feature with the given
+     * message. The wallet — not this client — constructs the specification
+     * preamble and body it signs, so the returned bytes cannot be taken on
+     * trust; this action unconditionally verifies them before resolving. It
+     * decodes the returned bytes, asserts they encode exactly the requested
+     * message for exactly the requested signers
+     * ({@link assertOffchainMessageV1Equal}), and verifies the signature
+     * against the connected account's public key.
+     *
+     * @param input - The message to sign ({@link WalletSignOffchainMessageInput}):
+     *   the format `version` (currently always `1`), the UTF-8 `message` text,
+     *   and optionally the `requiredSigners` list.
+     * @returns An {@link OffchainMessageEnvelope} — `{ content, signatures }` —
+     *   composed of the wallet's verified bytes and signature. With the default
+     *   single-signer list the envelope is fully signed and can be passed to
+     *   `verifyOffchainMessageEnvelope` directly; with additional
+     *   `requiredSigners` the other signatories map to `null` until their
+     *   signatures are collected elsewhere.
+     * @throws `SolanaError(SOLANA_ERROR__WALLET__NOT_CONNECTED)` if no wallet is connected.
+     * @throws `WalletStandardError(WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_FEATURE_UNIMPLEMENTED)`
+     *   if the wallet or the connected account does not support
+     *   `solana:signOffchainMessage`.
+     * @throws `SolanaError(SOLANA_ERROR__OFFCHAIN_MESSAGE__ADDRESSES_CANNOT_SIGN_OFFCHAIN_MESSAGE)`
+     *   if an explicit `requiredSigners` list omits the connected account.
+     * @throws `SolanaError(SOLANA_ERROR__OFFCHAIN_MESSAGE__UNEXPECTED_VERSION)` if the
+     *   wallet returns a message of a version other than the requested one.
+     * @throws `SolanaError(SOLANA_ERROR__OFFCHAIN_MESSAGE__CONTENT_DOES_NOT_MATCH_EXPECTED)`
+     *   or `SolanaError(SOLANA_ERROR__OFFCHAIN_MESSAGE__REQUIRED_SIGNATORIES_DO_NOT_MATCH_EXPECTED)`
+     *   if the wallet signed different bytes than were requested. Do not trust
+     *   its signature.
+     * @throws `SolanaError(SOLANA_ERROR__OFFCHAIN_MESSAGE__SIGNATURE_VERIFICATION_FAILURE)`
+     *   if the wallet's signature does not verify against the returned bytes.
+     * @throws `options.abortSignal.reason` if the signal is already aborted
+     *   when the action is called. Aborts after the wallet call has been
+     *   dispatched do not take effect.
+     *
+     * @example
+     * ```ts
+     * const envelope = await client.wallet.signOffchainMessage({
+     *     message: 'Sign in to Example App',
+     *     version: 1,
+     * });
+     * // envelope.content are the exact bytes the wallet signed;
+     * // envelope.signatures maps the account's address to its signature.
+     * ```
+     *
+     * @see {@link WalletSignOffchainMessageInput}
+     * @see {@link WalletNamespace.signMessage} for raw-bytes message signing.
+     */
+    signOffchainMessage: (
+        input: WalletSignOffchainMessageInput,
+        options?: WalletActionOptions,
+    ) => Promise<OffchainMessageEnvelope>;
 
     /**
      * Subscribe to any wallet state change. Compatible with React's

--- a/packages/kit-plugin-wallet/test/_setup.ts
+++ b/packages/kit-plugin-wallet/test/_setup.ts
@@ -139,6 +139,9 @@ export let connectMock = vi.fn<() => Promise<void>>().mockResolvedValue(undefine
 export let disconnectMock = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
 export let signInMock: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue([{}]);
 export let signMessageMock: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue([{ signature: new Uint8Array(64) }]);
+export let signOffchainMessageMock: ReturnType<typeof vi.fn> = vi
+    .fn()
+    .mockResolvedValue([{ signature: new Uint8Array(64), signedOffchainMessage: new Uint8Array([1]) }]);
 export let eventListenerCleanup: ReturnType<typeof vi.fn<() => void>> = vi.fn<() => void>();
 
 // Active `standard:events` change handlers, keyed by wallet name. The store
@@ -176,6 +179,13 @@ function resolveFeatureImpl(feature: IdentifierString, walletName?: string): unk
     }
     if (feature === 'solana:signMessage') {
         return { signMessage: signMessageMock, version: '1.0.0' };
+    }
+    if (feature === 'solana:signOffchainMessage') {
+        return {
+            signOffchainMessage: signOffchainMessageMock,
+            supportedMessageVersions: [1],
+            version: '1.0.0',
+        };
     }
     throw new Error(`Feature ${feature} not supported`);
 }
@@ -278,6 +288,9 @@ beforeEach(() => {
     disconnectMock = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
     signInMock = vi.fn().mockResolvedValue([{}]);
     signMessageMock = vi.fn().mockResolvedValue([{ signature: new Uint8Array(64) }]);
+    signOffchainMessageMock = vi
+        .fn()
+        .mockResolvedValue([{ signature: new Uint8Array(64), signedOffchainMessage: new Uint8Array([1]) }]);
     createSignerMock = vi.fn<(...args: unknown[]) => unknown>().mockReturnValue(mockSigner);
     eventListenerCleanup = vi.fn<() => void>();
 });

--- a/packages/kit-plugin-wallet/test/store.test.ts
+++ b/packages/kit-plugin-wallet/test/store.test.ts
@@ -1,7 +1,25 @@
 import {
+    type Address,
+    compileOffchainMessageV0Envelope,
+    compileOffchainMessageV1Envelope,
+    generateKeyPair,
+    getAddressEncoder,
+    getAddressFromPublicKey,
+    isFullySignedOffchainMessageEnvelope,
+    isSolanaError,
+    offchainMessageApplicationDomain,
+    offchainMessageContentRestrictedAsciiOf1232BytesMax,
+    partiallySignOffchainMessageEnvelope,
+    type SignatureBytes,
+    SOLANA_ERROR__OFFCHAIN_MESSAGE__ADDRESSES_CANNOT_SIGN_OFFCHAIN_MESSAGE,
+    SOLANA_ERROR__OFFCHAIN_MESSAGE__CONTENT_DOES_NOT_MATCH_EXPECTED,
+    SOLANA_ERROR__OFFCHAIN_MESSAGE__REQUIRED_SIGNATORIES_DO_NOT_MATCH_EXPECTED,
+    SOLANA_ERROR__OFFCHAIN_MESSAGE__SIGNATURE_VERIFICATION_FAILURE,
+    SOLANA_ERROR__OFFCHAIN_MESSAGE__UNEXPECTED_VERSION,
     SOLANA_ERROR__WALLET__ACCOUNT_NOT_AVAILABLE,
     SOLANA_ERROR__WALLET__NOT_CONNECTED,
     SolanaError,
+    verifyOffchainMessageEnvelope,
 } from '@solana/kit';
 import { isWalletStandardError } from '@wallet-standard/errors';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -22,6 +40,7 @@ import {
     registryListeners,
     signInMock,
     signMessageMock,
+    signOffchainMessageMock,
     unregisterWallet,
     updateRegisteredWallet,
     walletEventHandlers,
@@ -53,6 +72,13 @@ describe.skipIf(__BROWSER__)('store (SSR / non-browser)', () => {
         const store = createWalletStore({ chain: 'solana:mainnet' });
         await expect(() => store.signMessage(new Uint8Array())).rejects.toThrow(
             new SolanaError(SOLANA_ERROR__WALLET__NOT_CONNECTED, { operation: 'signMessage' }),
+        );
+    });
+
+    it('throws for signOffchainMessage on server', async () => {
+        const store = createWalletStore({ chain: 'solana:mainnet' });
+        await expect(() => store.signOffchainMessage({ message: 'Hello', version: 1 })).rejects.toThrow(
+            new SolanaError(SOLANA_ERROR__WALLET__NOT_CONNECTED, { operation: 'signOffchainMessage' }),
         );
     });
 
@@ -1602,6 +1628,207 @@ describe.skipIf(!__BROWSER__)('store (browser)', () => {
 
         await store.disconnect();
         expect(listener).not.toHaveBeenCalled();
+    });
+});
+
+describe.skipIf(!__BROWSER__)('store signOffchainMessage (browser)', () => {
+    /**
+     * Builds a connected-wallet fixture backed by a real Ed25519 key pair, so
+     * the action's unconditional decode-and-verify path runs against genuine
+     * signatures. The store's own `mockSignerAddress` fixture is 32 zero
+     * bytes, which WebCrypto cannot import as an Ed25519 public key.
+     */
+    async function createOffchainFixture(otherSignerAddresses: readonly Address[] = []) {
+        const keyPair = await generateKeyPair();
+        const signerAddress = await getAddressFromPublicKey(keyPair.publicKey);
+        const account = createMockAccount(signerAddress, ['solana:signOffchainMessage', 'solana:signTransaction']);
+        const wallet = createMockUiWallet({
+            accounts: [account],
+            features: ['standard:connect', 'standard:events', 'solana:signOffchainMessage'],
+            name: 'OffchainWallet',
+        });
+        registerWallet(wallet);
+
+        /** The response a spec-conforming wallet would produce for `message`. */
+        async function signAsWallet(message: string) {
+            const envelope = compileOffchainMessageV1Envelope({
+                content: message,
+                requiredSignatories: [signerAddress, ...otherSignerAddresses].map(address => ({ address })),
+                version: 1,
+            });
+            const signed = await partiallySignOffchainMessageEnvelope([keyPair], envelope);
+            return {
+                signature: signed.signatures[signerAddress] as SignatureBytes,
+                signedOffchainMessage: signed.content,
+            };
+        }
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(wallet);
+        return { account, signAsWallet, signerAddress, store };
+    }
+
+    it('throws when not connected', async () => {
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await expect(store.signOffchainMessage({ message: 'Hello', version: 1 })).rejects.toThrow(
+            new SolanaError(SOLANA_ERROR__WALLET__NOT_CONNECTED, { operation: 'signOffchainMessage' }),
+        );
+    });
+
+    it('throws a WalletStandardError when the account does not support solana:signOffchainMessage', async () => {
+        const account = createMockAccount('11111111111111111111111111111111', ['solana:signTransaction']);
+        const mockWallet = createMockUiWallet({
+            accounts: [account],
+            features: ['standard:connect', 'standard:events', 'solana:signOffchainMessage'],
+            name: 'AccountWithoutOffchain',
+        });
+        registerWallet(mockWallet);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(mockWallet);
+
+        await expect(store.signOffchainMessage({ message: 'Hello', version: 1 })).rejects.toSatisfy(
+            isWalletStandardError,
+        );
+        expect(signOffchainMessageMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects with the signal reason and never calls the wallet when already aborted', async () => {
+        const { store } = await createOffchainFixture();
+
+        const controller = new AbortController();
+        controller.abort(new Error('aborted by caller'));
+
+        await expect(
+            store.signOffchainMessage({ message: 'Hello', version: 1 }, { abortSignal: controller.signal }),
+        ).rejects.toThrow('aborted by caller');
+        expect(signOffchainMessageMock).not.toHaveBeenCalled();
+    });
+
+    it('throws when an explicit requiredSigners list omits the active account', async () => {
+        const { store } = await createOffchainFixture();
+        const other = await getAddressFromPublicKey((await generateKeyPair()).publicKey);
+
+        await expect(
+            store.signOffchainMessage({ message: 'Hello', requiredSigners: [other], version: 1 }),
+        ).rejects.toSatisfy(e =>
+            isSolanaError(e, SOLANA_ERROR__OFFCHAIN_MESSAGE__ADDRESSES_CANNOT_SIGN_OFFCHAIN_MESSAGE),
+        );
+        expect(signOffchainMessageMock).not.toHaveBeenCalled();
+    });
+
+    it('signs, verifies, and returns a fully signed envelope for a single signer', async () => {
+        const { signAsWallet, signerAddress, store } = await createOffchainFixture();
+        signOffchainMessageMock.mockResolvedValueOnce([await signAsWallet('Hello')]);
+
+        const envelope = await store.signOffchainMessage({ message: 'Hello', version: 1 });
+
+        expect(envelope.signatures[signerAddress]).toBeInstanceOf(Uint8Array);
+        expect(isFullySignedOffchainMessageEnvelope(envelope)).toBe(true);
+        // The envelope must compose with Kit's full verification directly.
+        await expect(verifyOffchainMessageEnvelope(envelope)).resolves.toBeUndefined();
+    });
+
+    it('passes the feature the account, message, version 1, and encoded required signers', async () => {
+        const { account, signAsWallet, signerAddress, store } = await createOffchainFixture();
+        signOffchainMessageMock.mockResolvedValueOnce([await signAsWallet('Hello')]);
+
+        await store.signOffchainMessage({ message: 'Hello', version: 1 });
+
+        // The store encodes the account's *address* to public-key bytes; the
+        // mock account's own `publicKey` field is a zeroed placeholder, so
+        // compare against a fresh encoding rather than against it.
+        expect(signOffchainMessageMock).toHaveBeenCalledExactlyOnceWith({
+            account,
+            message: 'Hello',
+            messageVersion: 1,
+            requiredSigners: [getAddressEncoder().encode(signerAddress)],
+        });
+    });
+
+    it('passes the underlying wallet account to the feature, not the UiWalletAccount handle', async () => {
+        const { account, signAsWallet, store } = await createOffchainFixture();
+        signOffchainMessageMock.mockResolvedValueOnce([await signAsWallet('Hello')]);
+
+        await store.signOffchainMessage({ message: 'Hello', version: 1 });
+
+        // Wallets may compare the input account by reference against their own
+        // WalletAccount object (e.g. `if (account !== this.#account) throw`),
+        // so the store must dematerialize the UiWalletAccount handle into the
+        // wallet's own account object before invoking the feature.
+        const rawWallet = registeredWallets.find(w => w.name === 'OffchainWallet')!;
+        const passedAccount = (signOffchainMessageMock.mock.calls[0][0] as { account: unknown }).account;
+        expect(passedAccount).toBe(rawWallet.accounts[0]);
+        expect(passedAccount).not.toBe(account);
+    });
+
+    it('returns a partially signed envelope keyed by the decoded signatories for multiple signers', async () => {
+        const otherAddress = await getAddressFromPublicKey((await generateKeyPair()).publicKey);
+        const { signAsWallet, signerAddress, store } = await createOffchainFixture([otherAddress]);
+        signOffchainMessageMock.mockResolvedValueOnce([await signAsWallet('Hello')]);
+
+        const envelope = await store.signOffchainMessage({
+            message: 'Hello',
+            requiredSigners: [signerAddress, otherAddress],
+            version: 1,
+        });
+
+        expect(envelope.signatures[signerAddress]).toBeInstanceOf(Uint8Array);
+        expect(envelope.signatures[otherAddress]).toBeNull();
+        // The signature map lists every decoded signatory, in canonical order.
+        expect(Object.keys(envelope.signatures).sort()).toEqual([signerAddress, otherAddress].slice().sort());
+        expect(isFullySignedOffchainMessageEnvelope(envelope)).toBe(false);
+    });
+
+    it('throws CONTENT_DOES_NOT_MATCH_EXPECTED when the wallet signs different content', async () => {
+        const { signAsWallet, store } = await createOffchainFixture();
+        // The wallet signs 'Goodbye' — a valid, verifiable message, just not
+        // the one that was requested.
+        signOffchainMessageMock.mockResolvedValueOnce([await signAsWallet('Goodbye')]);
+
+        await expect(store.signOffchainMessage({ message: 'Hello', version: 1 })).rejects.toSatisfy(e =>
+            isSolanaError(e, SOLANA_ERROR__OFFCHAIN_MESSAGE__CONTENT_DOES_NOT_MATCH_EXPECTED),
+        );
+    });
+
+    it('throws REQUIRED_SIGNATORIES_DO_NOT_MATCH_EXPECTED when the wallet changes the signer set', async () => {
+        const otherAddress = await getAddressFromPublicKey((await generateKeyPair()).publicKey);
+        // The wallet includes an extra signatory the app never asked for.
+        const { signAsWallet, store } = await createOffchainFixture([otherAddress]);
+        signOffchainMessageMock.mockResolvedValueOnce([await signAsWallet('Hello')]);
+
+        await expect(store.signOffchainMessage({ message: 'Hello', version: 1 })).rejects.toSatisfy(e =>
+            isSolanaError(e, SOLANA_ERROR__OFFCHAIN_MESSAGE__REQUIRED_SIGNATORIES_DO_NOT_MATCH_EXPECTED),
+        );
+    });
+
+    it('throws SIGNATURE_VERIFICATION_FAILURE when the signature does not verify', async () => {
+        const { signAsWallet, store } = await createOffchainFixture();
+        const response = await signAsWallet('Hello');
+        signOffchainMessageMock.mockResolvedValueOnce([{ ...response, signature: new Uint8Array(64).fill(7) }]);
+
+        await expect(store.signOffchainMessage({ message: 'Hello', version: 1 })).rejects.toSatisfy(e =>
+            isSolanaError(e, SOLANA_ERROR__OFFCHAIN_MESSAGE__SIGNATURE_VERIFICATION_FAILURE),
+        );
+    });
+
+    it('throws UNEXPECTED_VERSION when the wallet returns a non-v1 message', async () => {
+        const { signAsWallet, signerAddress, store } = await createOffchainFixture();
+        const v0 = compileOffchainMessageV0Envelope({
+            // Any 32-byte base58 string works as an application domain; reuse
+            // the signer address to avoid inventing one.
+            applicationDomain: offchainMessageApplicationDomain(signerAddress),
+            content: offchainMessageContentRestrictedAsciiOf1232BytesMax('Hello'),
+            requiredSignatories: [{ address: signerAddress }],
+            version: 0,
+        });
+        signOffchainMessageMock.mockResolvedValueOnce([
+            { signature: (await signAsWallet('Hello')).signature, signedOffchainMessage: v0.content },
+        ]);
+
+        await expect(store.signOffchainMessage({ message: 'Hello', version: 1 })).rejects.toSatisfy(e =>
+            isSolanaError(e, SOLANA_ERROR__OFFCHAIN_MESSAGE__UNEXPECTED_VERSION),
+        );
     });
 });
 

--- a/packages/kit-plugin-wallet/test/useWalletActions.react.test.tsx
+++ b/packages/kit-plugin-wallet/test/useWalletActions.react.test.tsx
@@ -2,7 +2,14 @@ import { renderHook } from '@testing-library/react';
 import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui';
 import { describe, expect, it, vi } from 'vitest';
 
-import { useConnect, useDisconnect, useSelectAccount, useSignIn, useSignMessage } from '../src/react';
+import {
+    useConnect,
+    useDisconnect,
+    useSelectAccount,
+    useSignIn,
+    useSignMessage,
+    useSignOffchainMessage,
+} from '../src/react';
 import type { ClientWithWallet } from '../src/types';
 
 /** Wrap a wallet namespace in a client so it can be passed to a hook. */
@@ -93,6 +100,23 @@ describe('useSignMessage', () => {
         expect(returned).toBe(signature);
         expect(signMessage).toHaveBeenCalledWith(
             message,
+            expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
+        );
+    });
+});
+
+describe('useSignOffchainMessage', () => {
+    it('dispatches signOffchainMessage with the message input and a threaded abort signal', async () => {
+        const envelope = { content: new Uint8Array([1]), signatures: {} };
+        const signOffchainMessage = vi.fn().mockResolvedValue(envelope);
+        const { result: hook } = renderHook(() => useSignOffchainMessage(clientFor({ signOffchainMessage })));
+
+        const input = { message: 'Hello', version: 1 } as const;
+        const returned = await hook.current.dispatchAsync(input);
+
+        expect(returned).toBe(envelope);
+        expect(signOffchainMessage).toHaveBeenCalledWith(
+            input,
             expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
         );
     });


### PR DESCRIPTION
Draft for now, will hold off on merging until we have wallet support for the feature. But reviewable 

This PR adds the wallet-standard `solana:signOffchainMessage` feature as `client.wallet.signOffchainMessage`, and a `useSignOffchainMessage` react hook for it. This allows apps to ask the connected wallet to sign a given message using the offchain message format. 

The function takes as input an object `{version: 1, message: string, requiredSigners?: Address[]}`, ie the fields for a version 1 offchain message. See https://github.com/solana-foundation/SRFCs/discussions/3 

`requiredSigners` is optional, if omitted it defaults to the connected wallet address. If provided then it must include the connected wallet address. It returns a Kit `OffchainMessageEnvelope`, which will be partially signed if there are more than one `requiredSigners`.

The returned message is decoded and Kit's `assertOffchainMessageV1Equal` is called to ensure it is equivalent to the requested message. The wallet-standard feature requires the wallet to construct the message envelope. The returned signature is verified against the returned message.

These checks are different to other wallet plugin functions. For transactions we use the Kit signers API, which can return a modified transaction. We don't verify signatures for the app for transactions, but apps typically don't need to trust them and can rely on sending the transaction. The `signMessage` API has always been more limited and we don't verify its returned signature either. We designed the `signOffchainMessage` feature to be easy to verify, and apps rely on its signatures offchain by design, so I think it makes sense to have the stricter checks here.