### PR TITLE
Fix `signMessage` to pass the wallet's own account to the `solana:signMessage` feature

### DIFF
--- a/.changeset/ready-bushes-yell.md
+++ b/.changeset/ready-bushes-yell.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-wallet': patch
+---
+
+Fix `signMessage` passing the `UiWalletAccount` handle to the wallet's `solana:signMessage` feature instead of the wallet's own account object. Wallets that compare the input account by reference against their own `WalletAccount` would reject the request.

--- a/packages/kit-plugin-wallet/src/store.ts
+++ b/packages/kit-plugin-wallet/src/store.ts
@@ -25,7 +25,11 @@ import {
 } from '@wallet-standard/features';
 import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui';
 import { getWalletAccountFeature, getWalletFeature } from '@wallet-standard/ui-features';
-import { getOrCreateUiWalletForStandardWallet, getWalletForHandle } from '@wallet-standard/ui-registry';
+import {
+    getOrCreateUiWalletForStandardWallet,
+    getWalletAccountForUiWalletAccount,
+    getWalletForHandle,
+} from '@wallet-standard/ui-registry';
 
 import { isWalletWarmingUp } from './status';
 import type {
@@ -707,9 +711,17 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
             account,
             SolanaSignMessage,
         ) as SolanaSignMessageFeature[typeof SolanaSignMessage];
+        // Dematerialize the UiWalletAccount handle into the wallet's own
+        // WalletAccount object: the handle is a copy made by the wallet-ui
+        // registry, and wallets may compare the input account by reference
+        // against their own account.
+        const walletAccount = getWalletAccountForUiWalletAccount(account);
         // The wallet-standard `SolanaSignMessageInput.message` is a mutable `Uint8Array`; signing
         // only reads the bytes, so coerce the read-only input at this single boundary.
-        const [output] = await signMessageFeature.signMessage({ account, message: message as Uint8Array });
+        const [output] = await signMessageFeature.signMessage({
+            account: walletAccount,
+            message: message as Uint8Array,
+        });
         return output.signature as SignatureBytes;
     }
 

