### PR TITLE
Add `supportedTransactionVersions` to the wallet plugin's connected state

### DIFF
--- a/.changeset/perky-stars-fry.md
+++ b/.changeset/perky-stars-fry.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit-plugin-wallet': minor
+---
+
+Add `supportedTransactionVersions` to `getState().connected`, reporting the transaction versions the active account can sign as a `ReadonlySet<SolanaTransactionVersion>`. The value is intersected across every signing feature the account has, since the signer exposes one method per feature and the call site decides which one Kit uses, and is an empty set for accounts with no signing feature. Raises the `@solana/wallet-standard-features` requirement to `^1.5.0`, whose `SolanaTransactionVersion` adds v1.

--- a/packages/kit-plugin-wallet/README.md
+++ b/packages/kit-plugin-wallet/README.md
@@ -116,11 +116,19 @@ All wallet state is accessed via `client.wallet.getState()`, which returns a ref
     }
     ```
 
-- **`getState().connected`** — The active connection (wallet, account, and signer), or `null` when disconnected.
+- **`getState().connected`** — The active connection (wallet, account, signer, and supported transaction versions), or `null` when disconnected.
 
     ```ts
     const { connected } = client.wallet.getState();
     console.log(connected?.account.address);
+    ```
+
+- **`getState().connected.supportedTransactionVersions`** — The transaction versions the active account can sign, as a `ReadonlySet<SolanaTransactionVersion>` — `'legacy'` plus whichever numbered versions the installed `@solana/wallet-standard-features` defines. Intersected across every signing feature the account has, because `signer` exposes one method per feature (`modifyAndSignTransactions` for `solana:signTransaction`, `signAndSendTransactions` for `solana:signAndSendTransaction`) and the Kit helper you call decides which one is used — a version is only reported when every path accepts it. Wallets that predate versioned transactions report `Set(['legacy'])`, and read-only or message-only accounts report an empty set — so check membership rather than emptiness.
+
+    ```ts
+    const { connected } = client.wallet.getState();
+    // Test for the version you intend to send rather than assuming a ceiling.
+    const canSendV0 = connected?.supportedTransactionVersions.has(0) ?? false;
     ```
 
 - **`getState().status`** — The current connection status: `'pending'`, `'disconnected'`, `'connecting'`, `'connected'`, `'disconnecting'`, or `'reconnecting'`.

--- a/packages/kit-plugin-wallet/package.json
+++ b/packages/kit-plugin-wallet/package.json
@@ -73,7 +73,7 @@
     "dependencies": {
         "@solana/wallet-account-signer": "^8.2.0",
         "@solana/wallet-standard-chains": "^1.1.2",
-        "@solana/wallet-standard-features": "^1.4.0",
+        "@solana/wallet-standard-features": "^1.5.0",
         "@wallet-standard/app": "^1.1.1",
         "@wallet-standard/base": "^1.1.1",
         "@wallet-standard/features": "^1.1.1",

--- a/packages/kit-plugin-wallet/src/react/index.ts
+++ b/packages/kit-plugin-wallet/src/react/index.ts
@@ -41,8 +41,9 @@ export function useWalletStatus(client: ClientWithWallet): WalletStatus {
  * the connection changes (connect, disconnect, or account switch).
  *
  * @param client - A client with a wallet plugin installed (e.g. `walletSigner()`).
- * @returns The active connection — `{ account, signer, wallet }` — or `null` when disconnected.
- *   `signer` is `null` for read-only wallets.
+ * @returns The active connection — `{ account, signer, supportedTransactionVersions, wallet }` — or
+ *   `null` when disconnected. `signer` is `null` for read-only wallets, whose
+ *   `supportedTransactionVersions` is empty.
  *
  * @example
  * ```tsx