--- a/packages/kit-plugin-wallet/test/_setup.ts
+++ b/packages/kit-plugin-wallet/test/_setup.ts
@@ -66,7 +66,10 @@ export const registryListeners: Record<string, Array<(...args: unknown[]) => voi
 
 function createMockRawWallet(uiWallet: UiWallet) {
     return {
-        accounts: [...uiWallet.accounts],
+        // Copy each account into a distinct object. In the real registry a
+        // UiWalletAccount handle is never the same object as the wallet's own
+        // WalletAccount, so identity between the two must not hold in tests.
+        accounts: uiWallet.accounts.map((account): UiWalletAccount => ({ ...account })),
         chains: [...uiWallet.chains],
         features: Object.fromEntries(uiWallet.features.map(f => [f, { version: '1.0.0' }])),
         icon: uiWallet.icon,
@@ -103,13 +106,8 @@ const nameToRaw = new Map<string, object>();
 // registry's WeakMap does. Populated by registerWallet / updateRegisteredWallet.
 const accountToRaw = new WeakMap<object, object>();
 
-vi.mock('@wallet-standard/ui-registry', () => ({
-    getOrCreateUiWalletForStandardWallet: (raw: object) => {
-        const ui = rawToUi.get(raw);
-        if (!ui) throw new Error('No UiWallet registered for this raw wallet');
-        return ui;
-    },
-    getWalletForHandle: (handle: UiWallet | UiWalletAccount) => {
+vi.mock('@wallet-standard/ui-registry', () => {
+    function getWalletForHandle(handle: UiWallet | UiWalletAccount) {
         // Account handle? Resolve by object identity, like the real WeakMap registry.
         const rawFromAccount = accountToRaw.get(handle as unknown as object);
         if (rawFromAccount) return rawFromAccount;
@@ -117,8 +115,24 @@ vi.mock('@wallet-standard/ui-registry', () => ({
         const raw = nameToRaw.get((handle as UiWallet).name);
         if (!raw) throw new Error(`No raw wallet registered for "${(handle as UiWallet).name}"`);
         return raw;
-    },
-}));
+    }
+    return {
+        getOrCreateUiWalletForStandardWallet: (raw: object) => {
+            const ui = rawToUi.get(raw);
+            if (!ui) throw new Error('No UiWallet registered for this raw wallet');
+            return ui;
+        },
+        // Mirrors the real registry: resolves the owning wallet, then finds the
+        // wallet's own account object by address.
+        getWalletAccountForUiWalletAccount: (account: UiWalletAccount) => {
+            const raw = getWalletForHandle(account) as { accounts: readonly UiWalletAccount[] };
+            const walletAccount = raw.accounts.find(({ address }) => address === account.address);
+            if (!walletAccount) throw new Error(`No underlying account for address "${account.address}"`);
+            return walletAccount;
+        },
+        getWalletForHandle,
+    };
+});
 
 // Track the connect/disconnect/events mocks per wallet.
 export let connectMock = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);

--- a/packages/kit-plugin-wallet/test/store.test.ts
+++ b/packages/kit-plugin-wallet/test/store.test.ts
@@ -17,6 +17,7 @@ import {
     disconnectMock,
     emitWalletChange,
     lateRegisterWallet,
+    registeredWallets,
     registerWallet,
     registryListeners,
     signInMock,
@@ -616,6 +617,33 @@ describe.skipIf(!__BROWSER__)('store (browser)', () => {
 
         expect(signMessageMock).toHaveBeenCalledExactlyOnceWith({ account, message });
         expect(result).toBe(expectedSignature);
+    });
+
+    it('signMessage passes the underlying wallet account to the feature, not the UiWalletAccount handle', async () => {
+        const account = createMockAccount('11111111111111111111111111111111', [
+            'solana:signTransaction',
+            'solana:signMessage',
+        ]);
+        const mockWallet = createMockUiWallet({
+            accounts: [account],
+            features: ['standard:connect', 'standard:events', 'solana:signMessage'],
+            name: 'TestWallet',
+        });
+        registerWallet(mockWallet);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(mockWallet);
+
+        await store.signMessage(new Uint8Array([1, 2, 3]));
+
+        // Wallets may compare the input account by reference against their own
+        // WalletAccount object (e.g. `if (account !== this.#account) throw`),
+        // so the store must dematerialize the UiWalletAccount handle into the
+        // wallet's own account object before invoking the feature.
+        const rawWallet = registeredWallets.find(w => w.name === 'TestWallet')!;
+        const passedAccount = (signMessageMock.mock.calls[0][0] as { account: unknown }).account;
+        expect(passedAccount).toBe(rawWallet.accounts[0]);
+        expect(passedAccount).not.toBe(account);
     });
 
     it('signMessage throws when wallet does not support solana:signMessage', async () => {


### PR DESCRIPTION
Previously the wallet store passed the `UiWalletAccount` handle, which is a copy created by the wallet-ui registry.

This meant that if the wallet had a reference to the connected account, then `input.account !== account`

I found that Salmon wallet (open source) does this: https://github.com/Salmon-HQ/salmon-wallet-frontend/blob/f1291314e58ced515d630ffcc9f129883093b881/apps/extension/src/wallet-standard/wallet.ts#L330 

We now use `getWalletAccountForUiWalletAccount` to get the original wallet account handle back, and pass that to the wallet feature. This is the same thing Kit does when creating the transaction signer: https://github.com/anza-xyz/kit/blob/2b841a6f795823993a9935b4da8246382dbc1694/packages/wallet-account-signer/src/wallet-account-transaction-signer.ts#L65 

Note that currently this only affects the `signMessage` function. Transaction signing goes through the signer API (correct already), and connect/signIn don't pass the account to the wallet. This was found while testing the new `signOffchainMessage` which requires the same fix, but that's added in a separate PR.

The tests are also updated to make the mocked UI registry use a distinct account object from the one in the mock wallets, to properly exercise this code. 