--- a/packages/kit-plugin-wallet/src/store.ts
+++ b/packages/kit-plugin-wallet/src/store.ts
@@ -7,12 +7,17 @@ import {
 } from '@solana/kit';
 import { createSignerFromWalletAccount } from '@solana/wallet-account-signer';
 import {
+    SolanaSignAndSendTransaction,
+    type SolanaSignAndSendTransactionFeature,
     SolanaSignIn,
     type SolanaSignInFeature,
     type SolanaSignInInput,
     type SolanaSignInOutput,
     SolanaSignMessage,
     type SolanaSignMessageFeature,
+    SolanaSignTransaction,
+    type SolanaSignTransactionFeature,
+    type SolanaTransactionVersion,
 } from '@solana/wallet-standard-features';
 import { getWallets } from '@wallet-standard/app';
 import {
@@ -64,8 +69,22 @@ type WalletStoreState = {
     reconnectingTo: UiWalletAccount | null;
     signer: WalletSigner | null;
     status: WalletStatus;
+    supportedTransactionVersions: ReadonlySet<SolanaTransactionVersion>;
     wallets: readonly UiWallet[];
 };
+
+// The subset of the state derived from a single wallet account's chains and
+// features. Derived together so the two can never disagree about the account
+// they describe.
+type AccountSignerState = Pick<WalletStoreState, 'signer' | 'supportedTransactionVersions'>;
+
+// Shared empty set for accounts that support no transaction versions, so the
+// value stays referentially stable while no account (or a read-only one) is
+// active.
+const NO_TRANSACTION_VERSIONS: ReadonlySet<SolanaTransactionVersion> = new Set();
+
+// The features that carry `supportedTransactionVersions`.
+const TRANSACTION_SIGNING_FEATURES = [SolanaSignAndSendTransaction, SolanaSignTransaction] as const;
 
 // -- Store ------------------------------------------------------------------
 
@@ -106,6 +125,7 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
         reconnectingTo: null,
         signer: null,
         status: 'pending',
+        supportedTransactionVersions: NO_TRANSACTION_VERSIONS,
         wallets: [],
     };
 
@@ -153,6 +173,7 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
                     ? Object.freeze({
                           account: s.account,
                           signer: s.signer,
+                          supportedTransactionVersions: s.supportedTransactionVersions,
                           wallet: s.connectedWallet,
                       })
                     : null,
@@ -204,6 +225,7 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
             state.reconnectingTo !== prev.reconnectingTo ||
             state.status !== prev.status ||
             state.signer !== prev.signer ||
+            state.supportedTransactionVersions !== prev.supportedTransactionVersions ||
             state.wallets !== prev.wallets
         ) {
             snapshot = deriveSnapshot(state);
@@ -241,6 +263,46 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
             // non-Solana chain).
             return null;
         }
+    }
+
+    // The transaction versions the account can sign, intersected across every
+    // signing feature it has. `createSignerFromWalletAccount` exposes one
+    // method per feature — `modifyAndSignTransactions` for
+    // `solana:signTransaction`, `signAndSendTransactions` for
+    // `solana:signAndSendTransaction` — and the call site, not this plugin,
+    // decides which one Kit reaches for. A version is therefore only safe to
+    // report if every path the signer exposes accepts it: picking one feature's
+    // list would over-report for whichever path the app happens to take.
+    // An account with no signing feature (read-only, or message-signing only)
+    // supports no versions at all.
+    //
+    // Read account-scoped rather than wallet-scoped for the same reason the
+    // signer is: an account may expose a narrower feature set than its wallet,
+    // and the registry regenerates the account handle precisely when that set
+    // changes. Feature resolution can still throw for a malformed or stale
+    // wallet, which degrades to the empty set rather than failing the
+    // connection over a metadata read.
+    function getSupportedTransactionVersions(account: UiWalletAccount): ReadonlySet<SolanaTransactionVersion> {
+        const featureNames = TRANSACTION_SIGNING_FEATURES.filter(name => account.features.includes(name));
+        if (featureNames.length === 0) return NO_TRANSACTION_VERSIONS;
+        try {
+            const [first, ...rest] = featureNames.map(name => {
+                const feature = getWalletAccountFeature(account, name) as
+                    | SolanaSignAndSendTransactionFeature[typeof SolanaSignAndSendTransaction]
+                    | SolanaSignTransactionFeature[typeof SolanaSignTransaction];
+                return feature.supportedTransactionVersions;
+            });
+            return new Set(first.filter(version => rest.every(versions => versions.includes(version))));
+        } catch {
+            return NO_TRANSACTION_VERSIONS;
+        }
+    }
+
+    function deriveAccountSignerState(account: UiWalletAccount): AccountSignerState {
+        return {
+            signer: tryCreateSigner(account),
+            supportedTransactionVersions: getSupportedTransactionVersions(account),
+        };
     }
 
     // -- Wallet discovery --------------------------------------------------
@@ -331,6 +393,7 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
             updates.connectedWallet = null;
             updates.account = null;
             updates.signer = null;
+            updates.supportedTransactionVersions = NO_TRANSACTION_VERSIONS;
             updates.status = 'disconnected';
             clearPersistedAccount();
         }
@@ -354,7 +417,7 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
         // events (a listener the already-run disposer can't clean up) or reports
         // itself connected.
         if (disposed) return;
-        const signer = tryCreateSigner(account);
+        const signerState = deriveAccountSignerState(account);
         disconnectingWalletName = null;
         // Reconcile `wallets` alongside the connection: `connect`/`signIn`/silent
         // reconnect authorize accounts on the underlying wallet, which regenerates
@@ -368,9 +431,9 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
         updateState({
             account,
             connectedWallet: wallet,
-            signer,
             status: 'connected',
             wallets: reconcileWalletList(),
+            ...signerState,
         });
         if (options?.persist !== false) {
             persistAccount(account, wallet);
@@ -445,7 +508,7 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
 
         // The active account changed (switched, removed, or regenerated because
         // its features/chains changed) — recreate the signer for it.
-        return { account: activeAccount, signer: tryCreateSigner(activeAccount) };
+        return { account: activeAccount, ...deriveAccountSignerState(activeAccount) };
     }
 
     // -- Connection lifecycle ----------------------------------------------
@@ -606,6 +669,7 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
             connectedWallet: null,
             signer: null,
             status: 'disconnected',
+            supportedTransactionVersions: NO_TRANSACTION_VERSIONS,
             // Reconcile the list too: when this runs from the change handler
             // because the connected wallet dropped the configured chain or
             // failed the filter, that wallet must leave `wallets` immediately
@@ -687,8 +751,12 @@ export function createWalletStore(config: WalletPluginConfig): WalletStore {
         // Switch the active connection (owner may differ from the current one). The
         // previously-active wallet is left authorized — we never disconnect it. Its
         // event subscription persists, so switching back stays live.
-        const signer = tryCreateSigner(selectedAccount);
-        updateState({ account: selectedAccount, connectedWallet: refreshed, signer, status: 'connected' });
+        updateState({
+            account: selectedAccount,
+            connectedWallet: refreshed,
+            status: 'connected',
+            ...deriveAccountSignerState(selectedAccount),
+        });
         persistAccount(selectedAccount, refreshed);
     }
 

--- a/packages/kit-plugin-wallet/src/types.ts
+++ b/packages/kit-plugin-wallet/src/types.ts
@@ -1,6 +1,6 @@
 import type { MessageSigner, ReadonlyUint8Array, SignatureBytes, TransactionSigner } from '@solana/kit';
 import type { SolanaChain } from '@solana/wallet-standard-chains';
-import type { SolanaSignInInput, SolanaSignInOutput } from '@solana/wallet-standard-features';
+import type { SolanaSignInInput, SolanaSignInOutput, SolanaTransactionVersion } from '@solana/wallet-standard-features';
 import type { IdentifierString } from '@wallet-standard/base';
 import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui';
 
@@ -59,6 +59,33 @@ export type WalletState = {
         readonly account: UiWalletAccount;
         /** The signer for the active account, or `null` for read-only wallets. */
         readonly signer: WalletSigner | null;
+        /**
+         * The transaction versions the active account can sign, intersected
+         * across every signing feature it has — `solana:signTransaction`,
+         * `solana:signAndSendTransaction`, or both.
+         *
+         * The intersection is deliberate. {@link signer} exposes one method per
+         * feature (`modifyAndSignTransactions` and `signAndSendTransactions`),
+         * and the Kit helper you call decides which one is used — so a version
+         * is only reported when every path the signer exposes accepts it. For a
+         * wallet advertising different versions per feature, this is narrower
+         * than either list. Read the features directly with
+         * `getWalletAccountFeature` if you need the per-path lists.
+         *
+         * Empty when the account has no signing feature — a read-only wallet,
+         * or one that only signs messages. A wallet that predates versioned
+         * transactions reports `Set(['legacy'])`, so check membership rather
+         * than emptiness before building a versioned transaction.
+         *
+         * @example
+         * ```ts
+         * const { connected } = client.wallet.getState();
+         * // Test for the version you intend to send rather than assuming a ceiling —
+         * // the set grows as wallet-standard adds versions.
+         * const canSendV0 = connected?.supportedTransactionVersions.has(0) ?? false;
+         * ```
+         */
+        readonly supportedTransactionVersions: ReadonlySet<SolanaTransactionVersion>;
         readonly wallet: UiWallet;
     } | null;
     /**

--- a/packages/kit-plugin-wallet/test/_setup.ts
+++ b/packages/kit-plugin-wallet/test/_setup.ts
@@ -1,4 +1,5 @@
 import { address } from '@solana/kit';
+import type { SolanaTransactionVersion } from '@solana/wallet-standard-features';
 import {
     WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_FEATURE_UNIMPLEMENTED,
     WalletStandardError,
@@ -152,6 +153,24 @@ export function emitWalletChange(name: string, props: Record<string, unknown>): 
 
 type IdentifierString = `${string}:${string}`;
 
+// `supportedTransactionVersions` reported by each transaction-signing feature
+// mock. Mutated in place by tests to exercise the precedence between
+// `solana:signAndSendTransaction` and `solana:signTransaction`; reset in
+// `beforeEach`.
+export const supportedTransactionVersions: {
+    'solana:signAndSendTransaction': readonly SolanaTransactionVersion[];
+    'solana:signTransaction': readonly SolanaTransactionVersion[];
+} = {
+    'solana:signAndSendTransaction': ['legacy', 0],
+    'solana:signTransaction': ['legacy', 0],
+};
+
+// When set, the transaction-signing feature mocks throw this instead of
+// resolving. Simulates a malformed wallet whose account advertises a feature
+// the wallet itself does not implement, which is what makes the real
+// `getWalletAccountFeature` throw past the account-level feature check.
+export const transactionFeatureFailure: { error: Error | null } = { error: null };
+
 function resolveFeatureImpl(feature: IdentifierString, walletName?: string): unknown {
     if (feature === 'standard:connect') {
         return { connect: connectMock, version: '1.0.0' };
@@ -176,6 +195,10 @@ function resolveFeatureImpl(feature: IdentifierString, walletName?: string): unk
     }
     if (feature === 'solana:signMessage') {
         return { signMessage: signMessageMock, version: '1.0.0' };
+    }
+    if (feature === 'solana:signTransaction' || feature === 'solana:signAndSendTransaction') {
+        if (transactionFeatureFailure.error) throw transactionFeatureFailure.error;
+        return { supportedTransactionVersions: supportedTransactionVersions[feature], version: '1.0.0' };
     }
     throw new Error(`Feature ${feature} not supported`);
 }
@@ -279,6 +302,9 @@ beforeEach(() => {
     signInMock = vi.fn().mockResolvedValue([{}]);
     signMessageMock = vi.fn().mockResolvedValue([{ signature: new Uint8Array(64) }]);
     createSignerMock = vi.fn<(...args: unknown[]) => unknown>().mockReturnValue(mockSigner);
+    supportedTransactionVersions['solana:signAndSendTransaction'] = ['legacy', 0];
+    supportedTransactionVersions['solana:signTransaction'] = ['legacy', 0];
+    transactionFeatureFailure.error = null;
     eventListenerCleanup = vi.fn<() => void>();
 });
 

--- a/packages/kit-plugin-wallet/test/store.test.ts
+++ b/packages/kit-plugin-wallet/test/store.test.ts
@@ -22,6 +22,8 @@ import {
     registryListeners,
     signInMock,
     signMessageMock,
+    supportedTransactionVersions,
+    transactionFeatureFailure,
     unregisterWallet,
     updateRegisteredWallet,
     walletEventHandlers,
@@ -3170,5 +3172,188 @@ describe.skipIf(!__BROWSER__)('store whenReady (browser)', () => {
         store[Symbol.dispose]();
         expect(store.getState().status).toBe('disconnected');
         await expect(store.whenReady()).resolves.toBeUndefined();
+    });
+});
+
+describe.skipIf(!__BROWSER__)('store supportedTransactionVersions (browser)', () => {
+    it('reports the versions from solana:signTransaction alone when it is the only feature', async () => {
+        supportedTransactionVersions['solana:signTransaction'] = ['legacy', 0];
+        // The other feature advertises less, but the account does not have it,
+        // so it must not narrow the result.
+        supportedTransactionVersions['solana:signAndSendTransaction'] = ['legacy'];
+        const account = createMockAccount(undefined, ['solana:signTransaction']);
+        const mockWallet = createMockUiWallet({ accounts: [account], name: 'TestWallet' });
+        registerWallet(mockWallet);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(mockWallet);
+
+        expect(store.getState().connected!.supportedTransactionVersions).toEqual(new Set(['legacy', 0]));
+    });
+
+    it('reports the union when both features advertise the same versions', async () => {
+        supportedTransactionVersions['solana:signAndSendTransaction'] = ['legacy', 0];
+        supportedTransactionVersions['solana:signTransaction'] = ['legacy', 0];
+        const account = createMockAccount(undefined, ['solana:signTransaction', 'solana:signAndSendTransaction']);
+        const mockWallet = createMockUiWallet({ accounts: [account], name: 'TestWallet' });
+        registerWallet(mockWallet);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(mockWallet);
+
+        expect(store.getState().connected!.supportedTransactionVersions).toEqual(new Set(['legacy', 0]));
+    });
+
+    it('intersects the two features when solana:signTransaction is the narrower one', async () => {
+        supportedTransactionVersions['solana:signAndSendTransaction'] = ['legacy', 0];
+        supportedTransactionVersions['solana:signTransaction'] = ['legacy'];
+        const account = createMockAccount(undefined, ['solana:signTransaction', 'solana:signAndSendTransaction']);
+        const mockWallet = createMockUiWallet({ accounts: [account], name: 'TestWallet' });
+        registerWallet(mockWallet);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(mockWallet);
+
+        // The signer exposes both signing paths, so only versions every path
+        // supports may be reported.
+        expect(store.getState().connected!.supportedTransactionVersions).toEqual(new Set(['legacy']));
+    });
+
+    it('intersects the two features when solana:signAndSendTransaction is the narrower one', async () => {
+        supportedTransactionVersions['solana:signAndSendTransaction'] = ['legacy'];
+        supportedTransactionVersions['solana:signTransaction'] = ['legacy', 0];
+        const account = createMockAccount(undefined, ['solana:signTransaction', 'solana:signAndSendTransaction']);
+        const mockWallet = createMockUiWallet({ accounts: [account], name: 'TestWallet' });
+        registerWallet(mockWallet);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(mockWallet);
+
+        expect(store.getState().connected!.supportedTransactionVersions).toEqual(new Set(['legacy']));
+    });
+
+    it('reports the versions from solana:signAndSendTransaction alone when it is the only feature', async () => {
+        supportedTransactionVersions['solana:signAndSendTransaction'] = ['legacy', 0];
+        supportedTransactionVersions['solana:signTransaction'] = ['legacy'];
+        const account = createMockAccount(undefined, ['solana:signAndSendTransaction']);
+        const mockWallet = createMockUiWallet({ accounts: [account], name: 'TestWallet' });
+        registerWallet(mockWallet);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(mockWallet);
+
+        expect(store.getState().connected!.supportedTransactionVersions).toEqual(new Set(['legacy', 0]));
+    });
+
+    it('reports a legacy-only set rather than null', async () => {
+        supportedTransactionVersions['solana:signTransaction'] = ['legacy'];
+        const account = createMockAccount(undefined, ['solana:signTransaction']);
+        const mockWallet = createMockUiWallet({ accounts: [account], name: 'TestWallet' });
+        registerWallet(mockWallet);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(mockWallet);
+
+        expect(store.getState().connected!.supportedTransactionVersions).toEqual(new Set(['legacy']));
+    });
+
+    it('reports an empty set for an account with no transaction signing feature', async () => {
+        const account = createMockAccount(undefined, ['solana:signMessage']);
+        const mockWallet = createMockUiWallet({ accounts: [account], name: 'TestWallet' });
+        registerWallet(mockWallet);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(mockWallet);
+
+        expect(store.getState().connected!.supportedTransactionVersions).toEqual(new Set());
+    });
+
+    it('keeps the set referentially stable across an unrelated snapshot change', async () => {
+        const account = createMockAccount();
+        const mockWallet = createMockUiWallet({ accounts: [account], name: 'TestWallet' });
+        registerWallet(mockWallet);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(mockWallet);
+        const before = store.getState().connected!.supportedTransactionVersions;
+        expect(before).toEqual(new Set(['legacy', 0]));
+
+        // A second wallet appearing rebuilds the snapshot without touching the
+        // active account, so the set must not be reallocated.
+        lateRegisterWallet(createMockUiWallet({ name: 'OtherWallet' }));
+
+        expect(store.getState().wallets).toHaveLength(2);
+        expect(store.getState().connected!.supportedTransactionVersions).toBe(before);
+    });
+
+    it('updates when the active account is regenerated with different versions', async () => {
+        supportedTransactionVersions['solana:signTransaction'] = ['legacy', 0];
+        const account = createMockAccount();
+        const mockWallet = createMockUiWallet({ accounts: [account], name: 'TestWallet' });
+        registerWallet(mockWallet);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(mockWallet);
+        expect(store.getState().connected!.supportedTransactionVersions).toEqual(new Set(['legacy', 0]));
+
+        // The wallet drops versioned-transaction support and regenerates the
+        // account handle to reflect it.
+        supportedTransactionVersions['solana:signTransaction'] = ['legacy'];
+        updateRegisteredWallet(createMockUiWallet({ accounts: [{ ...account }], name: 'TestWallet' }));
+        emitWalletChange('TestWallet', { features: true });
+
+        expect(store.getState().connected!.supportedTransactionVersions).toEqual(new Set(['legacy']));
+    });
+
+    it('reports an empty set when the account loses signing support', async () => {
+        const account = createMockAccount();
+        const mockWallet = createMockUiWallet({ accounts: [account], name: 'TestWallet' });
+        registerWallet(mockWallet);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(mockWallet);
+        expect(store.getState().connected!.supportedTransactionVersions.size).toBeGreaterThan(0);
+
+        createSignerMock.mockImplementation(() => {
+            throw new Error('No signing features');
+        });
+        updateRegisteredWallet(createMockUiWallet({ accounts: [{ ...account, features: [] }], name: 'TestWallet' }));
+        emitWalletChange('TestWallet', { features: true });
+
+        const { connected } = store.getState();
+        expect(connected!.signer).toBeNull();
+        expect(connected!.supportedTransactionVersions).toEqual(new Set());
+    });
+
+    it('reports an empty set when the feature lookup throws for a malformed wallet', async () => {
+        const account = createMockAccount();
+        const mockWallet = createMockUiWallet({ accounts: [account], name: 'TestWallet' });
+        registerWallet(mockWallet);
+        // The account advertises `solana:signTransaction` but the wallet does
+        // not implement it, so resolving the feature throws.
+        transactionFeatureFailure.error = new Error('Wallet does not implement solana:signTransaction');
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(mockWallet);
+
+        const { connected } = store.getState();
+        expect(connected!.supportedTransactionVersions).toEqual(new Set());
+        // The connection itself must survive a failed metadata read.
+        expect(connected!.signer).not.toBeNull();
+        expect(store.getState().status).toBe('connected');
+    });
+
+    it('passes through numbered versions beyond v0', async () => {
+        supportedTransactionVersions['solana:signTransaction'] = ['legacy', 0, 1];
+        const account = createMockAccount(undefined, ['solana:signTransaction']);
+        const mockWallet = createMockUiWallet({ accounts: [account], name: 'TestWallet' });
+        registerWallet(mockWallet);
+
+        const store = createWalletStore({ chain: 'solana:mainnet', storage: null });
+        await store.connect(mockWallet);
+
+        // The store reports whatever the wallet advertises — it must not filter
+        // the set down to the versions it happens to know about.
+        expect(store.getState().connected!.supportedTransactionVersions).toEqual(new Set(['legacy', 0, 1]));
     });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       '@solana/wallet-standard-features':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.5.0
+        version: 1.5.0
       '@wallet-standard/app':
         specifier: ^1.1.1
         version: 1.1.1
@@ -1743,8 +1743,8 @@ packages:
     resolution: {integrity: sha512-EZobEGclDBAFplpJC5F3d/s8Xnlqc5isNKuPrd5o9ZPZ7tWN84O0e68yIZ8MAOj9V7ieRadNiHtql7uIXCTyXg==}
     engines: {node: '>=22'}
 
-  '@solana/wallet-standard-features@1.4.0':
-    resolution: {integrity: sha512-f0tAdqwM2aL6CiFbIgt9h5zKFp+mgY/iNGwoxPMTj9VSTeQj7d1GGSmWhZw0XWoZ4N/1tnKTKmYFq+Dyq08jRw==}
+  '@solana/wallet-standard-features@1.5.0':
+    resolution: {integrity: sha512-gxlLaEfPAqbhd3LNkK0Ks2pbVvDm1SDGqBK/ynDQy13Gu+qiURLpRCfSPjbtrw5bmqQsZ6rS2YJHL31bY/Koag==}
     engines: {node: '>=22'}
 
   '@testing-library/dom@10.4.1':
@@ -3620,7 +3620,7 @@ snapshots:
       '@solana/subscribable': 8.1.0(typescript@7.0.2)
       '@solana/transaction-messages': 8.1.0(typescript@7.0.2)
       '@solana/transactions': 8.1.0(typescript@7.0.2)
-      '@solana/wallet-standard-features': 1.4.0
+      '@solana/wallet-standard-features': 1.5.0
       '@wallet-standard/base': 1.1.1
       '@wallet-standard/errors': 0.1.2
       '@wallet-standard/react': 1.0.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -3963,7 +3963,7 @@ snapshots:
       '@solana/transaction-messages': 8.2.0(typescript@7.0.2)
       '@solana/transactions': 8.2.0(typescript@7.0.2)
       '@solana/wallet-standard-chains': 1.1.2
-      '@solana/wallet-standard-features': 1.4.0
+      '@solana/wallet-standard-features': 1.5.0
       '@wallet-standard/base': 1.1.1
       '@wallet-standard/errors': 0.1.2
       '@wallet-standard/ui': 1.0.3
@@ -3977,7 +3977,7 @@ snapshots:
     dependencies:
       '@wallet-standard/base': 1.1.1
 
-  '@solana/wallet-standard-features@1.4.0':
+  '@solana/wallet-standard-features@1.5.0':
     dependencies:
       '@wallet-standard/base': 1.1.1
       '@wallet-standard/features': 1.1.1


### PR DESCRIPTION
This PR adds `connected.supportedTransactionVersions`, so that apps can easily read the supported transaction versions for the connected wallet account. This mirrors wallet-adapter which includes this on the adapter object. As wallets have differing levels of support for v1 this is more useful so I think worth adding to our plugin too.

This also raises `@solana/wallet-standard-features` to `^1.5.0`, adding `1` to the union type.

The value is derived from wallet features in a similar way to what wallet-adapter does.  See https://github.com/anza-xyz/wallet-standard/blob/d7c8537a889b67c66c1df2c438ff194defcd4790/packages/wallet-adapter/base/src/adapter.ts#L202-L205

Updated: We use the intersection of `supportedTransactionVersions` of whichever sign features are available, `signTransactions` or `signAndSendTransactions`. This is conservative, in practice wallets should support the same versions for these features. But since our signer exposes both, this is the safest option. Unlike wallet-adapter we do not null the field in support is only `['legacy']`. If wallets report weird combinations then we already have `getWalletAccountFeature` as an escape hatch to get the value from each feature. 

The derivation is scoped to the connected account rather than the wallet, which diverges from wallet-adapter. This means that it correctly updates if a wallet switches for example from a signing account to a read-only one.